### PR TITLE
Docs: Fix broken links 

### DIFF
--- a/docs/installation/desktop/_index.md
+++ b/docs/installation/desktop/_index.md
@@ -6,14 +6,14 @@ weight: 100
 Headlamp can be run as a desktop application, for users who don't want to
 deploy it in cluster, or those who want to manage unrelated clusters locally.
 
-Currently there are desktop apps for [Linux](./linux-installation) and [Mac](./mac-installation). A Windows version is coming soon too.
+Currently there are desktop apps for [Linux](./linux-installation.md) and [Mac](./mac-installation.md). A Windows version is coming soon too.
 
 Please check the following guides for the installation in your desired platform.
 
 ## Access using OIDC
 
 OIDC has a feature makes more sense when
-[running Headlamp in a cluster](../in-cluster) as it will allow cluster operators to just
+[running Headlamp in a cluster](../in-cluster.md) as it will allow cluster operators to just
 give users a URL that they can use for logging in and access Headlamp.
 However, if you have your kube config set to use OIDC for the authentication (because you already
 authenticated and produced a kube config with that data), Headlamp will read those settings and


### PR DESCRIPTION
# [Title: describe the change in one sentence]
Fix incorrect link refs in docs

To validate this PR: 
Go to the docs index page and click on mac,linux, in-cluster links they should work now

# Testing done
Yes