### PR TITLE
Check for nil and empty username in context parsing (#170)

### DIFF
--- a/backend/cmd/kubeconfig.go
+++ b/backend/cmd/kubeconfig.go
@@ -49,16 +49,23 @@ func GetContextsFromKubeConfigFile(kubeConfigPath string) ([]Context, error) {
 		authInfo := config.AuthInfos[value.AuthInfo]
 		authType := ""
 
-		authProvider := authInfo.AuthProvider
-		if authProvider != nil {
-			authType = "oidc"
+		if authInfo == nil && value.AuthInfo != "" {
+			log.Printf("Not adding context: %v because user: %v could not be found!\n", key, value.AuthInfo)
+			continue
+		}
 
-			var oidcConfig OidcConfig
-			oidcConfig.ClientID = authProvider.Config["client-id"]
-			oidcConfig.ClientSecret = authProvider.Config["client-secret"]
-			oidcConfig.IdpIssuerURL = authProvider.Config["idp-issuer-url"]
+		if authInfo != nil {
+			authProvider := authInfo.AuthProvider
+			if authProvider != nil {
+				authType = "oidc"
 
-			oidcConfigCache[key] = &oidcConfig
+				var oidcConfig OidcConfig
+				oidcConfig.ClientID = authProvider.Config["client-id"]
+				oidcConfig.ClientSecret = authProvider.Config["client-secret"]
+				oidcConfig.IdpIssuerURL = authProvider.Config["idp-issuer-url"]
+
+				oidcConfigCache[key] = &oidcConfig
+			}
 		}
 
 		cluster := Cluster{key, clusterConfig.Server, clusterConfig, authType}


### PR DESCRIPTION

# Mitigate panic in backend/cmd/kubeconfig.go:52

Continuing on from the PR https://github.com/kinvolk/headlamp/pull/170 related to https://github.com/kinvolk/headlamp/issues/112#issuecomment-762148606

There was a segfault in the backend when the user was not there, or not existing.


# How to use

1. Create a kubeconfig context referencing a user that does not exist

```yaml
...
contexts:
- context:
    cluster: my-existing-cluster
    user: non-existing
  name: my-context
...
```

Another case is where there is no user mentioned at all.

```yaml
...
contexts:
- context:
    cluster: my-existing-cluster
  name: my-context
...
```


2. Execute the backend

# Testing done

```nohighlight
$ make backend run-backend

2021/01/21 15:09:48 Not adding context: my-context because user:non-existing could not be found!
*** Headlamp Server ***
  API Routers:
	...
```

It shows this for when the user is not there, and anonymous users are not allowed auth.

<img width="585" alt="Screenshot 2021-01-22 at 18 18 36" src="https://user-images.githubusercontent.com/9541/105523115-4e3c4580-5cde-11eb-8c3a-a55921a82603.png">

