### PR TITLE
Don't use the cluster chooser on single cluster

### DIFF
--- a/frontend/src/components/cluster/Chooser.js
+++ b/frontend/src/components/cluster/Chooser.js
@@ -118,14 +118,26 @@ function Chooser(props) {
   const [show, setShow] = React.useState(true);
 
   React.useEffect(() => {
-    if (open && clusters.length === 0) {
+    if (!open) {
+      return;
+    }
+
+    if (clusters.length === 0) {
       api.getConfig()
         .then(config => {
           dispatch(setConfig(config));
         })
         .catch(err => console.error(err));
+      return;
+    }
+
+    // If we only have one cluster configured, then we skip offering
+    // the choice to the user.
+    if (clusters.length === 1) {
+      handleButtonClick(clusters[0]);
     }
   },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   [open, clusters, dispatch]);
 
   function handleClose() {

--- a/frontend/src/components/cluster/Chooser.js
+++ b/frontend/src/components/cluster/Chooser.js
@@ -28,15 +28,22 @@ export function ClusterTitle() {
   useLocation();
 
   const cluster = getCluster();
+  const clusters = useSelector(state => state.config.clusters);
   const [showChooser, setShowChooser] = React.useState(false);
+
+  const icon = <InlineIcon icon={kubernetesIcon} width="50" height="50" color="#fff" />;
 
   return (cluster &&
     <React.Fragment>
-      <IconButton
-        onClick={() => setShowChooser(true)}
-      >
-        <InlineIcon icon={kubernetesIcon} width="50" height="50" color="#fff" />
-      </IconButton>
+      {clusters.length > 1 ?
+        <IconButton
+          onClick={() => setShowChooser(true)}
+        >
+          {icon}
+        </IconButton>
+        :
+        icon
+      }
       <Typography variant="h4">&nbsp;{cluster}</Typography>
       <Chooser
         title="Clusters"


### PR DESCRIPTION
If we have just one cluster configured, there's no point in showing the cluster chooser.
Instead we just jupm straight into the configured cluster, and we don't use a button in the top left.