### PR TITLE
frontend: Reset docs when the editor contents change

### DIFF
--- a/frontend/src/components/common/EditorDialog.tsx
+++ b/frontend/src/components/common/EditorDialog.tsx
@@ -299,6 +299,8 @@ function DocsViewer(props: {docSpecs: any}) {
   const [docsError, setDocsError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    setDocsError(null);
+
     if (docSpecs.error) {
       setDocsError(`Cannot load documentation: ${docSpecs.error}`);
       return;


### PR DESCRIPTION
The docs' view is supposed to react to the contents of the editor. So
when the editor has a certain object kind and api version, the docs
should show the documentation for that object.
However, if there was an error shown (because e.g. the docs were not
found, or the contents were empty) then even if the contents were
corrected by the user, the error would remain.

To fix the mentioned issue, this patch resets the docs' error info
whenever the contents are changed.