### PR TITLE
Allow custom certificates in oidc mode

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -154,6 +154,13 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	r.HandleFunc("/oidc", func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		cluster := r.URL.Query().Get("cluster")
+		if config.insecure {
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // nolint:gosec
+			}
+			insecureClient := &http.Client{Transport: tr}
+			ctx = oidc.ClientContext(ctx, insecureClient)
+		}
 
 		oidcAuthConfig, err := GetClusterOidcConfig(cluster)
 		if err != nil {


### PR DESCRIPTION
Allow oidc flow with custom certificates when run in insecure mode


# Testing done
Done!! tested with setting up oidc auth flow with dex followed by untrusted cert

fixes #127