### PR TITLE
backend: Fix how we get home directory for preparing kubeconfig path

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	oidc "github.com/coreos/go-oidc"
@@ -353,7 +354,14 @@ func proxyHandler(url *url.URL, proxy *httputil.ReverseProxy) func(http.Response
 }
 
 func GetDefaultKubeConfigPath() string {
-	return filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	user, err := user.Current()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	homeDirectory := user.HomeDir
+
+	return filepath.Join(homeDirectory, ".kube", "config")
 }
 
 func (c *clientConfig) getConfig(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Our current method for preparing the default path for kubeconfig doesn't works on windows platform.
This patch updates how we prepare that path considering what is the homedir for current user
Testing done
Yes on linux and windows