### PR TITLE
Add make targets for desktop app builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,16 @@ tools/golangci-lint: backend/go.mod backend/go.sum
 backend-lint: tools/golangci-lint
 	cd backend && ./tools/golangci-lint run
 
+.PHONY: app
+app: 
+	cd app && npm run build && npm run package  -- --win --linux --mac 
+app-win: 
+	cd app && npm run build && npm run package  -- --win
+app-linux: 
+	cd app && npm run build && npm run package  -- --linux
+app-mac: 
+	cd app && npm run build && npm run package  -- --mac
+
 .PHONY: backend
 backend:
 	cd backend && go build -o ./server ./cmd


### PR DESCRIPTION
This patch adds make targets for desktop app build for all three
platforms.

# How to use
run make app to generate desktop app builds for all three platforms 
use app-win for windows build generation
use app-mac for mac specific build generation
use app-linux for linux build generation



