### PR TITLE
Update _index.md for clarity

### DIFF
--- a/docs/development/plugins/_index.md
+++ b/docs/development/plugins/_index.md
@@ -3,7 +3,7 @@ title: Plugins
 linkTitle: Plugins
 ---
 
-Plugins are one of the key features of Headlamp and allow to modify change what and how information is displayed, as well as other functionality. The ultimate goal of the plugins system is to allow vendors to build and deploy Headlamp with extra functionality without having to maintain a fork of the project.
+Plugins are one of the key features of Headlamp. They allow you to modify and change how and what information is displayed, as well as other functionality. The ultimate goal of the plugins system is to allow vendors to build and deploy Headlamp with extra functionality without having to maintain a fork of the project.
 
 # Developing Plugins
 

--- a/docs/development/plugins/_index.md
+++ b/docs/development/plugins/_index.md
@@ -3,7 +3,7 @@ title: Plugins
 linkTitle: Plugins
 ---
 
-Plugins are one of the key features of Headlamp. They allow you to modify and change how and what information is displayed, as well as other functionality. The ultimate goal of the plugins system is to allow vendors to build and deploy Headlamp with extra functionality without having to maintain a fork of the project.
+Plugins are one of the key features of Headlamp. They allow you to change how and what information is displayed, as well as other functionality. The ultimate goal of the plugins system is to allow vendors to build and deploy Headlamp with extra functionality without having to maintain a fork of the project.
 
 # Developing Plugins
 


### PR DESCRIPTION
# [Title: Clarify the grammar of the first paragraph of the plugins documentation]

The initial sentence had many "and" words and very easily lost the concentration of the reader.

# How to use

Not applicable

# Testing done

Not applicable; documentation only
