### PR TITLE
frontend: Don't show a cluster name if there's only one cluster

### DIFF
--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -45,20 +45,20 @@ export function ClusterTitle() {
     return null;
   }
 
+  if (Object.keys(clusters).length <= 1) {
+    return null;
+  }
+
   return (
     <React.Fragment>
-      {(Object.keys(clusters).length > 1) ?
-        <Button
-          size="large"
-          variant="contained"
-          onClick={() => setShowChooser(true)}
-          className={classes.button}
-        >
-          Cluster: {cluster}
-        </Button>
-        :
-        <Typography color="textPrimary">Cluster: {cluster}</Typography>
-      }
+      <Button
+        size="large"
+        variant="contained"
+        onClick={() => setShowChooser(true)}
+        className={classes.button}
+      >
+        Cluster: {cluster}
+      </Button>
       <Chooser
         open={showChooser}
         onClose={() => setShowChooser(false)}


### PR DESCRIPTION
If there is only one cluster configured, then we should show the cluster
name in the UI as the user context should be enough, and when deployed
in-cluster it was just showing "Cluster: main".