### PR TITLE
Permissions check & optional metrics-server

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -2,7 +2,6 @@ import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { KubeMetrics } from '../../lib/k8s/cluster';
 import Event from '../../lib/k8s/event';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
@@ -17,14 +16,14 @@ import { CpuCircularChart, MemoryCircularChart, PodsStatusCircleChart } from './
 
 export default function Overview() {
   const [pods, setPods] = React.useState<Pod[] | null>(null);
-  const [events, setEvents] = React.useState<Event[] | null>(null);
   const [nodes, setNodes] = React.useState<Node[] | null>(null);
-  const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
 
   Pod.useApiList(setPods);
   Node.useApiList(setNodes);
-  Node.useMetrics(setNodeMetrics);
-  Event.useApiList(setEvents);
+
+  const [nodeMetrics, metricsError] = Node.useMetrics();
+
+  const noMetrics = metricsError?.status === 404;
 
   return (
     <PageGrid>
@@ -38,12 +37,14 @@ export default function Overview() {
             <CpuCircularChart
               items={nodes}
               itemsMetrics={nodeMetrics}
+              noMetrics={noMetrics}
             />
           </Grid>
           <Grid item>
             <MemoryCircularChart
               items={nodes}
               itemsMetrics={nodeMetrics}
+              noMetrics={noMetrics}
             />
           </Grid>
           <Grid item>

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -7,7 +7,7 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import { localeDate, timeAgo } from '../../lib/util';
-import { LightTooltip } from './Tooltip';
+import { LightTooltip, TooltipIcon } from './Tooltip';
 
 const useStyles = makeStyles(theme => ({
   nameLabel: {
@@ -134,11 +134,12 @@ const useHeaderLabelStyles = makeStyles(theme => ({
 interface HeaderLabelProps {
   label: string;
   value: string;
+  tooltip?: string | null;
 }
 
 export function HeaderLabel(props: HeaderLabelProps) {
   const classes = useHeaderLabelStyles();
-  const { value, label } = props;
+  const { value, label, tooltip } = props;
 
   return (
     <Grid
@@ -147,7 +148,10 @@ export function HeaderLabel(props: HeaderLabelProps) {
       direction="column"
     >
       <Grid item>
-        <Typography className={classes.label}>{label}</Typography>
+        <Typography className={classes.label} display="inline">{label}</Typography>
+        {!!tooltip &&
+          <TooltipIcon>{tooltip}</TooltipIcon>
+        }
       </Grid>
       <Grid
         item

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -61,10 +61,17 @@ export interface SimpleTableProps {
   filterFunction?: (...args: any[]) => boolean;
   rowsPerPage?: number[];
   emptyMessage?: string;
+  errorMessage?: string | null;
 }
 
 export default function SimpleTable(props: SimpleTableProps) {
-  const {columns, data, filterFunction = null, emptyMessage = null} = props;
+  const {
+    columns,
+    data,
+    filterFunction = null,
+    emptyMessage = null,
+    errorMessage = null,
+  } = props;
   const [page, setPage] = React.useState(0);
   const [currentData, setCurrentData] = React.useState(data);
   const rowsPerPageOptions = props.rowsPerPage || [5, 10, 50];
@@ -103,6 +110,12 @@ export default function SimpleTable(props: SimpleTableProps) {
   }
 
   if (currentData === null) {
+    if (!!errorMessage) {
+      return (
+        <Empty color="error">{errorMessage}</Empty>
+      );
+    }
+
     return <Loader />;
   }
 

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -1,5 +1,9 @@
-import { withStyles } from '@material-ui/core/styles';
+import informationOutline from '@iconify/icons-mdi/information-outline';
+import { Icon, IconifyIcon } from '@iconify/react';
+import Container from '@material-ui/core/Container';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
+import React from 'react';
 
 const LightTooltip = withStyles(theme => ({
   tooltip: {
@@ -13,3 +17,36 @@ const LightTooltip = withStyles(theme => ({
 
 export { LightTooltip };
 
+interface TooltipIconProps {
+  children: string;
+  icon?: object;
+}
+
+const useContainerStyles = makeStyles({
+  container: {
+    display: 'inline',
+    padding: '0 .3rem',
+  },
+});
+
+export function TooltipIcon(props: TooltipIconProps) {
+  const classes = useContainerStyles();
+  const { children, icon = informationOutline } = props;
+
+  const IconReffed = React.forwardRef((props: IconifyIcon, ref) => {
+    return (
+      <Container
+        ref={ref}
+        className={classes.container}
+      >
+        <Icon {...props} />
+      </Container>
+    );
+  });
+
+  return (
+    <LightTooltip title={children} interactive>
+      <IconReffed icon={icon} />
+    </LightTooltip>
+  );
+}

--- a/frontend/src/components/configmap/List.tsx
+++ b/frontend/src/components/configmap/List.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function ConfigMapList() {
-  const [configMaps, setConfigMaps] = React.useState<ConfigMap[] | null>(null);
+  const [configMaps, error] = ConfigMap.useList();
   const filterFunc = useFilterFunc();
-
-  ConfigMap.useApiList(setConfigMaps);
 
   return (
     <SectionBox
@@ -23,6 +21,7 @@ export default function ConfigMapList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={ConfigMap.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function CustomResourceDefinitionList() {
-  const [crds, setCRDs] = React.useState<CRD[] | null>(null);
+  const [crds, error] = CRD.useList();
   const filterFunc = useFilterFunc();
-
-  CRD.useApiList(setCRDs);
 
   return (
     <SectionBox
@@ -24,6 +22,7 @@ export default function CustomResourceDefinitionList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={CRD.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/ingress/List.tsx
+++ b/frontend/src/components/ingress/List.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function IngressList() {
-  const [ingresses, setIngresses] = React.useState<Ingress[] | null>(null);
+  const [ingresses, error] = Ingress.useList();
   const filterFunc = useFilterFunc();
-
-  Ingress.useApiList(setIngresses);
 
   return (
     <SectionBox
@@ -23,6 +21,7 @@ export default function IngressList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={Ingress.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -8,10 +8,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function NamespacesList() {
-  const [namespaces, setNamespaces] = React.useState<Namespace[] | null>(null);
+  const [namespaces, error] = Namespace.useList();
   const filterFunc = useFilterFunc();
-
-  Namespace.useApiList(setNamespaces);
 
   function makeStatusLabel(namespace: Namespace) {
     const status = namespace.status.phase;
@@ -35,6 +33,7 @@ export default function NamespacesList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={Namespace.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/node/Charts.tsx
+++ b/frontend/src/components/node/Charts.tsx
@@ -3,20 +3,22 @@ import React from 'react';
 import { KubeMetrics } from '../../lib/k8s/cluster';
 import Node from '../../lib/k8s/node';
 import { getPercentStr, getResourceMetrics, getResourceStr } from '../../lib/util';
+import { TooltipIcon } from '../common';
 import { PercentageBar } from '../common/Chart';
 
 interface UsageBarChartProps {
   node: Node;
   nodeMetrics: KubeMetrics[] | null;
   resourceType: keyof (KubeMetrics['usage']);
+  noMetrics?: boolean;
 }
 
 export function UsageBarChart(props: UsageBarChartProps) {
-  const { node, nodeMetrics, resourceType } = props;
+  const { node, nodeMetrics, resourceType, noMetrics = false } = props;
   let [used, capacity] = [0, 0];
 
-  if (node && nodeMetrics) {
-    [used, capacity] = getResourceMetrics(node, nodeMetrics, resourceType);
+  if (node) {
+    [used, capacity] = getResourceMetrics(node, nodeMetrics || [], resourceType);
   }
 
   const data = [
@@ -35,7 +37,12 @@ export function UsageBarChart(props: UsageBarChartProps) {
     );
   }
 
-  return (
+  return ( noMetrics ?
+    <>
+      <Typography display="inline" >{getResourceStr(capacity, resourceType)}</Typography>
+      <TooltipIcon>Install the metrics-server to get usage data.</TooltipIcon>
+    </>
+    :
     <PercentageBar
       data={data}
       total={capacity}

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -16,10 +16,12 @@ import { NameValueTable } from '../common/SimpleTable';
 export default function NodeDetails() {
   const { name } = useParams();
   const [item, setItem] = React.useState<Node | null>(null);
-  const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
 
   Node.useApiGet(setItem, name);
-  Node.useMetrics(setNodeMetrics);
+
+  const [nodeMetrics, metricsError] = Node.useMetrics();
+
+  const noMetrics = metricsError?.status === 404;
 
   function getAddresses(item: Node) {
     return item.status.addresses.map(({type, address}) => {
@@ -36,7 +38,11 @@ export default function NodeDetails() {
       <MainInfoSection
 
         headerSection={
-          <ChartsSection node={item} metrics={nodeMetrics} />
+          <ChartsSection
+            node={item}
+            metrics={nodeMetrics}
+            noMetrics={noMetrics}
+          />
         }
         resource={item}
         extraInfo={item && [
@@ -59,10 +65,11 @@ export default function NodeDetails() {
 interface ChartsSectionProps {
   node: Node | null;
   metrics: KubeMetrics[] | null;
+  noMetrics?: boolean;
 }
 
 function ChartsSection(props: ChartsSectionProps) {
-  const { node, metrics } = props;
+  const { node, metrics, noMetrics } = props;
 
   function getUptime() {
     if (!node) {
@@ -96,12 +103,14 @@ function ChartsSection(props: ChartsSectionProps) {
           <CpuCircularChart
             items={node && [node]}
             itemsMetrics={metrics}
+            noMetrics={noMetrics}
           />
         </Grid>
         <Grid item>
           <MemoryCircularChart
             items={node && [node]}
             itemsMetrics={metrics}
+            noMetrics={noMetrics}
           />
         </Grid>
       </Grid>

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -17,11 +17,10 @@ const useStyle = makeStyles({
 
 export default function NodeList() {
   const classes = useStyle();
-  const [nodes, setNodes] = React.useState<Node[] | null>(null);
+  const [nodes, error] = Node.useList();
   const [nodeMetrics, metricsError] = Node.useMetrics();
   const filterFunc = useFilterFunc();
 
-  Node.useApiList(setNodes);
   const noMetrics = metricsError?.status === 404;
 
   return (
@@ -36,6 +35,7 @@ export default function NodeList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={Node.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { KubeMetrics } from '../../lib/k8s/cluster';
 import Node from '../../lib/k8s/node';
 import { useFilterFunc } from '../../lib/util';
 import { Link } from '../common';
@@ -19,11 +18,11 @@ const useStyle = makeStyles({
 export default function NodeList() {
   const classes = useStyle();
   const [nodes, setNodes] = React.useState<Node[] | null>(null);
-  const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
+  const [nodeMetrics, metricsError] = Node.useMetrics();
   const filterFunc = useFilterFunc();
 
   Node.useApiList(setNodes);
-  Node.useMetrics(setNodeMetrics);
+  const noMetrics = metricsError?.status === 404;
 
   return (
     <SectionBox
@@ -56,6 +55,7 @@ export default function NodeList() {
                 node={node}
                 nodeMetrics={nodeMetrics}
                 resourceType="cpu"
+                noMetrics={noMetrics}
               />
           },
           {
@@ -68,6 +68,7 @@ export default function NodeList() {
                 node={node}
                 nodeMetrics={nodeMetrics}
                 resourceType="memory"
+                noMetrics={noMetrics}
               />
           },
           {

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -9,10 +9,8 @@ import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
 export default function PodList() {
-  const [pods, setPods] = React.useState<Pod[] | null>(null);
+  const [pods, error] = Pod.useList();
   const filterFunc = useFilterFunc();
-
-  Pod.useApiList(setPods);
 
   function getRestartCount(pod: Pod) {
     return _.sumBy(pod.status.containerStatuses, container => container.restartCount);
@@ -46,6 +44,7 @@ export default function PodList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={Pod.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/replicaset/List.tsx
+++ b/frontend/src/components/replicaset/List.tsx
@@ -7,14 +7,12 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function ReplicaSetList() {
-  const [replicaSets, setReplicaSets] = React.useState<ReplicaSet | null>(null);
+  const [replicaSets, error] = ReplicaSet.useList();
   const filterFunc = useFilterFunc();
 
   function getReplicas(replicaSet: ReplicaSet) {
     return `${replicaSet.spec.replicas} / ${replicaSet.status.replicas}`;
   }
-
-  ReplicaSet.useApiList(setReplicaSets);
 
   return (
     <SectionBox
@@ -27,6 +25,7 @@ export default function ReplicaSetList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={ReplicaSet.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function SecretList() {
-  const [secrets, setSecrets] = React.useState<Secret[] | null>(null);
+  const [secrets, error] = Secret.useList();
   const filterFunc = useFilterFunc();
-
-  Secret.useApiList(setSecrets);
 
   return (
     <SectionBox
@@ -23,6 +21,7 @@ export default function SecretList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={Secret.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function ServiceList() {
-  const [services, setServices] = React.useState<Service | null>(null);
+  const [services, error] = Service.useList();
   const filterFunc = useFilterFunc();
-
-  Service.useApiList(setServices);
 
   return (
     <SectionBox
@@ -23,6 +21,7 @@ export default function ServiceList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={Service.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/serviceaccount/List.tsx
+++ b/frontend/src/components/serviceaccount/List.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function ServiceAccountList() {
-  const [serviceAccounts, setServiceAccounts] = React.useState<ServiceAccount[] | null>(null);
+  const [serviceAccounts, error] = ServiceAccount.useList();
   const filterFunc = useFilterFunc();
-
-  ServiceAccount.useApiList(setServiceAccounts);
 
   return (
     <SectionBox
@@ -23,6 +21,7 @@ export default function ServiceAccountList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={ServiceAccount.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -6,10 +6,8 @@ import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
 export default function VolumeClaimList() {
-  const [volumeClaim, setVolumeClaim] = React.useState<PersistentVolumeClaim[] | null>(null);
+  const [volumeClaim, error] = PersistentVolumeClaim.useList();
   const filterFunc = useFilterFunc();
-
-  PersistentVolumeClaim.useApiList(setVolumeClaim);
 
   return (
     <SectionBox
@@ -21,6 +19,7 @@ export default function VolumeClaimList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={PersistentVolumeClaim.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/components/storage/ClassList.tsx
+++ b/frontend/src/components/storage/ClassList.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function ClassList() {
-  const [storageClassData, setStorageClassData] = React.useState<StorageClass[] | null>(null);
+  const [storageClasses, error] = StorageClass.useList();
   const filterFunc = useFilterFunc();
-
-  StorageClass.useApiList(setStorageClassData);
 
   return (
     <SectionBox
@@ -24,6 +22,7 @@ export default function ClassList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={StorageClass.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',
@@ -42,7 +41,7 @@ export default function ClassList() {
             getter: (storageClass) => storageClass.getAge()
           },
         ]}
-        data={storageClassData}
+        data={storageClasses}
       />
     </SectionBox>
   );

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -7,10 +7,8 @@ import SectionFilterHeader from '../common/SectionFilterHeader';
 import SimpleTable from '../common/SimpleTable';
 
 export default function VolumeList() {
-  const [volumes, setVolumes] = React.useState<PersistentVolume[] | null>(null);
+  const [volumes, error] = PersistentVolume.useList();
   const filterFunc = useFilterFunc();
-
-  PersistentVolume.useApiList(setVolumes);
 
   return (
     <SectionBox
@@ -24,6 +22,7 @@ export default function VolumeList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        errorMessage={PersistentVolume.getErrorMessage(error)}
         columns={[
           {
             label: 'Name',

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -403,7 +403,12 @@ export async function apply(body: KubeObjectInterface): Promise<JSON> {
   }
 }
 
-export async function metrics(url: string, onMetrics: (arg: KubeMetrics[]) => void) {
+export interface ApiError extends Error {
+  status: number;
+}
+
+export async function metrics(url: string, onMetrics: (arg: KubeMetrics[]) => void,
+                              onError?: (err: ApiError) => void) {
   const handel = setInterval(getMetrics, 10000);
 
   async function getMetrics() {
@@ -411,7 +416,11 @@ export async function metrics(url: string, onMetrics: (arg: KubeMetrics[]) => vo
       const metric = await request(url);
       onMetrics(metric.items || metric);
     } catch (err) {
-      console.error('No metrics', {err, url});
+      console.debug('No metrics', {err, url});
+
+      if (onError) {
+        onError(err);
+      }
     }
   }
 

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -199,6 +199,21 @@ makeKubeObject<T extends (KubeObjectInterface | KubeEvent)>(objectName: string) 
         spec
       }, false);
     }
+
+    static getErrorMessage(err: ApiError | null) {
+      if (!err) {
+        return null;
+      }
+
+      switch (err.status) {
+        case 404:
+          return 'Error: Not found';
+        case 403:
+          return 'Error: No permissions';
+        default:
+          return 'Error';
+      }
+    }
   }
 
   return KubeObject;

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -1,5 +1,6 @@
+import React from 'react';
 import { createRouteURL } from '../router';
-import { timeAgo } from '../util';
+import { timeAgo, useErrorState } from '../util';
 import { useConnectApi } from '.';
 import { ApiError, apiFactory, apiFactoryWithNamespace, post } from './apiProxy';
 import CronJob from './cronJob';
@@ -116,6 +117,16 @@ makeKubeObject<T extends (KubeObjectInterface | KubeEvent)>(objectName: string) 
                                             onError?: (err: ApiError) => void) {
       const listCallback = onList as (arg: U[]) => void;
       useConnectApi(this.apiList(listCallback, onError));
+    }
+
+    static useList<U extends KubeObject>(onList?: (...arg: any[]) => any) {
+      const [objList, setObjList] = React.useState<U[] | null>(null);
+      const [error, setError] = useErrorState(setObjList);
+      this.useApiList(setObjList, setError);
+
+      // Return getters and then the setters as the getters are more likely to be used with
+      // this function.
+      return [objList, error, setObjList, setError];
     }
 
     static create<U extends KubeObject>(this: new (arg: T) => U, item: T): U {

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+import { useErrorState } from '../util';
 import { useConnectApi } from '.';
 import { apiFactory, metrics } from './apiProxy';
 import { KubeCondition, KubeMetrics, KubeObjectInterface, makeKubeObject } from './cluster';
@@ -45,8 +47,13 @@ class Node extends makeKubeObject<KubeNode>('node') {
     return this.jsonData!.spec;
   }
 
-  static useMetrics(onMetrics: (metricsList: KubeMetrics[]) => void) {
-    useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', onMetrics));
+  static useMetrics() {
+    const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
+    const [error, setError] = useErrorState(setNodeMetrics);
+
+    useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setNodeMetrics, setError));
+
+    return [nodeMetrics, error];
   }
 }
 

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -1,9 +1,11 @@
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
+import React from 'react';
 import { matchPath } from 'react-router';
 import { isElectron } from '../helpers';
 import { FilterState } from '../redux/reducers/filter';
 import { useTypedSelector } from '../redux/reducers/reducers';
+import { ApiError } from './k8s/apiProxy';
 import { KubeMetrics, KubeObjectInterface, Workload } from './k8s/cluster';
 import Node from './k8s/node';
 import { parseCpu, parseRam, unparseCpu, unparseRam } from './units';
@@ -106,4 +108,18 @@ export function getCluster(): string | null {
   const clusterURLMatch =
     matchPath<{cluster?: string}>(urlPath, {path: getClusterPrefixedPath()});
   return (!!clusterURLMatch && clusterURLMatch.params.cluster) || null;
+}
+
+export function useErrorState(dependentSetter?: (...args: any) => void) {
+  const [error, setError] = React.useState<ApiError | null>(null);
+
+  React.useEffect(() => {
+    if (!!error && !!dependentSetter) {
+      dependentSetter(null);
+    }
+  },
+  [error, dependentSetter]);
+
+  // Adding "as any" here because it was getting difficult to validate the setter type.
+  return [error, setError as any];
 }


### PR DESCRIPTION
We need to check whether the user has the permissions to list objects in the cluster, otherwise most of the views the user has direct access to from the sidebar will be confusing.

As part of this PR we also make the metrics-server optional.