### PR TITLE
frontend: Reset error when getting results on useList / useMetrics

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -146,7 +146,15 @@ makeKubeObject<T extends (KubeObjectInterface | KubeEvent)>(objectName: string):
       [U[] | null, ApiError | null, (items: U[]) => void, (err: ApiError | null) => void] {
       const [objList, setObjList] = React.useState<U[] | null>(null);
       const [error, setError] = useErrorState(setObjList);
-      this.useApiList(setObjList, setError);
+
+      function setList(items: U[] | null) {
+        setObjList(items);
+        if (items !== null) {
+          setError(null);
+        }
+      }
+
+      this.useApiList(setList, setError);
 
       // Return getters and then the setters as the getters are more likely to be used with
       // this function.

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -51,7 +51,15 @@ class Node extends makeKubeObject<KubeNode>('node') {
     const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
     const [error, setError] = useErrorState(setNodeMetrics);
 
-    useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setNodeMetrics, setError));
+    function setMetrics(metrics: KubeMetrics[]) {
+      setNodeMetrics(metrics);
+
+      if (metrics !== null) {
+        setError(null);
+      }
+    }
+
+    useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError));
 
     return [nodeMetrics, error];
   }


### PR DESCRIPTION
These hooks are supposed to make it very easy to use a results/error
associated with the resources we want, but while the error does reset
the list (sets it to null), the opposite is not true and this led to
an issue of not showing results after an error occurs (even if the
error is no longer happening).

This patch resets the error in the context explained above, which
fixes this issue.