### PR TITLE
frontend: Remove the UID from the MetadataDisplay component

### DIFF
--- a/frontend/src/components/common/Resource.tsx
+++ b/frontend/src/components/common/Resource.tsx
@@ -67,10 +67,6 @@ export function MetadataDisplay(props: MetadataDisplayProps) {
       value: localeDate(resource.metadata.creationTimestamp),
     },
     {
-      name: 'UID',
-      value: resource.metadata.uid,
-    },
-    {
       name: 'Labels',
       value: resource.metadata.labels && <MetadataDictGrid dict={resource.metadata.labels} />,
       hide: !resource.metadata.labels,


### PR DESCRIPTION
The UID is not very important to show in this view.