### PR TITLE
Fix windows build server failure

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -127,7 +127,7 @@ function createWindow () {
   let serverFilePath;
   if (!isDev) {
     serverFilePath = path.join(process.resourcesPath, './electron/server');
-    serverProcess = spawn(serverFilePath);
+    serverProcess = spawn(serverFilePath, {shell: true});
   }
 
   const startUrl = process.env.ELECTRON_START_URL || url.format({


### PR DESCRIPTION
# [Title: describe the change in one sentence]
Enable shell to be used while spawning the server

To validate this pr 
Generate a windows build of the desktop app and run it, earlier it was crashing because of server failure but now it wont
# Testing done
Yes
Testing done before submitting the pr: 
On windows generated the exe build and ran it 
To generate the exe I did the following steps
1. npm run build 
2. npm run package