### PR TITLE
Workload navigation

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -113,12 +113,6 @@ function EventsSection() {
             getter: event => event.involvedObject.name,
             sort: true
           },
-          {
-            label: 'Age',
-            getter: event => timeAgo(event.metadata.creationTimestamp),
-            sort: (e1: Event, e2: Event) => new Date(e2.metadata.creationTimestamp).getTime() -
-              new Date(e1.metadata.creationTimestamp).getTime()
-          },
           // @todo: Maybe the message should be shown on slide-down.
           {
             label: 'Reason',
@@ -129,6 +123,12 @@ function EventsSection() {
               >
                 <Box>{makeStatusLabel(event)}</Box>
               </LightTooltip>
+          },
+          {
+            label: 'Age',
+            getter: event => timeAgo(event.metadata.creationTimestamp),
+            sort: (e1: Event, e2: Event) => new Date(e2.metadata.creationTimestamp).getTime() -
+              new Date(e1.metadata.creationTimestamp).getTime()
           },
         ]
           :

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -7,6 +7,10 @@ import { createRouteURL, RouteURLProps } from '../../lib/router';
 interface LinkProps {
   routeName: string;
   params?: RouteURLProps;
+  search?: string;
+  state?: {
+    [prop: string]: any;
+  };
 }
 
 interface LinkObjectProps {
@@ -23,9 +27,16 @@ export default function Link(props: React.PropsWithChildren<LinkProps | LinkObje
     );
   }
 
-  const { routeName, params = {} } = props as LinkProps;
+  const { routeName, params = {}, search, state } = props as LinkProps;
   return (
-    <MuiLink component={RouterLink} to={createRouteURL(routeName, params)}>
+    <MuiLink
+      component={RouterLink}
+      to={{
+        pathname: createRouteURL(routeName, params),
+        search,
+        state
+      }}
+    >
       {props.children}
     </MuiLink>
   );

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -4,7 +4,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { makeKubeObject } from '../../lib/k8s/cluster';
 import { createRouteURL, RouteURLProps } from '../../lib/router';
 
-interface LinkProps {
+export interface LinkProps {
   routeName: string;
   params?: RouteURLProps;
   search?: string;

--- a/frontend/src/components/common/Resource.tsx
+++ b/frontend/src/components/common/Resource.tsx
@@ -18,7 +18,7 @@ import { Base64 } from 'js-base64';
 import _ from 'lodash';
 import * as monaco from 'monaco-editor';
 import React from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { KubeCondition, KubeContainer, KubeObject, KubeObjectInterface } from '../../lib/k8s/cluster';
 import { createRouteURL, RouteURLProps } from '../../lib/router';
 import { localeDate } from '../../lib/util';
@@ -209,6 +209,7 @@ interface MainInfoSectionProps {
   actions?: React.ReactNode[] | null;
   headerStyle?: HeaderStyleProps['headerStyle'];
   noDefaultActions?: boolean;
+  backLink?: string | ReturnType<typeof useLocation> | null;
 }
 
 export function MainInfoSection(props: MainInfoSectionProps) {
@@ -220,6 +221,7 @@ export function MainInfoSection(props: MainInfoSectionProps) {
     actions = [],
     headerStyle = 'main',
     noDefaultActions = false,
+    backLink,
   } = props;
   const headerActions = useTypedSelector(state => state.ui.views.details.headerActions);
 
@@ -244,7 +246,7 @@ export function MainInfoSection(props: MainInfoSectionProps) {
           startIcon={<Icon icon={chevronLeft} />}
           size="small"
           component={RouterLink}
-          to={createRouteURL(resource.listRoute)}
+          to={backLink || createRouteURL(resource.listRoute)}
         >
           <Typography style={{paddingTop: '3px'}}>Back</Typography>
         </Button>

--- a/frontend/src/components/common/Resource.tsx
+++ b/frontend/src/components/common/Resource.tsx
@@ -31,7 +31,7 @@ import DeleteButton from './DeleteButton';
 import EditButton from './EditButton';
 import Empty from './EmptyContent';
 import { DateLabel, HoverInfoLabel, StatusLabel, StatusLabelProps } from './Label';
-import Link from './Link';
+import Link, { LinkProps } from './Link';
 import { LightTooltip } from './Tooltip';
 
 const useStyles = makeStyles(theme => ({
@@ -177,7 +177,7 @@ export function MetadataDictGrid(props: MetadataDictGridProps) {
   );
 }
 
-interface ResourceLinkProps {
+interface ResourceLinkProps extends Omit<LinkProps, 'routeName' | 'params'> {
   name?: string;
   routeName?: string;
   routeParams?: RouteURLProps;
@@ -189,12 +189,14 @@ export function ResourceLink(props: ResourceLinkProps) {
     routeName = props.resource.kind,
     routeParams = props.resource.metadata as RouteURLProps,
     name = props.resource.metadata.name,
+    state
   } = props;
 
   return (
     <Link
       routeName={routeName}
       params={routeParams}
+      state={state}
     >
       {name}
     </Link>

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { NavLinkProps, useLocation, useParams } from 'react-router-dom';
 import { KubeObject, Workload } from '../../lib/k8s/cluster';
 import { ContainersSection, MainInfoSection, MetadataDictGrid, PageGrid, ReplicasSection } from '../common/Resource';
 
@@ -9,6 +9,7 @@ interface WorkloadDetailsProps {
 
 export default function WorkloadDetails(props: WorkloadDetailsProps) {
   const { namespace, name } = useParams();
+  const location = useLocation<{backLink: NavLinkProps['location']}>();
   const { workloadKind } = props;
   const [item, setItem] = React.useState<Workload | null>(null);
 
@@ -17,7 +18,7 @@ export default function WorkloadDetails(props: WorkloadDetailsProps) {
   return (
     <PageGrid>
       <MainInfoSection
-
+        backLink={location.state?.backLink}
         resource={item}
         extraInfo={item && [
           {

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -1,5 +1,6 @@
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import { Workload } from '../../lib/k8s/cluster';
 import CronJob from '../../lib/k8s/cronJob';
 import DaemonSet from '../../lib/k8s/daemonSet';
@@ -20,6 +21,7 @@ interface WorkloadDict {
 
 export default function Overview() {
   const [workloadsData, dispatch] = React.useReducer(setWorkloads, {});
+  const location = useLocation();
   const filterFunc = useFilterFunc();
 
   function setWorkloads(workloads: WorkloadDict,
@@ -91,7 +93,7 @@ export default function Overview() {
             {
               label: 'Name',
               getter: (item) =>
-                <ResourceLink resource={item} />,
+                <ResourceLink resource={item} state={{backLink: {...location}}} />,
               sort: (w1: Workload, w2: Workload) => {
                 if (w1.metadata.name < w2.metadata.name) {
                   return -1;

--- a/frontend/src/lib/k8s/deployment.ts
+++ b/frontend/src/lib/k8s/deployment.ts
@@ -25,10 +25,6 @@ class Deployment extends makeKubeObject<KubeDeployment>('Deployment') {
   get status() {
     return this.getValue('status');
   }
-
-  get listRoute() {
-    return 'workloads';
-  }
 }
 
 export default Deployment;

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -154,31 +154,31 @@ export const ROUTES: {
   DaemonSet: {
     path: '/daemonsets/:namespace/:name',
     exact: true,
-    sidebar: 'workloads',
+    sidebar: 'DaemonSets',
     component: () => <DaemonSetDetails />
   },
   StatefulSet: {
     path: '/statefulsets/:namespace/:name',
     exact: true,
-    sidebar: 'workloads',
+    sidebar: 'StatefulSets',
     component: () => <StatefulSetDetails />
   },
   Deployment: {
     path: '/deployments/:namespace/:name',
     exact: true,
-    sidebar: 'workloads',
+    sidebar: 'Deployments',
     component: () => <WorkloadDetails workloadKind={Deployment} />
   },
   Job: {
     path: '/jobs/:namespace/:name',
     exact: true,
-    sidebar: 'workloads',
+    sidebar: 'Jobs',
     component: () => <WorkloadDetails workloadKind={Job} />
   },
   CronJob: {
     path: '/cronjobs/:namespace/:name',
     exact: true,
-    sidebar: 'workloads',
+    sidebar: 'CronJobs',
     component: () => <WorkloadDetails workloadKind={CronJob} />
   },
   Pods: {


### PR DESCRIPTION
When visiting a workload details view from the workload overview, then the back button (of the details view) should go back to the workloads overview, but when visiting it from the actual workload type list it should go back to it.
We could achieve this behavior with a "history.goBack()" function, but we don't want to go back to any page in the history. And thus this PR adds extra functionality to the ResourceLink and Link components which is also useful for other use cases.