### PR TITLE
Service should come before the deployment

### DIFF
--- a/kubernetes-headlamp.yaml
+++ b/kubernetes-headlamp.yaml
@@ -1,3 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: headlamp
+  namespace: kube-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 4466
+  selector:
+    k8s-app: headlamp
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -30,16 +42,3 @@ spec:
           timeoutSeconds: 30
       nodeSelector:
         'beta.kubernetes.io/os': linux
-
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: headlamp
-  namespace: kube-system
-spec:
-  ports:
-    - port: 80
-      targetPort: 4466
-  selector:
-    k8s-app: headlamp


### PR DESCRIPTION
# Service before deployment

When a pod is scheduled Kubernetes checks if it will match existing services. If so it annotates the pod with the service name. This is used by sidecars for various use cases 

# How to use
NA

# Testing done
NA
