### PR TITLE
backend: Use https scheme for all OIDC redirect URL

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -167,11 +167,15 @@ func StartHeadlampServer(config *HeadlampConfig) {
 		oidcConfig := &oidc.Config{
 			ClientID: oidcAuthConfig.ClientID,
 		}
-		var urlScheme string
-		if r.TLS != nil {
-			urlScheme = "https://"
-		} else {
-			urlScheme = "http://"
+
+		urlScheme := r.URL.Scheme
+		if urlScheme == "" {
+			// @todo: Find a better way to get the scheme for the URL.
+			if r.Host == "localhost:"+config.port {
+				urlScheme = "http"
+			} else {
+				urlScheme = "https"
+			}
 		}
 
 		verifier := provider.Verifier(oidcConfig)
@@ -179,7 +183,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 			ClientID:     oidcAuthConfig.ClientID,
 			ClientSecret: oidcAuthConfig.ClientSecret,
 			Endpoint:     provider.Endpoint(),
-			RedirectURL:  fmt.Sprintf("%1s%2s/oidc-callback", urlScheme, r.Host),
+			RedirectURL:  fmt.Sprintf("%1s://%2s/oidc-callback", urlScheme, r.Host),
 			Scopes:       []string{oidc.ScopeOpenID, "profile", "email", "groups"},
 		}
 


### PR DESCRIPTION
The URL scheme used for the OIDC redirect URL was dependent on having
the TLS presence in the /oidc request, but TLS may have been delegated
to the k8s deployment. So this patch enforces https unless the host
being used is the localhost one. This is not a great solution but we
can use it for now and think about a more complete one later.