### PR TITLE
Add login screen back for OIDC configurations

### DIFF
--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -80,8 +80,10 @@ function AuthChooser(){
     let cancelled = false;
 
     // If we haven't yet figured whether we need to use a token for the current
-    // cluster, then we check here.
-    if (cluster.useToken === undefined) {
+    //   cluster, then we check here.
+    // With clusterAuthType == oidc,
+    //   they are presented with a choice of login or enter token.
+    if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
       let useToken = true;
 
       setTestingAuth(true);


### PR DESCRIPTION
So that the login screen is shown again as it was in v0.1.3

See https://github.com/kinvolk/headlamp/issues/182

It would be worthwhile to refactor this code so that the states are clear and tested (as started in https://github.com/kinvolk/headlamp/pull/168 ) but this is not done in this PR.

# How to use

Login against an OIDC configuration.
See that there is a choice between Login, and using a token.

<img width="317" alt="Screenshot 2021-01-26 at 16 33 48" src="https://user-images.githubusercontent.com/9541/105866495-548b3400-5ff4-11eb-84fb-e60c76036b6e.png">


# Testing done

Before it was going to the enter token state.
Now it's showing a choice.
