### PR TITLE
Check for nil in context parsing

### DIFF
--- a/backend/cmd/kubeconfig.go
+++ b/backend/cmd/kubeconfig.go
@@ -49,6 +49,11 @@ func GetContextsFromKubeConfigFile(kubeConfigPath string) ([]Context, error) {
 		authInfo := config.AuthInfos[value.AuthInfo]
 		authType := ""
 
+		if authInfo == nil {
+			log.Printf("Not adding context %v because authInfo is nil!\n", key)
+			continue
+		}
+
 		authProvider := authInfo.AuthProvider
 		if authProvider != nil {
 			authType = "oidc"


### PR DESCRIPTION
# Mitigate panic in backend/cmd/kubeconfig.go:52

Attempts to fix one of the problems causing https://github.com/kinvolk/headlamp/issues/112, especially the panic described in https://github.com/kinvolk/headlamp/issues/112#issuecomment-762148606

# How to use

1. Create a kubeconfig context referencing a user that does not exist

```yaml
...
contexts:
- context:
    cluster: my-existing-cluster
    user: non-existing
  name: my-context
...
```

2. Execute the backend

# Testing done

```nohighlight
$ make backend
cd backend && go build -o ./server ./cmd

$ backend/server

2021/01/18 17:42:18 Not adding context my-context because authInfo is nil!
*** Headlamp Server ***
  API Routers:
	...
```