### PR TITLE
docs: Use portable links

### DIFF
--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -4,7 +4,7 @@ title: Development
 
 This is a quickstart guide for building and running Headlamp for development.
 
-Please make sure you read the [Contribution Guidelines](../contributing) as well
+Please make sure you read the [Contribution Guidelines](../contributing.md) as well
 before starting to contribute to the project.
 
 ## Build the code

--- a/docs/development/plugins/how-to.md
+++ b/docs/development/plugins/how-to.md
@@ -89,5 +89,5 @@ Here is the result, running Headlamp with this plugin and using with a Minikube 
 
 ![screenshot showing a label on the top bar with the number of pods available](./podcounter_screenshot.png)
 
-Please refer to the [functionality](./functionality) section for learning about
+Please refer to the [functionality](./functionality.md) section for learning about
 the different functionality that is available to plugins by the registry.

--- a/docs/installation/_index.md
+++ b/docs/installation/_index.md
@@ -51,4 +51,4 @@ Once you have the Service Account token, paste it when prompted by Headlamp.
 
 ### Use OIDC
 
-For OpenIDConnect, please see the [in-cluster installation](./in-cluster#accessing-using-oidc) docs.
+For OpenIDConnect, please see the [in-cluster installation](./in-cluster.md#accessing-using-oidc) docs.

--- a/docs/installation/desktop/_index.md
+++ b/docs/installation/desktop/_index.md
@@ -6,14 +6,14 @@ weight: 100
 Headlamp can be run as a desktop application, for users who don't want to
 deploy it in cluster, or those who want to manage unrelated clusters locally.
 
-Currently there are desktop apps for [Linux](./linux-installation) and [Mac](./mac-installation). A Windows version is coming soon too.
+Currently there are desktop apps for [Linux](./linux-installation.md) and [Mac](./mac-installation.md). A Windows version is coming soon too.
 
 Please check the following guides for the installation in your desired platform.
 
 ## Access using OIDC
 
 OIDC has a feature makes more sense when
-[running Headlamp in a cluster](../in-cluster) as it will allow cluster operators to just
+[running Headlamp in a cluster](../in-cluster.md) as it will allow cluster operators to just
 give users a URL that they can use for logging in and access Headlamp.
 However, if you have your kube config set to use OIDC for the authentication (because you already
 authenticated and produced a kube config with that data), Headlamp will read those settings and


### PR DESCRIPTION
The links we were using had no .md extensions even when they referred to
markdown documents because we read the docs now in a Hugo powered
renderer: https://kinvolk.io/docs .
That system now does support .md extensions in links, so let's bring
back the extensions which make the docs readable also on Github.
