### PR TITLE
backend: make it possible to serve SSL

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -18,6 +18,10 @@ func main() {
 	oidcClientID := flag.String("oidc-client-id", "", "ClientID for OIDC")
 	oidcClientSecret := flag.String("oidc-client-secret", "", "ClientSecret for OIDC")
 	oidcIdpIssuerURL := flag.String("oidc-idp-issuer-url", "", "Identity provider issuer URL for oidc")
+	sslCert := flag.String("ssl-cert", "", "File with the SSL certificate")
+	sslCertKey := flag.String("ssl-cert-key", "", "File with the key for the SSL certificate")
+	sslCertCA := flag.String("ssl-cert-ca", "", "File with the ca certificate(s) for the SSL certificate")
+	sslClientCertRequired := flag.Bool("ssl-client-cert-required", false, "Require a valid client certificate")
 
 	flag.Parse()
 
@@ -28,15 +32,19 @@ func main() {
 	}
 
 	StartHeadlampServer(&HeadlampConfig{
-		useInCluster:     *inCluster,
-		kubeConfigPath:   *kubeconfig,
-		port:             *port,
-		devMode:          *devMode,
-		staticDir:        *staticDir,
-		insecure:         *insecure,
-		pluginDir:        *pluginDir,
-		oidcClientID:     *oidcClientID,
-		oidcClientSecret: *oidcClientSecret,
-		oidcIdpIssuerURL: *oidcIdpIssuerURL,
+		useInCluster:          *inCluster,
+		kubeConfigPath:        *kubeconfig,
+		port:                  *port,
+		devMode:               *devMode,
+		staticDir:             *staticDir,
+		insecure:              *insecure,
+		pluginDir:             *pluginDir,
+		oidcClientID:          *oidcClientID,
+		oidcClientSecret:      *oidcClientSecret,
+		oidcIdpIssuerURL:      *oidcIdpIssuerURL,
+		sslCert:               *sslCert,
+		sslCertKey:            *sslCertKey,
+		sslCertCA:             *sslCertCA,
+		sslClientCertRequired: *sslClientCertRequired,
 	})
 }


### PR DESCRIPTION
This adds 4 new optional command line parameters:

  -ssl-cert filename
  -ssl-cert-key filename
  -ssl-cert-ca filename
  -ssl-client-cert-required

To serve SSL, the first two parameters are needed, without them HTTP is
served (like before).

The parameter -ssl-cert-ca might be used if the given SSL-certificate
uses a root CA which is not known by default.

The parameter -ssl-client-cert-required is by default false but might
be used to require that clients are having a valid client certificate.

So in order to serve SSL without something else which does SSL
termination, just mount the certificate(s) into the container (e.g. by
using a secret) and add the parameters -ssl-cert and -ssl-cert-key to
the args in the yaml with the deployment.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

# How to use

[ describe what reviewers need to do in order to validate this PR ]

# Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

