### PR TITLE
Makefile: Specify Docker build path and ignore node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+frontend/node_modules

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,5 @@ image:
 	--no-cache \
 	--build-arg IMAGE_BASE=$(DOCKER_IMAGE_BASE) \
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
-	Dockerfile
+	Dockerfile \
+	.


### PR DESCRIPTION
This PR makes `make image` work. I'm not sure if the produced image works but at least we get an image.
It also adds `node_modules` to `.dockerignore` since this directory is huge and there is no need to send it to the Docker daemon when building images.