### PR TITLE
Makefile: Remove --no-cache Docker flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ frontend-fixlint:
 
 image:
 	$(DOCKER_CMD) build \
-	--no-cache \
 	--build-arg IMAGE_BASE=$(DOCKER_IMAGE_BASE) \
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile \


### PR DESCRIPTION
Disabling the Docker cache greatly increases the time it takes to rebuild an image during development.

To test this PR, run `make image` twice in a row. The 2nd run should complete nearly instantly.