### PR TITLE
frontend: Set right color for workload charts' foreground

### DIFF
--- a/frontend/src/components/workload/Charts.tsx
+++ b/frontend/src/components/workload/Charts.tsx
@@ -54,7 +54,7 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
       data={makeData()}
       total={workloadData.length}
       totalProps={{
-        fill: theme.palette.primary.main
+        fill: theme.palette.common.black
       }}
       label={getLabel()}
       legend={getLegend()}


### PR DESCRIPTION
The color should be black and not blue.