### PR TITLE
frontend: Show plugins' header actions before others

### DIFF
--- a/frontend/src/components/common/Resource.tsx
+++ b/frontend/src/components/common/Resource.tsx
@@ -223,7 +223,8 @@ export function MainInfoSection(props: MainInfoSectionProps) {
   const headerActions = useTypedSelector(state => state.ui.views.details.headerActions);
 
   function getHeaderActions() {
-    return Object.values(headerActions).map(action => action({item: resource}));
+    return React.Children.toArray(Object.values(headerActions).map(action =>
+      action({item: resource})));
   }
 
   let defaultActions: MainInfoSectionProps['actions'] = [];
@@ -253,8 +254,8 @@ export function MainInfoSection(props: MainInfoSectionProps) {
             title={title || (resource ? resource.kind : '')}
             headerStyle={headerStyle}
             actions={
-              React.Children.toArray(actions).concat(defaultActions)
-                .concat(getHeaderActions())
+              getHeaderActions().concat(React.Children.toArray(actions))
+                .concat(defaultActions)
             }
           />
         }


### PR DESCRIPTION
We were showing the plugins' header actions after the default ones but
this means that the UI is less consistent among views, e.g.: if a plugin
added a header button in pods' details but not in the deployments', then
the other buttons would be pushed left. This was even more evident if
the plugin took a while to add the button (even leading to a misclick).

This patch makes the plugins' header action components be added to the
left, so the rest of the buttons don't move in such case.