### PR TITLE
kubernetes-headlamp.yaml: Fix plugins-dir flag typo

### DIFF
--- a/kubernetes-headlamp.yaml
+++ b/kubernetes-headlamp.yaml
@@ -18,7 +18,7 @@ spec:
         image: quay.io/kinvolk/headlamp:latest
         args:
           - "-in-cluster"
-          - "-plugin-dir=/headlamp/plugins"
+          - "-plugins-dir=/headlamp/plugins"
         ports:
         - containerPort: 4466
         livenessProbe:


### PR DESCRIPTION
Based on a patch by Saiyam Pathak (saiyam1814 on Github).

There was a typo in the plugins-dir flag of the K8s YAML file, and this
was preventing Headlamp to start in the image.

fixes #111
