### PR TITLE
backend: Don't print an error when the plugins folder doesn't exist

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -125,7 +125,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	}
 
 	files, err := ioutil.ReadDir(config.pluginDir)
-	if err != nil {
+	if !os.IsNotExist(err) {
 		log.Println("Error: ", err)
 	}
 


### PR DESCRIPTION
Plugins are optional in Headlamp, so we shouldn't print an error if the
folder doesn't exist.
