### PR TITLE
Link service account Details view to secret details view

### DIFF
--- a/frontend/src/components/serviceaccount/Details.tsx
+++ b/frontend/src/components/serviceaccount/Details.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import ServiceAccount from '../../lib/k8s/serviceAccount';
+import { Link } from '../common';
 import { MainInfoSection } from '../common/Resource';
 
 export default function ServiceAccountDetails() {
@@ -15,7 +16,18 @@ export default function ServiceAccountDetails() {
       extraInfo={item && [
         {
           name: 'Secrets',
-          value: item.secrets.map(({name}) => name).join(', ')
+          value: <React.Fragment>
+            {
+              item.secrets.map(({name}, index) =>
+                <React.Fragment key={`${name}__${index}`}>
+                  <Link routeName={'secret'} params={{namespace, name}}>
+                    {name}
+                  </Link>
+                  {index !== item.secrets.length - 1 && ','}
+                </React.Fragment>
+              )
+            }
+          </React.Fragment>
         }
       ]}
     />


### PR DESCRIPTION
On the service account details view page we want to connect the secret name to its own page this will reduce copy pasting and manually looking for that secret name in secrets list.