### PR TITLE
frontend: Make class names in k8s.resourceClasses consistent

### DIFF
--- a/frontend/src/lib/k8s/clusterRoleBinding.ts
+++ b/frontend/src/lib/k8s/clusterRoleBinding.ts
@@ -4,6 +4,10 @@ import RoleBinding from './roleBinding';
 class ClusterRoleBinding extends RoleBinding {
   static apiEndpoint = apiFactory('rbac.authorization.k8s.io', 'v1', 'clusterrolebindings');
 
+  static get className(): string {
+    return 'ClusterRoleBinding';
+  }
+
   get detailsRoute() {
     return 'clusterRoleBinding';
   }

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -21,6 +21,7 @@ import PersistentVolumeClaim from './persistentVolumeClaim';
 import Pod from './pod';
 import ReplicaSet from './replicaSet';
 import Role from './role';
+import RoleBinding from './roleBinding';
 import Service from './service';
 import ServiceAccount from './serviceAccount';
 import StatefulSet from './statefulSet';
@@ -43,6 +44,7 @@ const classList = [
   Pod,
   ReplicaSet,
   Role,
+  RoleBinding,
   Service,
   ServiceAccount,
   StatefulSet,

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -54,7 +54,10 @@ const resourceClassesDict: {
 } = {};
 
 classList.forEach(cls => {
-  resourceClassesDict[cls.className] = cls;
+  // Ideally this should just be the class name, but until we ensure the class name is consistent
+  // (in what comes to the capitalization), we use this lazy approach.
+  const className: string = cls.className.charAt(0).toUpperCase() + cls.className.slice(1);
+  resourceClassesDict[className] = cls;
 });
 
 export const ResourceClasses = resourceClassesDict;


### PR DESCRIPTION
The class names have not been set in a consistent way: some are using
a capital first letter, and as a result the names in
k8s.resourceClasses were not the expected ones. We should make the
class names consistent but that has implications in the routes and
the sidebar, so for now we just capitalize the first letter when
adding the classes to k8s.resourceClasses. This is a temporary
measure until we have made de class names consistent.