### PR TITLE
Github actions: Fix backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2.1.2
+      uses: actions/setup-go@v2
       with:
-        go-version: '1.15.2'
+        go-version: '1.15.4'
       id: go
 
     - name: Check out code


### PR DESCRIPTION
With a recent update to github set-env and add-path commands were deprecated 
Read more here => https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and because actions/setup-go uses internally these commands our ci was failing


