### PR TITLE
Don't stop the server if no config is found

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -91,7 +91,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	if config.useInCluster {
 		context, err := GetOwnContext(config)
 		if err != nil {
-			log.Fatal("Failed to get in-cluster config", err)
+			log.Println("Failed to get in-cluster config", err)
 		}
 
 		contexts = append(contexts, *context)
@@ -103,7 +103,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 
 		contextsFound, err := GetContextsFromKubeConfigFile(kubeConfigPath)
 		if err != nil {
-			log.Fatal("Failed to get contexts from", kubeConfigPath, err)
+			log.Println("Failed to get contexts from", kubeConfigPath, err)
 		}
 
 		contexts = append(contexts, contextsFound...)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -272,7 +272,7 @@ interface AuthRouteProps {
 
 function AuthRoute(props: AuthRouteProps) {
   const { children, sidebar, requiresAuth = true, requiresCluster = true, ...other } = props;
-  const clusters = useClustersConf();
+  const {clusters} = useClustersConf();
   const redirectRoute = getCluster() ? 'login' : 'chooser';
 
   useSidebarItem(sidebar);

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -21,10 +21,9 @@ interface ReactRouterLocationStateIface {
 
 function Auth() {
   const history = useHistory();
-  const clusterConf = useClustersConf();
   const [token, setToken] = React.useState('');
   const [showError, setShowError] = React.useState(false);
-  const clusters = useClustersConf();
+  const {clusters} = useClustersConf();
 
   function onAuthClicked() {
     loginWithToken(token).then(code => {
@@ -46,7 +45,7 @@ function Auth() {
         disableBackdropClick
       >
         <DialogTitle id="responsive-dialog-title">
-          {Object.keys(clusterConf).length > 1 ? `Authentication: ${getCluster()}` : 'Authentication'}
+          {Object.keys(clusters).length > 1 ? `Authentication: ${getCluster()}` : 'Authentication'}
         </DialogTitle>
         <DialogContent>
           <DialogContentText>

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -34,7 +34,7 @@ interface ReactRouterLocationStateIface {
 function AuthChooser(){
   const history = useHistory();
   const location = useLocation();
-  const clusters = useClustersConf();
+  const {clusters} = useClustersConf();
   const dispatch = useDispatch();
   const isDevMode = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
   const [testingAuth, setTestingAuth] = React.useState(false);

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -36,7 +36,7 @@ const useClusterTitleStyle = makeStyles(theme => ({
 export function ClusterTitle() {
   const classes = useClusterTitleStyle();
   const cluster = useCluster();
-  const clusters = useClustersConf();
+  const {clusters} = useClustersConf();
   const [showChooser, setShowChooser] = React.useState(false);
 
   useHotkeys('ctrl+shift+l', () => setShowChooser(true));
@@ -217,7 +217,7 @@ export function ClusterDialog(props: ClusterDialogProps) {
 
 function Chooser(props: ClusterDialogProps) {
   const history = useHistory();
-  const clusters = useClustersConf();
+  const {clusters, error} = useClustersConf();
   const {open = null, onClose, ...otherProps} = props;
   // Only used if open is not provided
   const [show, setShow] = React.useState(props.open);
@@ -270,9 +270,9 @@ function Chooser(props: ClusterDialogProps) {
       {clusterList.length === 0 ?
         <React.Fragment>
           <DialogContentText>
-            Wait while fetching clusters…
+            {error ? error : 'Wait while fetching clusters…'}
           </DialogContentText>
-          <Loader />
+          { !!error || <Loader /> }
         </React.Fragment>
         :
         <React.Fragment>

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -77,7 +77,8 @@ interface Config {
 // Hook for getting or fetching the clusters configuration.
 export function useClustersConf() {
   const dispatch = useDispatch();
-  const clusters = useTypedSelector(state => state.config.clusters);
+  const clustersState = useTypedSelector(state => state.config);
+  const clusters = clustersState.clusters;
 
   function fetchConfig() {
     request('/config', {}, false, false)
@@ -107,7 +108,7 @@ export function useClustersConf() {
   // eslint-disable-next-line
   []);
 
-  return clusters;
+  return {...clustersState};
 }
 
 export function useCluster() {
@@ -115,7 +116,7 @@ export function useCluster() {
   // Make sure we update when changing clusters.
   // @todo: We need a better way to do this.
   const location = useLocation();
-  const clusters = useClustersConf();
+  const {clusters} = useClustersConf();
 
   React.useEffect(() => {
     const currentCluster = getCluster();

--- a/frontend/src/redux/reducers/config.tsx
+++ b/frontend/src/redux/reducers/config.tsx
@@ -5,10 +5,12 @@ export interface ConfigState {
   clusters: {
     [clusterName: string]: Cluster;
   };
+  error: string;
 }
 
 export const INITIAL_STATE: ConfigState = {
   clusters: {},
+  error: ''
 };
 
 function reducer(state = INITIAL_STATE, action: Action) {
@@ -16,6 +18,7 @@ function reducer(state = INITIAL_STATE, action: Action) {
   switch (action.type) {
     case CONFIG_NEW:
       newState.clusters = {...action.config.clusters};
+      newState.error = action.config.error;
       break;
     default:
       break;


### PR DESCRIPTION
we shouldn't use log.Fatal if there is no kubeconfig available as it gives a call to os.Exit and thus stops the server.
