### PR TITLE
Update backend target to produce a server excutable when on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 backend/server
+backend/server.exe
 backend/tools

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 GO111MODULE=on
 export GO111MODULE
 
+SERVER_EXE_EXT ?=
 DOCKER_CMD ?= docker
 DOCKER_REPO ?= docker.io/joaquim
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)
 DOCKER_IMAGE_BASE ?= alpine:3.11.3
 
+ifeq ($(OS), Windows_NT)
+	SERVER_EXE_EXT = .exe
+endif
 all: backend frontend
 
 tools/golangci-lint: backend/go.mod backend/go.sum
@@ -27,7 +31,7 @@ app-mac:
 
 .PHONY: backend
 backend:
-	cd backend && go build -o ./server ./cmd
+	cd backend && go build -o ./server${SERVER_EXE_EXT} ./cmd
 
 frontend-install:
 	cd frontend && npm install

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,4 +2,5 @@
 /dist
 /build
 /electron/server
+/electron/server.exe
 /electron-builder.yml

--- a/app/package.json
+++ b/app/package.json
@@ -47,7 +47,7 @@
       "../frontend/node_modules/**/*",
       "node_modules/**/*"
     ],
-    "extraResources": "./electron/server",
+    "extraResources": ["./electron/server","./electron/server.exe"],
     "publish": {
       "provider": "github",
       "repo": "headlamp",


### PR DESCRIPTION
# How to use
package the app on windows and try running the desktop app 
earlier it was only showing a infinite spinner because of server not running, this is fixed now.
# Testing done
yes

