### PR TITLE
Add prettier code formatting tool for frontend

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -8,15 +8,17 @@ import path from 'path';
 import url from 'url';
 import yargs from 'yargs';
 
-const args = yargs.option('headless', {
-  describe: 'Open Headlamp in the default web browser instead of its app window'
-}).parse();
+const args = yargs
+  .option('headless', {
+    describe: 'Open Headlamp in the default web browser instead of its app window',
+  })
+  .parse();
 const isHeadlessMode = args.headless;
 const defaultPort = 4466;
 
 function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
   const serverFilePath = path.join(process.resourcesPath, './electron/server');
-  return spawn(serverFilePath, [...flags], {shell: true});
+  return spawn(serverFilePath, [...flags], { shell: true });
 }
 
 let serverProcess: ChildProcessWithoutNullStreams | null;
@@ -33,26 +35,28 @@ function startElecron() {
 
   const template = [
     // { role: 'appMenu' }
-    ...(isMac ? [{
-      label: app.name,
-      submenu: [
-        { role: 'about' },
-        { type: 'separator' },
-        { role: 'services' },
-        { type: 'separator' },
-        { role: 'hide' },
-        { role: 'hideothers' },
-        { role: 'unhide' },
-        { type: 'separator' },
-        { role: 'quit' }
-      ]
-    }] : []),
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' },
+              { type: 'separator' },
+              { role: 'services' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideothers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' },
+            ],
+          },
+        ]
+      : []),
     // { role: 'fileMenu' }
     {
       label: 'File',
-      submenu: [
-        isMac ? { role: 'close' } : { role: 'quit' }
-      ]
+      submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
     },
     // { role: 'editMenu' }
     {
@@ -64,24 +68,19 @@ function startElecron() {
         { role: 'cut' },
         { role: 'copy' },
         { role: 'paste' },
-        ...(isMac ? [
-          { role: 'pasteAndMatchStyle' },
-          { role: 'delete' },
-          { role: 'selectAll' },
-          { type: 'separator' },
-          {
-            label: 'Speech',
-            submenu: [
-              { role: 'startspeaking' },
-              { role: 'stopspeaking' }
+        ...(isMac
+          ? [
+              { role: 'pasteAndMatchStyle' },
+              { role: 'delete' },
+              { role: 'selectAll' },
+              { type: 'separator' },
+              {
+                label: 'Speech',
+                submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+              },
             ]
-          }
-        ] : [
-          { role: 'delete' },
-          { type: 'separator' },
-          { role: 'selectAll' }
-        ])
-      ]
+          : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
+      ],
     },
     // { role: 'viewMenu' }
     {
@@ -95,23 +94,18 @@ function startElecron() {
         { role: 'zoomin' },
         { role: 'zoomout' },
         { type: 'separator' },
-        { role: 'togglefullscreen' }
-      ]
+        { role: 'togglefullscreen' },
+      ],
     },
     // { role: 'windowMenu' }
     {
       label: 'Window',
       submenu: [
         { role: 'minimize' },
-        ...(isMac ? [
-          { type: 'separator' },
-          { role: 'front' },
-          { type: 'separator' },
-          { role: 'window' }
-        ] : [
-          { role: 'close' }
-        ])
-      ]
+        ...(isMac
+          ? [{ type: 'separator' }, { role: 'front' }, { type: 'separator' }, { role: 'window' }]
+          : [{ role: 'close' }]),
+      ],
     },
     {
       role: 'help',
@@ -121,17 +115,17 @@ function startElecron() {
           click: async () => {
             const { shell } = require('electron');
             await shell.openExternal('https://github.com/kinvolk/headlamp/issues');
-          }
+          },
         },
         {
           label: 'About',
           click: async () => {
             const { shell } = require('electron');
             await shell.openExternal('https://github.com/kinvolk/headlamp');
-          }
-        }
-      ]
-    }
+          },
+        },
+      ],
+    },
   ];
 
   const menu = Menu.buildFromTemplate(template as (MenuItemConstructorOptions | MenuItem)[]);
@@ -139,12 +133,14 @@ function startElecron() {
 
   const isDev = process.env.ELECTRON_DEV || false;
 
-  function createWindow () {
-    const startUrl = process.env.ELECTRON_START_URL || url.format({
-      pathname: path.join(__dirname, '../index.html'),
-      protocol: 'file:',
-      slashes: true,
-    });
+  function createWindow() {
+    const startUrl =
+      process.env.ELECTRON_START_URL ||
+      url.format({
+        pathname: path.join(__dirname, '../index.html'),
+        protocol: 'file:',
+        slashes: true,
+      });
     const { width, height } = screen.getPrimaryDisplay().workAreaSize;
     mainWindow = new BrowserWindow({ width, height });
     mainWindow.loadURL(startUrl);
@@ -167,7 +163,7 @@ function startElecron() {
     }
   }
 
-  autoUpdater.on('update-not-available', (info) => {
+  autoUpdater.on('update-not-available', info => {
     sendStatusToWindow('Update not available.');
   });
 
@@ -219,14 +215,14 @@ app.on('quit', function () {
  * add some error handlers to the serverProcess.
  * @param  {ChildProcess} serverProcess to attach the error handlers to.
  */
-function attachServerEventHandlers (serverProcess: ChildProcessWithoutNullStreams) {
-  serverProcess.on('error', (err) => {
+function attachServerEventHandlers(serverProcess: ChildProcessWithoutNullStreams) {
+  serverProcess.on('error', err => {
     log.error(`server process failed to start: ${err}`);
   });
-  serverProcess.stdout.on('data', (data) => {
+  serverProcess.stdout.on('data', data => {
     log.info(`server process stdout: ${data}`);
   });
-  serverProcess.stderr.on('data', (data) => {
+  serverProcess.stderr.on('data', data => {
     const sterrMessage = `server process stderr: ${data}`;
     if (data && data.indexOf && data.indexOf('Requesting') !== -1) {
       // The server prints out urls it's getting, which aren't errors.

--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -1,1 +1,0 @@
-extends: '@kinvolk'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2380,16 +2380,6 @@
         "react-transition-group": "^4.4.0"
       },
       "dependencies": {
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
-          }
-        },
         "hoist-non-react-statics": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -2435,16 +2425,6 @@
         "prop-types": "^15.7.2"
       },
       "dependencies": {
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
-          }
-        },
         "hoist-non-react-statics": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -2464,18 +2444,6 @@
         "@material-ui/utils": "^4.11.2",
         "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
-          }
-        }
       }
     },
     "@material-ui/types": {
@@ -2551,12 +2519,12 @@
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.12.13"
+            "@babel/highlight": "^7.10.4"
           }
         },
         "@babel/core": {
@@ -2584,21 +2552,19 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-          "dev": true,
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+          "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
+            "@babel/helper-get-function-arity": "^7.12.10",
+            "@babel/template": "^7.12.7",
+            "@babel/types": "^7.12.11"
           }
         },
         "@babel/helper-get-function-arity": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
           "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
@@ -2615,14 +2581,12 @@
         "@babel/helper-validator-identifier": {
           "version": "7.12.11",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
         },
         "@babel/highlight": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
           "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
             "chalk": "^2.0.0",
@@ -2632,18 +2596,26 @@
         "@babel/parser": {
           "version": "7.12.15",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
-          "dev": true
+          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA=="
         },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/parser": "^7.12.13",
             "@babel/types": "^7.12.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+              "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+              "requires": {
+                "@babel/highlight": "^7.12.13"
+              }
+            }
           }
         },
         "@babel/traverse": {
@@ -2663,6 +2635,15 @@
             "lodash": "^4.17.19"
           },
           "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+              "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.12.13"
+              }
+            },
             "@babel/generator": {
               "version": "7.12.15",
               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
@@ -2673,6 +2654,17 @@
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
               }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+              "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.12.13",
+                "@babel/template": "^7.12.13",
+                "@babel/types": "^7.12.13"
+              }
             }
           }
         },
@@ -2680,7 +2672,6 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
           "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
             "lodash": "^4.17.19",
@@ -3060,6 +3051,12 @@
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
+        "prettier": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+          "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -4943,6 +4940,12 @@
             "json5": "^2.1.2"
           }
         },
+        "prettier": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+          "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5732,33 +5735,116 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz",
-      "integrity": "sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
+      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.14.2",
-        "@typescript-eslint/scope-manager": "4.14.2",
+        "@typescript-eslint/experimental-utils": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.15.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+          "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "@typescript-eslint/visitor-keys": "4.15.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+          "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+          "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz",
-      "integrity": "sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
+      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+          "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "@typescript-eslint/visitor-keys": "4.15.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+          "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+          "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "@typescript-eslint/visitor-keys": "4.15.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+          "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/parser": {
@@ -6691,6 +6777,11 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
       "version": "2.6.3",
@@ -8185,7 +8276,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -8198,6 +8288,15 @@
       "requires": {
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
+      }
+    },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "requires": {
+        "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
       }
     },
@@ -8240,9 +8339,9 @@
       }
     },
     "clsx": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
-      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",
@@ -8356,6 +8455,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+    },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -10569,6 +10673,12 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+      "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+      "dev": true
+    },
     "eslint-config-react-app": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
@@ -11902,7 +12012,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -12067,6 +12176,14 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
         "locate-path": "^2.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "requires": {
+        "semver-regex": "^3.1.2"
       }
     },
     "flatten": {
@@ -13372,6 +13489,114 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+    },
+    "husky": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "hyphenate-style-name": {
       "version": "1.0.4",
@@ -16558,6 +16783,251 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
+    "lint-staged": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.4.tgz",
+      "integrity": "sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "commander": "^6.2.0",
+        "cosmiconfig": "^7.0.0",
+        "debug": "^4.2.0",
+        "dedent": "^0.7.0",
+        "enquirer": "^2.3.6",
+        "execa": "^4.1.0",
+        "listr2": "^3.2.2",
+        "log-symbols": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "string-argv": "0.3.1",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "enquirer": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+          "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+          "requires": {
+            "ansi-colors": "^4.1.1"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "listr2": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.3.1.tgz",
+      "integrity": "sha512-8Zoxe7s/8nNr4bJ8bdAduHD8uJce+exmMmUWTXlq0WuUdffnH3muisHPHPFtW2vvOfohIsq7FGCaguUxN/h3Iw==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "figures": "^3.2.0",
+        "indent-string": "^4.0.0",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rxjs": "^6.6.3",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -16675,6 +17145,103 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "requires": {
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
+      }
     },
     "loglevel": {
       "version": "1.7.1",
@@ -17881,6 +18448,11 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-7.2.3.tgz",
       "integrity": "sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA=="
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -18353,6 +18925,14 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "pnp-webpack-plugin": {
@@ -19409,10 +19989,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
-      "dev": true
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
     },
     "pretty-bytes": {
       "version": "5.5.0",
@@ -21929,7 +22508,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -22099,7 +22677,6 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -22389,6 +22966,16 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "semver-regex": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA=="
     },
     "send": {
       "version": "0.17.1",
@@ -22733,6 +23320,39 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -23202,6 +23822,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
     },
     "string-length": {
       "version": "4.0.1",
@@ -24496,8 +25121,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
@@ -26623,6 +27247,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,14 +19,17 @@
     "@types/semver": "^7.3.4",
     "@types/webpack-env": "^1.16.0",
     "ansi-to-react": "^6.1.4",
+    "husky": "^4.3.8",
     "javascript-time-ago": "^2.3.4",
     "js-base64": "^3.6.0",
     "js-cookie": "^2.2.1",
     "js-yaml": "^3.14.0",
+    "lint-staged": "^10.5.4",
     "lodash": "^4.17.20",
     "monaco-editor": "^0.21.2",
     "notistack": "^1.0.3",
     "openapi-types": "^7.2.3",
+    "prettier": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hotkeys-hook": "^3.0.3",
@@ -45,7 +48,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint -c .eslintrc.yml --ext .js,.ts,.tsx src/ ../app/electron",
+    "lint": "eslint -c package.json --ext .js,.ts,.tsx src/ ../app/electron",
+    "format": "prettier --config package.json --write src/ ../app/electron",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
   },
@@ -61,6 +65,27 @@
       "last 1 safari version"
     ]
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "src/**/*.{js,jsx,ts,tsx}": [
+      "eslint -c package.json --fix"
+    ],
+    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier --config package.json --write"
+    ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "@kinvolk",
+      "prettier",
+      "prettier/react"
+    ]
+  },
+  "prettier": "@kinvolk/eslint-config/prettier-config",
   "devDependencies": {
     "@iconify/icons-mdi": "^1.1.10",
     "@iconify/react": "^1.1.3",
@@ -76,6 +101,7 @@
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
     "eslint": "^7.19.0",
+    "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,15 @@ import { ThemeProvider } from '@material-ui/styles';
 import { SnackbarProvider } from 'notistack';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, HashRouter, Redirect, Route, RouteProps, Switch, useHistory } from 'react-router-dom';
+import {
+  BrowserRouter,
+  HashRouter,
+  Redirect,
+  Route,
+  RouteProps,
+  Switch,
+  useHistory,
+} from 'react-router-dom';
 import { ClusterTitle } from './components/cluster/Chooser';
 import ActionsNotifier from './components/common/ActionsNotifier';
 import AlertNotification from './components/common/AlertNotification';
@@ -36,14 +44,15 @@ import store from './redux/stores/store';
 const useStyle = makeStyles(theme => ({
   root: {
     background: theme.palette.background.default,
-    paddingLeft: (props: {isSidebarOpen: boolean}) => props.isSidebarOpen ? `${drawerWidth}px` : '0px',
+    paddingLeft: (props: { isSidebarOpen: boolean }) =>
+      props.isSidebarOpen ? `${drawerWidth}px` : '0px',
     marginLeft: drawerWidth,
     '& > *': {
       color: theme.palette.text.primary,
-    }
+    },
   },
   content: {
-    flexGrow: 1
+    flexGrow: 1,
   },
   toolbar: theme.mixins.toolbar,
 }));
@@ -53,11 +62,12 @@ function RouteSwitcher() {
 
   return (
     <Switch>
-      {Object.values(ROUTES).concat(Object.values(routes))
+      {Object.values(ROUTES)
+        .concat(Object.values(routes))
         .map((route, index) =>
-          route.name === 'OidcAuth' ?
-            <Route path={route.path} component={() => <route.component/>} key={index}/>
-            :
+          route.name === 'OidcAuth' ? (
+            <Route path={route.path} component={() => <route.component />} key={index} />
+          ) : (
             <AuthRoute
               key={index}
               path={getRoutePath(route)}
@@ -67,6 +77,7 @@ function RouteSwitcher() {
               exact={!!route.exact}
               children={<route.component />}
             />
+          )
         )}
     </Switch>
   );
@@ -100,21 +111,23 @@ function TopBar() {
 
   return (
     <>
-      { // @todo: Use a grid to compose the toolbar
-        Object.values(appBarActions).map((action, i) =>
-          <React.Fragment key={i}>{action()}</React.Fragment>)
+      {
+        // @todo: Use a grid to compose the toolbar
+        Object.values(appBarActions).map((action, i) => (
+          <React.Fragment key={i}>{action()}</React.Fragment>
+        ))
       }
       <IconButton
-        aria-label='User menu'
-        aria-controls='menu-appbar'
-        aria-haspopup='true'
+        aria-label="User menu"
+        aria-controls="menu-appbar"
+        aria-haspopup="true"
         onClick={handleMenu}
-        color='inherit'
+        color="inherit"
       >
         <Icon icon={accountIcon} />
       </IconButton>
       <Menu
-        id='customized-menu'
+        id="customized-menu"
         anchorEl={menuAnchorEl}
         open={!!menuAnchorEl}
         onClose={handleClose}
@@ -127,19 +140,11 @@ function TopBar() {
           horizontal: 'right',
         }}
       >
-        <MenuItem
-          component="a"
-          onClick={logout}
-          disabled={!hasToken()}
-          dense
-        >
+        <MenuItem component="a" onClick={logout} disabled={!hasToken()} dense>
           <ListItemIcon>
             <Icon icon={logoutIcon} />
           </ListItemIcon>
-          <ListItemText
-            primary="Log out"
-            secondary={hasToken() ? null : '(No token set up)'}
-          />
+          <ListItemText primary="Log out" secondary={hasToken() ? null : '(No token set up)'} />
         </MenuItem>
       </Menu>
     </>
@@ -151,7 +156,7 @@ interface ThemeChangeButtonProps {
 }
 
 function ThemeChangeButton(props: ThemeChangeButtonProps) {
-  const {onChange} = props;
+  const { onChange } = props;
   type iconType = typeof darkIcon;
 
   const counterIcons: {
@@ -176,10 +181,7 @@ function ThemeChangeButton(props: ThemeChangeButtonProps) {
   }
 
   return (
-    <IconButton
-      aria-label="change-theme"
-      onClick={() => changeTheme()}
-    >
+    <IconButton aria-label="change-theme" onClick={() => changeTheme()}>
       <Icon icon={icon} />
     </IconButton>
   );
@@ -192,12 +194,11 @@ interface AppContainerProps {
 function AppContainer(props: AppContainerProps) {
   const isSidebarOpen = useTypedSelector(state => state.ui.sidebar.isSidebarOpen);
   const classes = useStyle({ isSidebarOpen });
-  const {setThemeName} = props;
-  const Router = ({children} : React.PropsWithChildren<{}>) => isElectron() ?
-    <HashRouter>{children}</HashRouter> :
-    <BrowserRouter>{children}</BrowserRouter>;
+  const { setThemeName } = props;
+  const Router = ({ children }: React.PropsWithChildren<{}>) =>
+    isElectron() ? <HashRouter>{children}</HashRouter> : <BrowserRouter>{children}</BrowserRouter>;
 
-  localStorage.setItem('sidebar', JSON.stringify({'shrink': isSidebarOpen}));
+  localStorage.setItem('sidebar', JSON.stringify({ shrink: isSidebarOpen }));
 
   return (
     <SnackbarProvider
@@ -210,24 +211,18 @@ function AppContainer(props: AppContainerProps) {
         <Box display="flex">
           <CssBaseline />
 
-          <AppBar
-            position="fixed"
-            className={classes.root}
-            elevation={1}
-          >
+          <AppBar position="fixed" className={classes.root} elevation={1}>
             <Toolbar>
-              <div style={{flex: '1 0 0'}} />
+              <div style={{ flex: '1 0 0' }} />
               <ClusterTitle />
-              <div style={{flex: '1 0 0'}} />
-              <ThemeChangeButton
-                onChange={(theme: string) => setThemeName(theme)}
-              />
+              <div style={{ flex: '1 0 0' }} />
+              <ThemeChangeButton onChange={(theme: string) => setThemeName(theme)} />
               <TopBar />
             </Toolbar>
           </AppBar>
           <Sidebar />
           <main className={classes.content}>
-            <AlertNotification/>
+            <AlertNotification />
             <Box p={3}>
               <div className={classes.toolbar} />
               <Container maxWidth="lg">
@@ -248,18 +243,16 @@ function App() {
 
   React.useEffect(() => {
     initializePlugins();
-  },
-  [themeName]);
+  }, [themeName]);
 
   React.useEffect(() => {
     console.log(themes[themeName]);
-  },
-  [themeName]);
+  }, [themeName]);
 
   return (
     <Provider store={store}>
       <ThemeProvider theme={themes[themeName]}>
-        <AppContainer setThemeName={setThemeName}/>
+        <AppContainer setThemeName={setThemeName} />
       </ThemeProvider>
     </Provider>
   );
@@ -289,7 +282,7 @@ function AuthRoute(props: AuthRouteProps) {
       const clusterName = getCluster();
       if (!!clusterName) {
         const cluster = clusters ? clusters[clusterName] : undefined;
-        const requiresToken = (cluster?.useToken === undefined || cluster?.useToken);
+        const requiresToken = cluster?.useToken === undefined || cluster?.useToken;
         if (!!getToken(clusterName) || !requiresToken) {
           return children;
         }
@@ -300,7 +293,7 @@ function AuthRoute(props: AuthRouteProps) {
       <Redirect
         to={{
           pathname: createRouteURL(redirectRoute),
-          state: { from: location }
+          state: { from: location },
         }}
       />
     );
@@ -308,12 +301,7 @@ function AuthRoute(props: AuthRouteProps) {
 
   // If no auth is required for the view, or the token is set up, then
   // render the assigned component. Otherwise redirect to the login route.
-  return (
-    <Route
-      {...other}
-      render={getRenderer}
-    />
-  );
+  return <Route {...other} render={getRenderer} />;
 }
 
 export default App;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -80,24 +80,23 @@ const useStyle = makeStyles(theme => ({
   toolbar: {
     borderBottom: '1px solid #1e1e1e',
     paddingTop: theme.spacing(1.5),
-    paddingLeft: (
-      props: { isSidebarOpen: boolean }
-    ) => props.isSidebarOpen ? theme.spacing(2) : theme.spacing(1),
+    paddingLeft: (props: { isSidebarOpen: boolean }) =>
+      props.isSidebarOpen ? theme.spacing(2) : theme.spacing(1),
     paddingBottom: theme.spacing(1),
   },
   sidebarGrid: {
-    height: '100%'
+    height: '100%',
   },
   '.MuiListItemText-primary': {
-    color: 'red'
+    color: 'red',
   },
   logo: {
     height: '32px',
     width: 'auto',
-  }
+  },
 }));
 
-const IconTooltip = withStyles((theme) => ({
+const IconTooltip = withStyles(theme => ({
   tooltip: {
     backgroundColor: '#474747',
     color: '#fff',
@@ -105,8 +104,8 @@ const IconTooltip = withStyles((theme) => ({
     padding: '0.5rem',
     fontSize: '0.8rem',
     border: '1px solid #474747',
-    marginLeft: '1rem'
-  }
+    marginLeft: '1rem',
+  },
 }))(Tooltip);
 
 const LIST_ITEMS: SidebarEntry[] = [
@@ -117,21 +116,21 @@ const LIST_ITEMS: SidebarEntry[] = [
     subList: [
       {
         name: 'namespaces',
-        label: 'Namespaces'
+        label: 'Namespaces',
       },
       {
         name: 'nodes',
-        label: 'Nodes'
+        label: 'Nodes',
       },
       {
         name: 'crds',
-        label: 'CRDs'
+        label: 'CRDs',
       },
       {
         name: 'configMaps',
-        label: 'Config Maps'
+        label: 'Config Maps',
       },
-    ]
+    ],
   },
   {
     name: 'workloads',
@@ -140,34 +139,33 @@ const LIST_ITEMS: SidebarEntry[] = [
     subList: [
       {
         name: 'Pods',
-        label: 'Pods'
+        label: 'Pods',
       },
       {
         name: 'ReplicaSets',
-        label: 'Replica Sets'
+        label: 'Replica Sets',
       },
       {
         name: 'DaemonSets',
-        label: 'Daemon Sets'
+        label: 'Daemon Sets',
       },
       {
         name: 'StatefulSets',
-        label: 'Stateful Sets'
+        label: 'Stateful Sets',
       },
       {
         name: 'Jobs',
-        label: 'Jobs'
+        label: 'Jobs',
       },
       {
         name: 'Deployments',
-        label: 'Deployments'
+        label: 'Deployments',
       },
       {
         name: 'CronJobs',
-        label: 'CronJobs'
-
-      }
-    ]
+        label: 'CronJobs',
+      },
+    ],
   },
   {
     name: 'storage',
@@ -176,17 +174,17 @@ const LIST_ITEMS: SidebarEntry[] = [
     subList: [
       {
         name: 'storageClasses',
-        label: 'Storage Classes'
+        label: 'Storage Classes',
       },
       {
         name: 'persistentVolumes',
-        label: 'Storage Volumes'
+        label: 'Storage Volumes',
       },
       {
         name: 'persistentVolumeClaims',
-        label: 'Persistent Volume Claims'
+        label: 'Persistent Volume Claims',
       },
-    ]
+    ],
   },
   {
     name: 'network',
@@ -195,13 +193,13 @@ const LIST_ITEMS: SidebarEntry[] = [
     subList: [
       {
         name: 'services',
-        label: 'Services'
+        label: 'Services',
       },
       {
         name: 'ingresses',
-        label: 'Ingresses'
+        label: 'Ingresses',
       },
-    ]
+    ],
   },
   {
     name: 'security',
@@ -210,21 +208,21 @@ const LIST_ITEMS: SidebarEntry[] = [
     subList: [
       {
         name: 'serviceAccounts',
-        label: 'Service Accounts'
+        label: 'Service Accounts',
       },
       {
         name: 'roles',
-        label: 'Roles'
+        label: 'Roles',
       },
       {
         name: 'roleBindings',
-        label: 'Role Bindings'
+        label: 'Role Bindings',
       },
       {
         name: 'secrets',
-        label: 'Secrets'
+        label: 'Secrets',
       },
-    ]
+    ],
   },
 ];
 
@@ -234,7 +232,7 @@ function prepareRoutes() {
   const routes: SidebarEntry[] = JSON.parse(JSON.stringify(LIST_ITEMS));
 
   for (const item of Object.values(items)) {
-    const parent = item.parent ? routes.find(({name}) => name === item.parent) : null;
+    const parent = item.parent ? routes.find(({ name }) => name === item.parent) : null;
     let placement = routes;
     if (parent) {
       if (!parent['subList']) {
@@ -255,11 +253,11 @@ const useVersionButtonStyle = makeStyles(theme => ({
     textAlign: 'center',
     '& .MuiButton-label': {
       color: theme.palette.sidebarLink.main,
-    }
+    },
   },
   versionIcon: {
     marginTop: '5px',
-    marginRight: '5px'
+    marginRight: '5px',
   },
 }));
 
@@ -300,83 +298,74 @@ function VersionButton() {
     ];
   }
 
-  React.useEffect(() => {
-    function fetchVersion() {
-      getVersion()
-        .then((results: StringDict) => {
-          setClusterVersion(results);
-          let versionChange = 0;
-          if (clusterVersion && results && results.gitVersion) {
-            versionChange = semver.compare(results.gitVersion, clusterVersion.gitVersion);
+  React.useEffect(
+    () => {
+      function fetchVersion() {
+        getVersion()
+          .then((results: StringDict) => {
+            setClusterVersion(results);
+            let versionChange = 0;
+            if (clusterVersion && results && results.gitVersion) {
+              versionChange = semver.compare(results.gitVersion, clusterVersion.gitVersion);
 
-            let msg = '';
-            if (versionChange > 0) {
-              msg = `Cluster version upgraded to ${results.gitVersion}`;
-            } else if (versionChange < 0) {
-              msg = `Cluster version downgraded to ${results.gitVersion}`;
+              let msg = '';
+              if (versionChange > 0) {
+                msg = `Cluster version upgraded to ${results.gitVersion}`;
+              } else if (versionChange < 0) {
+                msg = `Cluster version downgraded to ${results.gitVersion}`;
+              }
+
+              if (msg) {
+                enqueueSnackbar(msg, {
+                  key: 'version',
+                  preventDuplicate: true,
+                  autoHideDuration: versionSnackbarHideTimeout,
+                  variant: 'info',
+                });
+              }
             }
+          })
+          .catch((error: Error) => console.error('Getting the cluster version:', error));
+      }
 
-            if (msg) {
-              enqueueSnackbar(msg, {
-                key: 'version',
-                preventDuplicate: true,
-                autoHideDuration: versionSnackbarHideTimeout,
-                variant: 'info',
-              });
-            }
-          }
-        })
-        .catch((error: Error) => console.error('Getting the cluster version:', error));
-    }
+      if (!clusterVersion) {
+        fetchVersion();
+      }
 
-    if (!clusterVersion) {
-      fetchVersion();
-    }
+      const intervalHandler = setInterval(() => {
+        fetchVersion();
+      }, versionFetchInterval);
 
-    const intervalHandler = setInterval(() => {
-      fetchVersion();
-    }, versionFetchInterval);
-
-    return function cleanup() {
-      clearInterval(intervalHandler);
-    };
-  },
-  // eslint-disable-next-line
-  [clusterVersion]);
+      return function cleanup() {
+        clearInterval(intervalHandler);
+      };
+    },
+    // eslint-disable-next-line
+    [clusterVersion]
+  );
 
   // Use the location to make sure the version is changed, as it depends on the cluster
   // (defined in the URL ATM).
   // @todo: Update this if the active cluster management is changed.
   React.useEffect(() => {
     setClusterVersion(null);
-  },
-  [cluster]);
+  }, [cluster]);
 
   function handleClose() {
     setOpen(false);
   }
 
-  return (!clusterVersion ?
-    null
-    :
+  return !clusterVersion ? null : (
     <Box mx="auto" py=".2em" className={classes.versionBox}>
-      <Button
-        onClick={() => setOpen(true) }
-        style={{textTransform: 'none', }}
-      >
+      <Button onClick={() => setOpen(true)} style={{ textTransform: 'none' }}>
         <Box display={sidebar.isSidebarOpen ? 'flex' : 'block'} alignItems="center">
           <Box>
             <Icon color="#adadad" icon={kubernetesIcon} className={classes.versionIcon} />
           </Box>
-          <Box>
-            {clusterVersion.gitVersion}
-          </Box>
+          <Box>{clusterVersion.gitVersion}</Box>
         </Box>
       </Button>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-      >
+      <Dialog open={open} onClose={handleClose}>
         <DialogTitle>Kubernetes Version</DialogTitle>
         <DialogContent>
           <NameValueTable rows={getVersionRows()} />
@@ -406,32 +395,30 @@ function ListItemLink(props: ListItemLinkProps) {
       React.forwardRef<any, Omit<RouterLinkProps, 'to'>>((itemProps, ref) => (
         <RouterLink to={to} ref={ref} {...itemProps} />
       )),
-    [to],
+    [to]
   );
   let listItemLink = null;
 
   if (icon) {
-    listItemLink =
+    listItemLink = (
       <ListItemIcon>
         <Icon icon={icon} width={30} height={30} />
-      </ListItemIcon>;
+      </ListItemIcon>
+    );
   }
 
   let listItemLinkContainer = listItemLink;
   if (!primary) {
-    listItemLinkContainer = listItemLink &&
-    <IconTooltip title={name} placement="right-start">
-      {listItemLink}
-    </IconTooltip>;
+    listItemLinkContainer = listItemLink && (
+      <IconTooltip title={name} placement="right-start">
+        {listItemLink}
+      </IconTooltip>
+    );
   }
 
   return (
     <li>
-      <ListItem
-        button
-        component={renderLink}
-        {...other}
-      >
+      <ListItem button component={renderLink} {...other}>
         {listItemLinkContainer}
         <ListItemText primary={primary} />
       </ListItem>
@@ -470,10 +457,11 @@ export default function Sidebar() {
       }}
     >
       <div className={classes.toolbar}>
-        <Button onClick={() => {
-          dispatch(setWhetherSidebarOpen(!open));
-          setOpen(!open);
-        }}
+        <Button
+          onClick={() => {
+            dispatch(setWhetherSidebarOpen(!open));
+            setOpen(!open);
+          }}
         >
           <SvgIcon
             className={classes.logo}
@@ -491,14 +479,9 @@ export default function Sidebar() {
       >
         <Grid item>
           <List>
-            {items.map((item, i) =>
-              <SidebarItem
-                key={i}
-                selectedName={sidebar.selected}
-                fullWidth={open}
-                {...item}
-              />
-            )}
+            {items.map((item, i) => (
+              <SidebarItem key={i} selectedName={sidebar.selected} fullWidth={open} {...item} />
+            ))}
           </List>
         </Grid>
         <Grid item>
@@ -516,7 +499,7 @@ const useItemStyle = makeStyles(theme => ({
   nested: {
     '& .MuiListItem-root': {
       paddingLeft: theme.spacing(9),
-    }
+    },
   },
   linkMain: {
     textTransform: 'uppercase',
@@ -552,7 +535,7 @@ const useItemStyle = makeStyles(theme => ({
     color: theme.palette.primary.contrastText,
     '&:hover': {
       backgroundColor: theme.palette.sidebarLink.selectedBg,
-      'svg': {
+      svg: {
         color: theme.palette.primary.contrastText,
       },
     },
@@ -588,11 +571,11 @@ function SidebarItem(props: SidebarItemProps) {
     ...other
   } = props;
 
-  const classes = useItemStyle({fullWidth});
+  const classes = useItemStyle({ fullWidth });
 
   let fullURL = url;
   if (fullURL && useClusterURL && getCluster()) {
-    fullURL = generatePath(getClusterPrefixedPath(url), {cluster: getCluster()!});
+    fullURL = generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! });
   }
 
   if (!fullURL) {
@@ -637,20 +620,15 @@ function SidebarItem(props: SidebarItemProps) {
         name={label}
         {...other}
       />
-      {subList.length > 0 &&
+      {subList.length > 0 && (
         <Collapse in={fullWidth && expanded}>
           <List component="div" disablePadding className={classes.nested}>
-            {subList.map((item, i) =>
-              <SidebarItem
-                key={i}
-                selectedName={selectedName}
-                hasParent
-                {...item}
-              />
-            )}
+            {subList.map((item, i) => (
+              <SidebarItem key={i} selectedName={selectedName} hasParent {...item} />
+            ))}
           </List>
         </Collapse>
-      }
+      )}
     </React.Fragment>
   );
 }
@@ -658,26 +636,28 @@ function SidebarItem(props: SidebarItemProps) {
 export function useSidebarItem(itemName: string | null) {
   const dispatch = useDispatch();
 
-  React.useEffect(() => {
-    dispatch(setSidebarSelected(itemName));
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  []);
+  React.useEffect(
+    () => {
+      dispatch(setSidebarSelected(itemName));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 }
 
-function searchNameInSubList(sublist : SidebarEntry['subList'], name: string): boolean {
+function searchNameInSubList(sublist: SidebarEntry['subList'], name: string): boolean {
   if (!sublist) {
     return false;
   }
   for (let i = 0; i < sublist.length; i++) {
-    if (sublist[i].name === name){
+    if (sublist[i].name === name) {
       return true;
     }
   }
   return false;
 }
 
-function findParentOfSubList(list: SidebarEntry[], name: string | null): SidebarEntry | null{
+function findParentOfSubList(list: SidebarEntry[], name: string | null): SidebarEntry | null {
   if (!name) {
     return null;
   }
@@ -700,7 +680,7 @@ export function NavigationTabs() {
 
   let defaultIndex = null;
   const listItems = prepareRoutes();
-  let navigationItem = listItems.find((item) => item.name === sidebar.selected);
+  let navigationItem = listItems.find(item => item.name === sidebar.selected);
   if (!navigationItem) {
     const parent = findParentOfSubList(listItems, sidebar.selected);
     if (!parent) {
@@ -722,11 +702,11 @@ export function NavigationTabs() {
 
     const url = subList[index].url;
     if (url) {
-      pathname = generatePath(getClusterPrefixedPath(url), {cluster: getCluster()!});
+      pathname = generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! });
     } else {
       pathname = createRouteURL(subList[index].name);
     }
-    history.push({pathname});
+    history.push({ pathname });
   }
 
   if (createRouteURL(navigationItem.name)) {
@@ -734,17 +714,20 @@ export function NavigationTabs() {
   }
 
   const tabRoutes = subList.map((item: any) => {
-    return {'label': item.label, component: <></>};
+    return { label: item.label, component: <></> };
   });
 
-  defaultIndex = subList.findIndex((item) => item.name === sidebar.selected);
+  defaultIndex = subList.findIndex(item => item.name === sidebar.selected);
   return (
     <Box mb={2}>
       <Tabs
         tabs={tabRoutes}
-        onTabChanged={(index) => {tabChangeHandler(index);}}
+        onTabChanged={index => {
+          tabChangeHandler(index);
+        }}
         defaultIndex={defaultIndex}
       />
       <Divider />
-    </Box>);
+    </Box>
+  );
 }

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -28,7 +28,7 @@ export default function AuthToken() {
   const clusters = useClustersConf();
 
   function onAuthClicked() {
-    loginWithToken(token).then((code) => {
+    loginWithToken(token).then(code => {
       // If successful, redirect.
       if (code === 200) {
         history.replace(
@@ -54,9 +54,7 @@ export default function AuthToken() {
       token={token}
       showError={showError}
       showActions={Object.keys(clusters || {}).length > 1}
-      onChangeToken={(event: React.ChangeEvent<HTMLInputElement>) =>
-        setToken(event.target.value)
-      }
+      onChangeToken={(event: React.ChangeEvent<HTMLInputElement>) => setToken(event.target.value)}
       onAuthClicked={onAuthClicked}
       onCloseError={() => {
         setShowError(false);
@@ -98,9 +96,7 @@ export function PureAuthToken({
       <ClusterDialog useCover disableEscapeKeyDown disableBackdropClick>
         <DialogTitle id="responsive-dialog-title">{title}</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            Please paste your authentication token.
-          </DialogContentText>
+          <DialogContentText>Please paste your authentication token.</DialogContentText>
           <TextField
             autoFocus
             margin="dense"
@@ -116,7 +112,7 @@ export function PureAuthToken({
           <Box ml={2}>
             Check out how to generate a
             <Link
-              style={{cursor: 'pointer', marginLeft: '0.4rem'}}
+              style={{ cursor: 'pointer', marginLeft: '0.4rem' }}
               target="_blank"
               href="https://kinvolk.io/docs/headlamp/latest/installation/#authentication--log-in"
             >
@@ -124,7 +120,7 @@ export function PureAuthToken({
             </Link>
             .
           </Box>
-          <div style={{flex: '1 0 0'}}></div>
+          <div style={{ flex: '1 0 0' }}></div>
         </DialogActions>
         <DialogActions>
           {showActions && (

--- a/frontend/src/components/account/AuthToken.stories.tsx
+++ b/frontend/src/components/account/AuthToken.stories.tsx
@@ -13,9 +13,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<PureAuthTokenProps> = (args) => (
-  <PureAuthToken {...args} />
-);
+const Template: Story<PureAuthTokenProps> = args => <PureAuthToken {...args} />;
 
 export const ShowError = Template.bind({});
 ShowError.args = {

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -15,7 +15,7 @@ import { Loader } from '../common';
 import Empty from '../common/EmptyContent';
 import OauthPopup from '../oidcauth/OauthPopup';
 
-const ColorButton = withStyles((theme) => ({
+const ColorButton = withStyles(theme => ({
   root: {
     color: theme.palette.primary.contrastText,
     backgroundColor: theme.palette.sidebarBg,
@@ -23,8 +23,8 @@ const ColorButton = withStyles((theme) => ({
     padding: '0.5rem 2rem',
     '&:hover': {
       opacity: '0.8',
-      backgroundColor: theme.palette.sidebarBg
-    }
+      backgroundColor: theme.palette.sidebarBg,
+    },
   },
 }))(Button);
 
@@ -32,7 +32,7 @@ interface ReactRouterLocationStateIface {
   from?: Location;
 }
 
-function AuthChooser(){
+function AuthChooser() {
   const history = useHistory();
   const location = useLocation();
   const clusters = useClustersConf();
@@ -40,7 +40,8 @@ function AuthChooser(){
   const isDevMode = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
   const [testingAuth, setTestingAuth] = React.useState(false);
   const [error, setError] = React.useState<Error | null>(null);
-  const {from = { pathname: createRouteURL('cluster') }} = (location.state || {}) as ReactRouterLocationStateIface;
+  const { from = { pathname: createRouteURL('cluster') } } = (location.state ||
+    {}) as ReactRouterLocationStateIface;
   const clusterName = getCluster() as string;
 
   let clusterAuthType = '';
@@ -50,168 +51,174 @@ function AuthChooser(){
 
   function handleTokenAuth() {
     history.push({
-      pathname: generatePath(getRoutePath(getRoute('token')), {cluster: clusterName as string}),
+      pathname: generatePath(getRoutePath(getRoute('token')), { cluster: clusterName as string }),
     });
   }
 
   function handleOidcAuth() {
     history.replace({
-      pathname: generatePath(getClusterPrefixedPath(), {cluster: clusterName as string}),
+      pathname: generatePath(getClusterPrefixedPath(), { cluster: clusterName as string }),
     });
   }
 
-  function handleBackButtonPress(){
+  function handleBackButtonPress() {
     history.goBack();
   }
 
   const numClusters = Object.keys(clusters || {}).length;
 
-  React.useEffect(() => {
-    const clusterName = getCluster();
-    if (!clusterName || !clusters || error || numClusters === 0) {
-      return;
-    }
+  React.useEffect(
+    () => {
+      const clusterName = getCluster();
+      if (!clusterName || !clusters || error || numClusters === 0) {
+        return;
+      }
 
-    const cluster = clusters[clusterName];
-    if (!cluster) {
-      return;
-    }
+      const cluster = clusters[clusterName];
+      if (!cluster) {
+        return;
+      }
 
-    let cancelled = false;
+      let cancelled = false;
 
-    // If we haven't yet figured whether we need to use a token for the current
-    //   cluster, then we check here.
-    // With clusterAuthType == oidc,
-    //   they are presented with a choice of login or enter token.
-    if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
-      let useToken = true;
+      // If we haven't yet figured whether we need to use a token for the current
+      //   cluster, then we check here.
+      // With clusterAuthType == oidc,
+      //   they are presented with a choice of login or enter token.
+      if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
+        let useToken = true;
 
-      setTestingAuth(true);
+        setTestingAuth(true);
 
-      let errorObj: Error | null = null;
-      setError(errorObj);
+        let errorObj: Error | null = null;
+        setError(errorObj);
 
-      testAuth()
-        .then(() => {
-          console.debug('Not requiring token as testing auth succeeded');
-          useToken = false;
-        })
-        .catch((err) => {
-          if (!cancelled) {
-            console.debug('Requiring token as testing auth failed:', err);
+        testAuth()
+          .then(() => {
+            console.debug('Not requiring token as testing auth succeeded');
+            useToken = false;
+          })
+          .catch(err => {
+            if (!cancelled) {
+              console.debug('Requiring token as testing auth failed:', err);
 
-            // Ideally we'd only not assign the error if it was 401 or 403 (so we let the logic
-            // proceed to request a token), but let's first check whether this is all we get
-            // from clusters that require a token.
-            if ([408, 504, 502].includes(err.status)) {
-              errorObj = err;
+              // Ideally we'd only not assign the error if it was 401 or 403 (so we let the logic
+              // proceed to request a token), but let's first check whether this is all we get
+              // from clusters that require a token.
+              if ([408, 504, 502].includes(err.status)) {
+                errorObj = err;
+              }
+
+              setTestingAuth(false);
             }
+          })
+          .finally(() => {
+            if (!cancelled) {
+              cancelled = true;
+              setTestingAuth(false);
 
-            setTestingAuth(false);
-          }
-        })
-        .finally(() => {
-          if (!cancelled) {
-            cancelled = true;
-            setTestingAuth(false);
+              if (!!errorObj) {
+                setError(errorObj);
+                return;
+              }
 
-            if (!!errorObj) {
-              setError(errorObj);
-              return;
+              cluster.useToken = useToken;
+              dispatch(setConfig({ clusters: { ...clusters } }));
+              // If we don't require a token, then we just move to the attempted URL or root.
+              if (!useToken) {
+                history.replace(from);
+              }
+
+              // If we reach this point, then we know whether or not we need a token. If we don't,
+              // just redirect.
+              if (cluster.useToken === false) {
+                history.replace(from);
+              } else if (!clusterAuthType) {
+                // we know that it requires token and also doesn't have oidc configured
+                // so let's redirect to token page
+                history.replace({
+                  pathname: generatePath(getClusterPrefixedPath('token'), {
+                    cluster: clusterName as string,
+                  }),
+                });
+              }
             }
+          });
+      } else if (cluster.useToken) {
+        history.replace({
+          pathname: generatePath(getClusterPrefixedPath('token'), {
+            cluster: clusterName as string,
+          }),
+        });
+      }
 
-            cluster.useToken = useToken;
-            dispatch(setConfig({clusters: {...clusters}}));
-            // If we don't require a token, then we just move to the attempted URL or root.
-            if (!useToken) {
-              history.replace(from);
-            }
-
-            // If we reach this point, then we know whether or not we need a token. If we don't,
-            // just redirect.
-            if (cluster.useToken === false) {
-              history.replace(from);
-            } else if (!clusterAuthType){
-              // we know that it requires token and also doesn't have oidc configured
-              // so let's redirect to token page
-              history.replace({
-                pathname: generatePath(getClusterPrefixedPath('token'), {cluster: clusterName as string}),
-              });
-            }
-          }
-        }
-        );
-    } else if (cluster.useToken) {
-      history.replace({
-        pathname: generatePath(getClusterPrefixedPath('token'), {cluster: clusterName as string}),
-      });
-    }
-
-    return function cleanup () {
-      cancelled = true;
-    };
-  },
-  // eslint-disable-next-line
-  [clusters, error]);
+      return function cleanup() {
+        cancelled = true;
+      };
+    },
+    // eslint-disable-next-line
+    [clusters, error]
+  );
 
   return (
-    <ClusterDialog
-      useCover
-      disableEscapeKeyDown
-      disableBackdropClick
-    >
-      {testingAuth ?
+    <ClusterDialog useCover disableEscapeKeyDown disableBackdropClick>
+      {testingAuth ? (
         <Box textAlign="center">
           <DialogTitle>
-            { numClusters > 1 ? `Getting auth info: ${clusterName}` : 'Getting auth info' }
+            {numClusters > 1 ? `Getting auth info: ${clusterName}` : 'Getting auth info'}
           </DialogTitle>
-          <Loader/>
+          <Loader />
         </Box>
-        :
+      ) : (
         <Box display="flex" flexDirection="column" alignItems="center">
           <DialogTitle>
-            { numClusters > 1 ? `Authentication: ${clusterName}` : 'Authentication' }
+            {numClusters > 1 ? `Authentication: ${clusterName}` : 'Authentication'}
           </DialogTitle>
-          { !error ?
+          {!error ? (
             <Box>
-              {
-                clusterAuthType === 'oidc' ?
-                  <Box m={2}>
-                    <OauthPopup onCode={handleOidcAuth}
-                      url={`${isDevMode || isElectron() ?
-                        'http://localhost:4466/' : '/'}oidc?dt=${Date()}&cluster=${getCluster()}`
-                      }
-                      title="Headlamp Cluster Authentication"
-                    >
-                      <ColorButton>Sign In</ColorButton>
-                    </OauthPopup>
-                  </Box>
-                  : null
-              }
+              {clusterAuthType === 'oidc' ? (
+                <Box m={2}>
+                  <OauthPopup
+                    onCode={handleOidcAuth}
+                    url={`${
+                      isDevMode || isElectron() ? 'http://localhost:4466/' : '/'
+                    }oidc?dt=${Date()}&cluster=${getCluster()}`}
+                    title="Headlamp Cluster Authentication"
+                  >
+                    <ColorButton>Sign In</ColorButton>
+                  </OauthPopup>
+                </Box>
+              ) : null}
               <Box m={2}>
                 <ColorButton onClick={handleTokenAuth}>Use A Token</ColorButton>
               </Box>
             </Box>
-            :
+          ) : (
             <Box alignItems="center" textAlign="center">
               <Box m={2}>
                 <Empty>Failed to get authentication information: {error!.message}</Empty>
               </Box>
               <ColorButton onClick={() => setError(null)}>Try Again</ColorButton>
             </Box>
-          }
+          )}
         </Box>
-      }
-      {!!clusters && Object.keys(clusters).length > 1 &&
+      )}
+      {!!clusters && Object.keys(clusters).length > 1 && (
         <Box display="flex" flexDirection="column" alignItems="center">
-          <Box m={2} display="flex" alignItems="center" style={{cursor: 'pointer'}} onClick={handleBackButtonPress}>
+          <Box
+            m={2}
+            display="flex"
+            alignItems="center"
+            style={{ cursor: 'pointer' }}
+            onClick={handleBackButtonPress}
+          >
             <Box pt={0.5}>
-              <InlineIcon icon={chevronLeft} height={20} width={20}/>
+              <InlineIcon icon={chevronLeft} height={20} width={20} />
             </Box>
             <Box fontSize={14}>BACK</Box>
           </Box>
         </Box>
-      }
+      )}
     </ClusterDialog>
   );
 }

--- a/frontend/src/components/cluster/Charts.tsx
+++ b/frontend/src/components/cluster/Charts.tsx
@@ -31,10 +31,9 @@ export function ResourceCircularChart(props: ResourceCircularChartProps) {
   const [used, available] = getResourceUsage();
 
   function filterMetrics(items: KubeObject[], metrics: any[]) {
-    if (!items || !metrics)
-      return [];
+    if (!items || !metrics) return [];
 
-    const names = items.map(({metadata}) => metadata.name);
+    const names = items.map(({ metadata }) => metadata.name);
     return metrics.filter(item => names.includes(item.metadata.name));
   }
 
@@ -42,12 +41,11 @@ export function ResourceCircularChart(props: ResourceCircularChartProps) {
     if (available === 0) {
       return '…';
     }
-    return `${(used / available * 100).toFixed(1)} %`;
+    return `${((used / available) * 100).toFixed(1)} %`;
   }
 
   function getResourceUsage() {
-    if (!items)
-      return [-1, -1];
+    if (!items) return [-1, -1];
 
     const nodeMetrics = filterMetrics(items, itemsMetrics);
     const usedValue = _.sumBy(nodeMetrics, resourceUsedGetter);
@@ -65,17 +63,17 @@ export function ResourceCircularChart(props: ResourceCircularChartProps) {
       {
         name: 'used',
         value: used,
-      }
+      },
     ];
   }
 
-  return (noMetrics ?
+  return noMetrics ? (
     <HeaderLabel
       label={title || ''}
       value={props.getLegend!(used, available)}
       tooltip={'Install the metrics-server to get usage data.'}
     />
-    :
+  ) : (
     <PercentageCircle
       {...others}
       title={title}
@@ -161,7 +159,9 @@ export function PodsStatusCircleChart(props: Pick<ResourceCircularChartProps, 'i
   const theme = useTheme();
   const { items } = props;
 
-  const podsReady = (items || []).filter(pod => ['Running', 'Succeeded'].includes(pod.status!.phase));
+  const podsReady = (items || []).filter(pod =>
+    ['Running', 'Succeeded'].includes(pod.status!.phase)
+  );
 
   function getLegend() {
     if (items === null) {
@@ -174,7 +174,7 @@ export function PodsStatusCircleChart(props: Pick<ResourceCircularChartProps, 'i
     if (items === null) {
       return '…';
     }
-    const percentage = (podsReady.length / items.length * 100).toFixed(1);
+    const percentage = ((podsReady.length / items.length) * 100).toFixed(1);
     return `${percentage} %`;
   }
 
@@ -186,13 +186,13 @@ export function PodsStatusCircleChart(props: Pick<ResourceCircularChartProps, 'i
     return [
       {
         name: 'ready',
-        value: podsReady.length
+        value: podsReady.length,
       },
       {
         name: 'notReady',
         value: items.length - podsReady.length,
-        fill: theme.palette.error.main
-      }
+        fill: theme.palette.error.main,
+      },
     ];
   }
 

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -29,8 +29,8 @@ const useClusterTitleStyle = makeStyles(theme => ({
     color: theme.palette.primary.contrastText,
     '&:hover': {
       color: theme.palette.text.primary,
-    }
-  }
+    },
+  },
 }));
 
 export function ClusterTitle() {
@@ -59,10 +59,7 @@ export function ClusterTitle() {
       >
         Cluster: {cluster}
       </Button>
-      <Chooser
-        open={showChooser}
-        onClose={() => setShowChooser(false)}
-      />
+      <Chooser open={showChooser} onClose={() => setShowChooser(false)} />
     </React.Fragment>
   );
 }
@@ -76,7 +73,7 @@ const useStyles = makeStyles(theme => ({
       color: theme.palette.primaryColor,
       paddingTop: theme.spacing(3),
       paddingBottom: theme.spacing(3),
-    }
+    },
   },
   chooserDialogCover: {
     background: theme.palette.common.black,
@@ -99,28 +96,25 @@ const useClusterButtonStyles = makeStyles({
   root: {
     width: 150,
     height: 160,
-    paddingTop: '15%'
+    paddingTop: '15%',
   },
   content: {
-    textAlign: 'center'
+    textAlign: 'center',
   },
 });
 
 interface ClusterButtonProps {
   cluster: Cluster;
-  onClick?: ((...args: any[]) => void);
+  onClick?: (...args: any[]) => void;
 }
 
 function ClusterButton(props: ClusterButtonProps) {
   const classes = useClusterButtonStyles();
   const theme = useTheme();
-  const {cluster, onClick = undefined} = props;
+  const { cluster, onClick = undefined } = props;
 
   return (
-    <ButtonBase
-      focusRipple
-      onClick={onClick}
-    >
+    <ButtonBase focusRipple onClick={onClick}>
       <Card className={classes.root}>
         <CardContent className={classes.content}>
           <Icon icon={kubernetesIcon} width="50" height="50" color={theme.palette.primaryColor} />
@@ -139,23 +133,15 @@ interface ClusterListProps {
 }
 
 function ClusterList(props: ClusterListProps) {
-  const {clusters, onButtonClick} = props;
+  const { clusters, onButtonClick } = props;
 
   return (
-    <Grid
-      container
-      alignItems="center"
-      justify="space-around"
-      spacing={2}
-    >
-      {clusters.map((cluster, i) =>
+    <Grid container alignItems="center" justify="space-around" spacing={2}>
+      {clusters.map((cluster, i) => (
         <Grid item key={cluster.name}>
-          <ClusterButton
-            cluster={cluster}
-            onClick={() => onButtonClick(cluster)}
-          />
+          <ClusterButton cluster={cluster} onClick={() => onButtonClick(cluster)} />
         </Grid>
-      )}
+      ))}
     </Grid>
   );
 }
@@ -170,7 +156,7 @@ export function ClusterDialog(props: ClusterDialogProps) {
   const classes = useStyles();
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
-  const {open, onClose = null, useCover = false, children = [], ...otherProps} = props;
+  const { open, onClose = null, useCover = false, children = [], ...otherProps } = props;
   // Only used if open is not provided
   const [show, setShow] = React.useState(true);
 
@@ -195,22 +181,10 @@ export function ClusterDialog(props: ClusterDialogProps) {
       className={useCover ? classes.chooserDialogCover : ''}
       {...otherProps}
     >
-      <DialogTitle
-        id="responsive-dialog-title"
-        className={classes.chooserTitle}
-        disableTypography
-      >
-        <SvgIcon
-          className={classes.logo}
-          component={LogoLight}
-          viewBox="0 0 175 32"
-        />
+      <DialogTitle id="responsive-dialog-title" className={classes.chooserTitle} disableTypography>
+        <SvgIcon className={classes.logo} component={LogoLight} viewBox="0 0 175 32" />
       </DialogTitle>
-      <DialogContent
-        className={classes.chooserDialog}
-      >
-        {children}
-      </DialogContent>
+      <DialogContent className={classes.chooserDialog}>{children}</DialogContent>
     </Dialog>
   );
 }
@@ -218,28 +192,30 @@ export function ClusterDialog(props: ClusterDialogProps) {
 function Chooser(props: ClusterDialogProps) {
   const history = useHistory();
   const clusters = useClustersConf();
-  const {open = null, onClose, ...otherProps} = props;
+  const { open = null, onClose, ...otherProps } = props;
   // Only used if open is not provided
   const [show, setShow] = React.useState(props.open);
 
-  React.useEffect(() => {
-    if (open !== null && open !== show) {
-      setShow(open);
-      return;
-    }
+  React.useEffect(
+    () => {
+      if (open !== null && open !== show) {
+        setShow(open);
+        return;
+      }
 
-    // If we only have one cluster configured, then we skip offering
-    // the choice to the user.
-    if (!!clusters && Object.keys(clusters).length === 1) {
-      handleButtonClick(Object.values(clusters)[0]);
-    }
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [open, show, clusters]);
+      // If we only have one cluster configured, then we skip offering
+      // the choice to the user.
+      if (!!clusters && Object.keys(clusters).length === 1) {
+        handleButtonClick(Object.values(clusters)[0]);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [open, show, clusters]
+  );
 
   function handleButtonClick(cluster: Cluster) {
     if (cluster.name !== getCluster()) {
-      history.push({pathname: generatePath(getClusterPrefixedPath(), {cluster: cluster.name})});
+      history.push({ pathname: generatePath(getClusterPrefixedPath(), { cluster: cluster.name }) });
     }
 
     setShow(false);
@@ -262,44 +238,29 @@ function Chooser(props: ClusterDialogProps) {
   const clusterList = Object.values(clusters || {});
 
   return (
-    <ClusterDialog
-      open={show}
-      onClose={onClose || handleClose}
-      {...otherProps}
-    >
-      {clusterList.length === 0 ?
+    <ClusterDialog open={show} onClose={onClose || handleClose} {...otherProps}>
+      {clusterList.length === 0 ? (
         <React.Fragment>
-          {clusters === null ?
+          {clusters === null ? (
             <>
-              <DialogContentText>
-                Wait while fetching clusters…
-              </DialogContentText>
+              <DialogContentText>Wait while fetching clusters…</DialogContentText>
               <Loader />
             </>
-            :
+          ) : (
             <>
-              <DialogContentText>
-                There seems to be no clusters configured…
-              </DialogContentText>
+              <DialogContentText>There seems to be no clusters configured…</DialogContentText>
               <DialogContentText>
                 Please make sure you have at least one cluster configured.
               </DialogContentText>
             </>
-          }
+          )}
         </React.Fragment>
-        :
+      ) : (
         <React.Fragment>
-          <DialogContentText
-            variant="h4"
-          >
-            Choose a cluster
-          </DialogContentText>
-          <ClusterList
-            clusters={clusterList}
-            onButtonClick={handleButtonClick}
-          />
+          <DialogContentText variant="h4">Choose a cluster</DialogContentText>
+          <ClusterList clusters={clusterList} onButtonClick={handleButtonClick} />
         </React.Fragment>
-      }
+      )}
     </ClusterDialog>
   );
 }

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -30,35 +30,21 @@ export default function Overview() {
   return (
     <PageGrid>
       <SectionBox py={2}>
-        { noPermissions ?
+        {noPermissions ? (
           <Empty color="error">No permissions to list pods.</Empty>
-          :
-          <Grid
-            container
-            justify="space-around"
-            alignItems="flex-start"
-          >
+        ) : (
+          <Grid container justify="space-around" alignItems="flex-start">
             <Grid item>
-              <CpuCircularChart
-                items={nodes}
-                itemsMetrics={nodeMetrics}
-                noMetrics={noMetrics}
-              />
+              <CpuCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
             </Grid>
             <Grid item>
-              <MemoryCircularChart
-                items={nodes}
-                itemsMetrics={nodeMetrics}
-                noMetrics={noMetrics}
-              />
+              <MemoryCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
             </Grid>
             <Grid item>
-              <PodsStatusCircleChart
-                items={pods}
-              />
+              <PodsStatusCircleChart items={pods} />
             </Grid>
           </Grid>
-        }
+        )}
       </SectionBox>
       <EventsSection />
     </PageGrid>
@@ -70,7 +56,7 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('md')]: {
       minWidth: '180px',
     },
-  }
+  },
 }));
 
 function EventsSection() {
@@ -80,9 +66,7 @@ function EventsSection() {
 
   function makeStatusLabel(event: Event) {
     return (
-      <StatusLabel status={event.type === 'Normal' ? '' : 'warning'}
-        className={classes.eventLabel}
-      >
+      <StatusLabel status={event.type === 'Normal' ? '' : 'warning'} className={classes.eventLabel}>
         {event.reason}
       </StatusLabel>
     );
@@ -102,37 +86,37 @@ function EventsSection() {
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
         errorMessage={Event.getErrorMessage(error)}
-        columns={events ? [
-          {
-            label: 'Type',
-            getter: event => event.involvedObject.kind,
-            sort: true
-          },
-          {
-            label: 'Name',
-            getter: event => event.involvedObject.name,
-            sort: true
-          },
-          // @todo: Maybe the message should be shown on slide-down.
-          {
-            label: 'Reason',
-            getter: event =>
-              <LightTooltip
-                title={event.message}
-                interactive
-              >
-                <Box>{makeStatusLabel(event)}</Box>
-              </LightTooltip>
-          },
-          {
-            label: 'Age',
-            getter: event => timeAgo(event.metadata.creationTimestamp),
-            sort: (e1: Event, e2: Event) => new Date(e2.metadata.creationTimestamp).getTime() -
-              new Date(e1.metadata.creationTimestamp).getTime()
-          },
-        ]
-          :
-          []
+        columns={
+          events
+            ? [
+                {
+                  label: 'Type',
+                  getter: event => event.involvedObject.kind,
+                  sort: true,
+                },
+                {
+                  label: 'Name',
+                  getter: event => event.involvedObject.name,
+                  sort: true,
+                },
+                // @todo: Maybe the message should be shown on slide-down.
+                {
+                  label: 'Reason',
+                  getter: event => (
+                    <LightTooltip title={event.message} interactive>
+                      <Box>{makeStatusLabel(event)}</Box>
+                    </LightTooltip>
+                  ),
+                },
+                {
+                  label: 'Age',
+                  getter: event => timeAgo(event.metadata.creationTimestamp),
+                  sort: (e1: Event, e2: Event) =>
+                    new Date(e2.metadata.creationTimestamp).getTime() -
+                    new Date(e1.metadata.creationTimestamp).getTime(),
+                },
+              ]
+            : []
         }
         data={events}
         defaultSortingColumn={3}

--- a/frontend/src/components/common/ActionsNotifier.tsx
+++ b/frontend/src/components/common/ActionsNotifier.tsx
@@ -25,18 +25,18 @@ export default function ActionsNotifier() {
 
     const action = () => (
       <React.Fragment>
-        {(clusterAction.buttons || []).map(({label, actionToDispatch}, i) =>
+        {(clusterAction.buttons || []).map(({ label, actionToDispatch }, i) => (
           <Button
             key={i}
             color="secondary"
             size="small"
             onClick={() => {
-              dispatch({type: actionToDispatch});
+              dispatch({ type: actionToDispatch });
             }}
           >
             {label}
           </Button>
-        )}
+        ))}
       </React.Fragment>
     );
 
@@ -47,23 +47,25 @@ export default function ActionsNotifier() {
       closeSnackbar(clusterAction.dismissSnackbar);
     }
 
-    const {key, message, snackbarProps} = clusterAction;
+    const { key, message, snackbarProps } = clusterAction;
     enqueueSnackbar(message, {
       key,
       preventDuplicate: true,
       autoHideDuration: CLUSTER_ACTION_GRACE_PERIOD,
       action,
-      ...snackbarProps
+      ...snackbarProps,
     });
   }
 
-  React.useEffect(() => {
-    for (const clusterAction of Object.values(clusterActions)) {
-      handleAction(clusterAction);
-    }
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [clusterActions]);
+  React.useEffect(
+    () => {
+      for (const clusterAction of Object.values(clusterActions)) {
+        handleAction(clusterAction);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [clusterActions]
+  );
 
   return null;
 }

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -9,7 +9,7 @@ const NOT_FOUND_ERROR_MESSAGES = ['Error: Api request error: Bad Gateway', 'Offl
 // in ms
 const NETWORK_STATUS_CHECK_TIME = 5000;
 
-export default function AlertNotification(){
+export default function AlertNotification() {
   const routes = useTypedSelector(state => state.ui.routes);
   const [networkStatusCheckTimeFactor, setNetworkStatusCheckTimeFactor] = React.useState(0);
   const [error, setError] = React.useState<null | string | boolean>(null);
@@ -22,48 +22,53 @@ export default function AlertNotification(){
         return;
       }
       setError(null);
-      testAuth().then(() => {
-        setError(false);
-      })
-        .catch((err) => {
+      testAuth()
+        .then(() => {
+          setError(false);
+        })
+        .catch(err => {
           const error = new Error(err);
           setError(error.message);
-          setNetworkStatusCheckTimeFactor(networkStatusCheckTimeFactor =>
-            networkStatusCheckTimeFactor + 1);
+          setNetworkStatusCheckTimeFactor(
+            networkStatusCheckTimeFactor => networkStatusCheckTimeFactor + 1
+          );
         });
     }, (networkStatusCheckTimeFactor + 1) * NETWORK_STATUS_CHECK_TIME);
   }
 
-  React.useEffect(() => {
-    const id = registerSetInterval();
-    setIntervalID(id);
-    return () => clearInterval(id);
-  },
-  // eslint-disable-next-line
-  []);
+  React.useEffect(
+    () => {
+      const id = registerSetInterval();
+      setIntervalID(id);
+      return () => clearInterval(id);
+    },
+    // eslint-disable-next-line
+    []
+  );
 
-  React.useEffect(() => {
-    if (intervalID) {
-      clearInterval(intervalID);
-    }
-    const id = registerSetInterval();
-    setIntervalID(id);
-    return () => clearInterval(id);
-  },
-  // eslint-disable-next-line
-  [networkStatusCheckTimeFactor]);
+  React.useEffect(
+    () => {
+      if (intervalID) {
+        clearInterval(intervalID);
+      }
+      const id = registerSetInterval();
+      setIntervalID(id);
+      return () => clearInterval(id);
+    },
+    // eslint-disable-next-line
+    [networkStatusCheckTimeFactor]
+  );
 
-  function checkWhetherInNoAuthRequireRoute():boolean {
-    const noAuthRequiringRoutes =
-            Object.values(ROUTES)
-              .concat(Object.values(routes))
-              .filter((route) => route.noAuthRequired);
+  function checkWhetherInNoAuthRequireRoute(): boolean {
+    const noAuthRequiringRoutes = Object.values(ROUTES)
+      .concat(Object.values(routes))
+      .filter(route => route.noAuthRequired);
 
     for (const route of noAuthRequiringRoutes) {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const routeMatch = useRouteMatch({
         path: getRoutePath(route),
-        strict: true
+        strict: true,
       });
       if (routeMatch && routeMatch.isExact) {
         return true;
@@ -82,7 +87,7 @@ export default function AlertNotification(){
     return null;
   }
 
-  if (NOT_FOUND_ERROR_MESSAGES.filter((err) => err === error).length === 0) {
+  if (NOT_FOUND_ERROR_MESSAGES.filter(err => err === error).length === 0) {
     return null;
   }
   return (
@@ -99,16 +104,14 @@ export default function AlertNotification(){
       top={'0'}
       height={'3.8vh'}
     >
-      <Box marginLeft={isErrorInNoAuthRequiredRoute ? '0%' : '-15%'}>
-        Something Went Wrong.
-      </Box>
+      <Box marginLeft={isErrorInNoAuthRequiredRoute ? '0%' : '-15%'}>Something Went Wrong.</Box>
       <Box
         bgcolor={theme.palette.common.white}
         color="error.main"
         ml={1}
         px={1}
         py={0.1}
-        style={{cursor: 'pointer'}}
+        style={{ cursor: 'pointer' }}
         onClick={() => setNetworkStatusCheckTimeFactor(0)}
       >
         Try Again

--- a/frontend/src/components/common/Autocomplete.tsx
+++ b/frontend/src/components/common/Autocomplete.tsx
@@ -31,9 +31,7 @@ export function NamespacesAutocomplete() {
       jointTags = jointTags.slice(0, 15) + '…';
     }
 
-    return (
-      <Typography>{jointTags}</Typography>
-    );
+    return <Typography>{jointTags}</Typography>;
   }
 
   return (
@@ -56,7 +54,8 @@ export function NamespacesAutocomplete() {
             icon={<Icon icon={checkboxBlankOutline} />}
             checkedIcon={<Icon icon={checkBoxOutline} />}
             style={{
-              color: selected ? theme.palette.primary.main : theme.palette.text.primary }}
+              color: selected ? theme.palette.primary.main : theme.palette.text.primary,
+            }}
             checked={selected}
           />
           {option}
@@ -70,8 +69,8 @@ export function NamespacesAutocomplete() {
             variant="standard"
             label="Namespaces"
             fullWidth
-            InputLabelProps={{shrink: true}}
-            style={{marginTop: 0}}
+            InputLabelProps={{ shrink: true }}
+            style={{ marginTop: 0 }}
             placeholder={[...filter.namespaces.values()].length > 0 ? '' : 'Filter'}
           />
         </Box>

--- a/frontend/src/components/common/Chart.stories/PercentageCircle.stories.tsx
+++ b/frontend/src/components/common/Chart.stories/PercentageCircle.stories.tsx
@@ -8,9 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<PercentageCircleProps> = (args) => (
-  <PercentageCircle {...args} />
-);
+const Template: Story<PercentageCircleProps> = args => <PercentageCircle {...args} />;
 
 export const Percent100 = Template.bind({});
 Percent100.args = {

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -3,7 +3,17 @@ import Paper from '@material-ui/core/Paper';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
-import { Bar, BarChart, Label, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import {
+  Bar,
+  BarChart,
+  Label,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import Loader from './Loader';
 
 const useStyle = makeStyles(theme => ({
@@ -21,7 +31,7 @@ const useStyle = makeStyles(theme => ({
   chart: {
     marginLeft: 'auto',
     marginRight: 'auto',
-  }
+  },
 }));
 
 export interface ChartDataPoint {
@@ -55,10 +65,10 @@ export function PercentageCircle(props: PercentageCircleProps) {
     title = '',
     legend = null,
     total = 100,
-    totalProps = {}
+    totalProps = {},
   } = props;
 
-  const chartSize = size * .8;
+  const chartSize = size * 0.8;
   const isLoading = total < 0;
 
   function formatData() {
@@ -67,43 +77,36 @@ export function PercentageCircle(props: PercentageCircleProps) {
       filledValue += item.value;
 
       return {
-        percentage: item.value / total * 100,
-        ...item
+        percentage: (item.value / total) * 100,
+        ...item,
       };
     });
 
-    const totalValue = total === 0 ?
-      {
-        name: 'total',
-        percentage: 100,
-        value: total,
-        fill: theme.palette.chartStyles.defaultFillColor,
-      }
-      :
-      {
-        name: 'total',
-        percentage: (total - filledValue) / total * 100,
-        value: total,
-        fill: theme.palette.chartStyles.defaultFillColor,
-        ...totalProps
-      };
+    const totalValue =
+      total === 0
+        ? {
+            name: 'total',
+            percentage: 100,
+            value: total,
+            fill: theme.palette.chartStyles.defaultFillColor,
+          }
+        : {
+            name: 'total',
+            percentage: ((total - filledValue) / total) * 100,
+            value: total,
+            fill: theme.palette.chartStyles.defaultFillColor,
+            ...totalProps,
+          };
 
     return formattedData.concat(totalValue);
   }
 
   return (
-    <Box
-      justifyContent="center"
-      alignItems="center"
-      alignContent="center"
-      mx="auto"
-    >
-      {title &&
-        <Typography className={classes.title}>{title}</Typography>
-      }
-      {isLoading ?
+    <Box justifyContent="center" alignItems="center" alignContent="center" mx="auto">
+      {title && <Typography className={classes.title}>{title}</Typography>}
+      {isLoading ? (
         <Loader />
-        :
+      ) : (
         <PieChart
           cx={size / 2}
           cy={size / 2}
@@ -116,8 +119,8 @@ export function PercentageCircle(props: PercentageCircleProps) {
             // Center the chart
             cx={chartSize / 2}
             cy={chartSize / 2}
-            innerRadius={chartSize * .35}
-            outerRadius={chartSize * .4}
+            innerRadius={chartSize * 0.35}
+            outerRadius={chartSize * 0.4}
             dataKey={dataKey}
             // Start at the top
             startAngle={90}
@@ -129,16 +132,16 @@ export function PercentageCircle(props: PercentageCircleProps) {
               value={label || ''}
               position="center"
               style={{
-                fontSize: `${chartSize * .15}px`,
-                fill: theme.palette.chartStyles.labelColor
+                fontSize: `${chartSize * 0.15}px`,
+                fill: theme.palette.chartStyles.labelColor,
               }}
             />
           </Pie>
         </PieChart>
-      }
-      {!isLoading && legend !== null &&
+      )}
+      {!isLoading && legend !== null && (
         <Typography className={classes.legend}>{legend}</Typography>
-      }
+      )}
     </Box>
   );
 }
@@ -163,17 +166,13 @@ export function PercentageBar(props: PercentageBarProps) {
   const classes = useBarStyle();
   const theme = useTheme();
 
-  const {
-    data,
-    total = 100,
-    tooltipFunc = null,
-  } = props;
+  const { data, total = 100, tooltipFunc = null } = props;
 
   function formatData() {
-    const dataItems: {[name: string]: number} = {};
+    const dataItems: { [name: string]: number } = {};
 
     data.forEach(item => {
-      dataItems[item.name] = item.value / total * 100;
+      dataItems[item.name] = (item.value / total) * 100;
     });
 
     return dataItems;
@@ -181,20 +180,8 @@ export function PercentageBar(props: PercentageBarProps) {
 
   return (
     <ResponsiveContainer width="95%" height={20} className={classes.container}>
-      <BarChart
-        layout="vertical"
-        maxBarSize={5}
-        data={[formatData()]}
-        className={classes.chart}
-      >
-        {tooltipFunc &&
-          <Tooltip content={
-            <PaperTooltip >
-              {tooltipFunc(data)}
-            </PaperTooltip>
-          }
-          />
-        }
+      <BarChart layout="vertical" maxBarSize={5} data={[formatData()]} className={classes.chart}>
+        {tooltipFunc && <Tooltip content={<PaperTooltip>{tooltipFunc(data)}</PaperTooltip>} />}
         <XAxis hide domain={[0, 100]} type="number" />
         <YAxis hide type="category" />
         {data.map((item, index) => {
@@ -205,7 +192,7 @@ export function PercentageBar(props: PercentageBarProps) {
               stackId="1"
               fill={item.fill || theme.palette.primary.main}
               layout="vertical"
-              background={{fill: theme.palette.grey['300']}}
+              background={{ fill: theme.palette.grey['300'] }}
             />
           );
         })}
@@ -217,9 +204,7 @@ export function PercentageBar(props: PercentageBarProps) {
 function PaperTooltip(props: React.PropsWithChildren<{}>) {
   return (
     <Paper className="custom-tooltip">
-      <Box m={1}>
-        {props.children}
-      </Box>
+      <Box m={1}>{props.children}</Box>
     </Paper>
   );
 }

--- a/frontend/src/components/common/CreateButton.tsx
+++ b/frontend/src/components/common/CreateButton.tsx
@@ -40,24 +40,21 @@ export default function CreateButton() {
     }
 
     setOpenDialog(false);
-    dispatch(clusterAction(() => applyFunc(newItemDef),
-      {
+    dispatch(
+      clusterAction(() => applyFunc(newItemDef), {
         startMessage: `Applying ${newItemDef.metadata.name}…`,
         cancelledMessage: `Cancelled applying ${newItemDef.metadata.name}.`,
         successMessage: `Applied ${newItemDef.metadata.name}.`,
         errorMessage: `Failed to apply ${newItemDef.metadata.name}.`,
         cancelUrl,
-      }
-    ));
+      })
+    );
   }
 
   return (
     <React.Fragment>
       <Tooltip title="Create / Apply">
-        <IconButton
-          aria-label="apply"
-          onClick={() => setOpenDialog(true)}
-        >
+        <IconButton aria-label="apply" onClick={() => setOpenDialog(true)}>
           <Icon color="#adadad" icon={plusCircle} width="48" />
         </IconButton>
       </Tooltip>

--- a/frontend/src/components/common/DeleteButton.tsx
+++ b/frontend/src/components/common/DeleteButton.tsx
@@ -21,41 +21,41 @@ export default function DeleteButton(props: DeleteButtonProps) {
   const [visible, setVisible] = React.useState(false);
   const location = useLocation();
 
-  const deleteFunc = React.useCallback(() => {
-    if (!item) {
-      return;
-    }
-
-    const callback = item!.delete;
-
-    callback && dispatch(clusterAction(callback.bind(item),
-      {
-        startMessage: `Deleting item ${item!.metadata.name}…`,
-        cancelledMessage: `Cancelled deletion of ${item!.metadata.name}.`,
-        successMessage: `Deleted item ${item!.metadata.name}.`,
-        errorMessage: `Error deleting item ${item!.metadata.name}.`,
-        cancelUrl: location.pathname,
-        startUrl: item!.getListLink(),
-        errorUrl: item!.getListLink(),
-        ...options
+  const deleteFunc = React.useCallback(
+    () => {
+      if (!item) {
+        return;
       }
-    ));
-  },
-  // eslint-disable-next-line
-  [item]);
+
+      const callback = item!.delete;
+
+      callback &&
+        dispatch(
+          clusterAction(callback.bind(item), {
+            startMessage: `Deleting item ${item!.metadata.name}…`,
+            cancelledMessage: `Cancelled deletion of ${item!.metadata.name}.`,
+            successMessage: `Deleted item ${item!.metadata.name}.`,
+            errorMessage: `Error deleting item ${item!.metadata.name}.`,
+            cancelUrl: location.pathname,
+            startUrl: item!.getListLink(),
+            errorUrl: item!.getListLink(),
+            ...options,
+          })
+        );
+    },
+    // eslint-disable-next-line
+    [item]
+  );
 
   React.useEffect(() => {
     if (item) {
-      item.getAuthorization('delete').then(
-        (result: any) => {
-          if (result.status.allowed) {
-            setVisible(true);
-          }
+      item.getAuthorization('delete').then((result: any) => {
+        if (result.status.allowed) {
+          setVisible(true);
         }
-      );
+      });
     }
-  },
-  [item]);
+  }, [item]);
 
   if (!visible) {
     return null;
@@ -64,10 +64,7 @@ export default function DeleteButton(props: DeleteButtonProps) {
   return (
     <React.Fragment>
       <Tooltip title="Delete">
-        <IconButton
-          aria-label="delete"
-          onClick={() => setOpenAlert(true)}
-        >
+        <IconButton aria-label="delete" onClick={() => setOpenAlert(true)}>
           <Icon icon={deleteIcon} />
         </IconButton>
       </Tooltip>
@@ -76,7 +73,7 @@ export default function DeleteButton(props: DeleteButtonProps) {
         title="Delete item"
         description="Are you sure you want to delete this item?"
         handleClose={() => setOpenAlert(false)}
-        onConfirm={() => deleteFunc() }
+        onConfirm={() => deleteFunc()}
       />
     </React.Fragment>
   );

--- a/frontend/src/components/common/Dialog.stories.tsx
+++ b/frontend/src/components/common/Dialog.stories.tsx
@@ -1,9 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
-import {
-  ConfirmDialog as ConfirmDialogComponent,
-  ConfirmDialogProps,
-} from './Dialog';
+import { ConfirmDialog as ConfirmDialogComponent, ConfirmDialogProps } from './Dialog';
 
 // NOTE: Dialog.tsx should maybe be renamed ConfirmDialog.tsx
 
@@ -16,9 +13,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<ConfirmDialogProps> = (args) => (
-  <ConfirmDialogComponent {...args} />
-);
+const Template: Story<ConfirmDialogProps> = args => <ConfirmDialogComponent {...args} />;
 
 export const ConfirmDialog = Template.bind({});
 ConfirmDialog.args = {

--- a/frontend/src/components/common/EditButton.tsx
+++ b/frontend/src/components/common/EditButton.tsx
@@ -49,31 +49,28 @@ export default function EditButton(props: EditButtonProps) {
     const cancelUrl = location.pathname;
 
     setOpenDialog(false);
-    dispatch(clusterAction(() => applyFunc(newItemDef),
-      {
+    dispatch(
+      clusterAction(() => applyFunc(newItemDef), {
         startMessage: `Applying changes to ${item.metadata.name}…`,
         cancelledMessage: `Cancelled changes to ${item.metadata.name}.`,
         successMessage: `Applied changes to ${item.metadata.name}.`,
         errorMessage: `Failed to apply changes to ${item.metadata.name}.`,
         cancelUrl,
         errorUrl: cancelUrl,
-        ...options
-      }
-    ));
+        ...options,
+      })
+    );
   }
 
   React.useEffect(() => {
     if (item) {
-      item.getAuthorization('update').then(
-        (result: any) => {
-          if (result.status.allowed) {
-            setVisible(true);
-          }
+      item.getAuthorization('update').then((result: any) => {
+        if (result.status.allowed) {
+          setVisible(true);
         }
-      );
+      });
     }
-  },
-  [item]);
+  }, [item]);
 
   if (!visible) {
     return null;
@@ -82,10 +79,7 @@ export default function EditButton(props: EditButtonProps) {
   return (
     <React.Fragment>
       <Tooltip title="Edit">
-        <IconButton
-          aria-label="edit"
-          onClick={() => setOpenDialog(true)}
-        >
+        <IconButton aria-label="edit" onClick={() => setOpenDialog(true)}>
           <Icon icon={pencilIcon} />
         </IconButton>
       </Tooltip>

--- a/frontend/src/components/common/EditorDialog.tsx
+++ b/frontend/src/components/common/EditorDialog.tsx
@@ -50,7 +50,7 @@ const useStyle = makeStyles(theme => ({
 
 type KubeObjectIsh = Partial<KubeObjectInterface>;
 
-interface EditorDialogProps extends DialogProps{
+interface EditorDialogProps extends DialogProps {
   item: KubeObjectIsh | null;
   onClose: () => void;
   onSave: ((...args: any[]) => void) | null;
@@ -103,15 +103,13 @@ export default function EditorDialog(props: EditorDialogProps) {
         setPreviousVersion(item!.metadata!.resourceVersion);
       }
     }
-  },
-  [item, previousVersion, originalCode, code]);
+  }, [item, previousVersion, originalCode, code]);
 
   function isReadOnly() {
     return onSave === null;
   }
 
-  function onChange(value: string | undefined,
-                    ev: Monaco.editor.IModelContentChangedEvent): void {
+  function onChange(value: string | undefined, ev: Monaco.editor.IModelContentChangedEvent): void {
     setCode(value as string);
 
     if (error && getObjectFromCode(value as string)) {
@@ -142,12 +140,12 @@ export default function EditorDialog(props: EditorDialogProps) {
 
     const codeObj = getObjectFromCode(code);
 
-    const {kind, apiVersion} = (codeObj || {}) as KubeObjectInterface;
+    const { kind, apiVersion } = (codeObj || {}) as KubeObjectInterface;
     if (codeObj === null || (!!kind && !!apiVersion)) {
       setDocSpecs({
         error: codeObj === null,
         kind,
-        apiVersion
+        apiVersion,
       });
     }
   }
@@ -184,31 +182,22 @@ export default function EditorDialog(props: EditorDialogProps) {
   const errorLabel = error || errorMessage;
   let dialogTitle = title;
   if (!dialogTitle && item) {
-    dialogTitle = isReadOnly() ? `View: ${item.metadata?.name || 'New Object'}`
+    dialogTitle = isReadOnly()
+      ? `View: ${item.metadata?.name || 'New Object'}`
       : `Edit: ${item.metadata?.name || 'New Object'}`;
   }
 
   return (
-    <Dialog
-      maxWidth="lg"
-      scroll="paper"
-      fullWidth
-      onBackdropClick={onClose}
-      {...other}
-    >
-      {!item ?
+    <Dialog maxWidth="lg" scroll="paper" fullWidth onBackdropClick={onClose} {...other}>
+      {!item ? (
         <Loader />
-        :
+      ) : (
         <React.Fragment>
-          <DialogTitle>
-            {dialogTitle}
-          </DialogTitle>
-          <DialogContent
-            className={classes.dialogContent}
-          >
-            {isReadOnly() ?
+          <DialogTitle>{dialogTitle}</DialogTitle>
+          <DialogContent className={classes.dialogContent}>
+            {isReadOnly() ? (
               makeEditor()
-              :
+            ) : (
               <Tabs
                 onTabChanged={handleTabChange}
                 tabProps={{
@@ -217,69 +206,57 @@ export default function EditorDialog(props: EditorDialogProps) {
                 tabs={[
                   {
                     label: 'Editor',
-                    component: makeEditor()
+                    component: makeEditor(),
                   },
                   {
                     label: 'Documentation',
-                    component:
-                <Box p={2} className={classes.scrollable} height="600px">
-                  <DocsViewer
-                    docSpecs={docSpecs}
-                  />
-                </Box>
+                    component: (
+                      <Box p={2} className={classes.scrollable} height="600px">
+                        <DocsViewer docSpecs={docSpecs} />
+                      </Box>
+                    ),
                   },
                 ]}
               />
-            }
+            )}
           </DialogContent>
           <DialogActions>
-            {!isReadOnly() &&
-            <ConfirmButton
-              disabled={originalCode === code}
-              color="secondary"
-              aria-label="undo"
-              onConfirm={onUndo}
-              confirmTitle="Are you sure?"
-              confirmDescription="This will discard your changes in the editor. Do you want to proceed?"
-            >
-              Undo Changes
-            </ConfirmButton>
-            }
-            <div style={{flex: '1 0 0'}} />
-            { errorLabel &&
-            <Typography color="error">{errorLabel}</Typography>
-            }
-            <div style={{flex: '1 0 0'}} />
-            <Button
-              onClick={onClose}
-              color="primary"
-              autoFocus
-            >
+            {!isReadOnly() && (
+              <ConfirmButton
+                disabled={originalCode === code}
+                color="secondary"
+                aria-label="undo"
+                onConfirm={onUndo}
+                confirmTitle="Are you sure?"
+                confirmDescription="This will discard your changes in the editor. Do you want to proceed?"
+              >
+                Undo Changes
+              </ConfirmButton>
+            )}
+            <div style={{ flex: '1 0 0' }} />
+            {errorLabel && <Typography color="error">{errorLabel}</Typography>}
+            <div style={{ flex: '1 0 0' }} />
+            <Button onClick={onClose} color="primary" autoFocus>
               Close
             </Button>
-            {!isReadOnly() &&
-            <Button
-              onClick={handleSave}
-              color="primary"
-              disabled={originalCode === code || !!error}
-            >
-              { saveLabel || 'Save & Apply'}
-            </Button>
-            }
+            {!isReadOnly() && (
+              <Button
+                onClick={handleSave}
+                color="primary"
+                disabled={originalCode === code || !!error}
+              >
+                {saveLabel || 'Save & Apply'}
+              </Button>
+            )}
           </DialogActions>
         </React.Fragment>
-      }
+      )}
     </Dialog>
   );
 }
 
 export function ViewDialog(props: Omit<EditorDialogProps, 'onSave'>) {
-  return (
-    <EditorDialog
-      {...props}
-      onSave={null}
-    />
-  );
+  return <EditorDialog {...props} onSave={null} />;
 }
 
 const useStyles = makeStyles(theme => ({
@@ -291,7 +268,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 // @todo: Declare strict types.
-function DocsViewer(props: {docSpecs: any}) {
+function DocsViewer(props: { docSpecs: any }) {
   const { docSpecs } = props;
   const classes = useStyles();
   const [docs, setDocs] = React.useState<object | null>(null);
@@ -305,7 +282,9 @@ function DocsViewer(props: {docSpecs: any}) {
       return;
     }
     if (!docSpecs.apiVersion || !docSpecs.kind) {
-      setDocsError('Cannot load documentation: Please make sure the YAML is valid and has the kind and apiVersion set.');
+      setDocsError(
+        'Cannot load documentation: Please make sure the YAML is valid and has the kind and apiVersion set.'
+      );
       return;
     }
 
@@ -313,11 +292,10 @@ function DocsViewer(props: {docSpecs: any}) {
       .then(result => {
         setDocs(result?.properties || {});
       })
-      .catch((err) => {
+      .catch(err => {
         setDocsError(`Cannot load documentation: ${err}`);
       });
-  },
-  [docSpecs]);
+  }, [docSpecs]);
 
   function makeItems(name: string, value: any, key: string) {
     return (
@@ -327,11 +305,7 @@ function DocsViewer(props: {docSpecs: any}) {
         label={
           <div>
             <Typography display="inline">{name}</Typography>&nbsp;
-            <Typography
-              display="inline"
-              color="textSecondary"
-              variant="caption"
-            >
+            <Typography display="inline" color="textSecondary" variant="caption">
               ({value.type})
             </Typography>
           </div>
@@ -345,25 +319,22 @@ function DocsViewer(props: {docSpecs: any}) {
     );
   }
 
-  return (
-    docs === null && docsError === null ?
-      <Loader />
-      : !_.isEmpty(docsError) ?
-        <Empty color="error">{docsError}</Empty>
-        : _.isEmpty(docs) ?
-          <Empty>No documentation for type {docSpecs.kind.trim()}.</Empty>
-          :
-          <Box p={4}>
-            <Typography>Showing documentation for: {docSpecs.kind.trim()}</Typography>
-            <TreeView
-              className={classes.root}
-              defaultCollapseIcon={<Icon icon={chevronDown} />}
-              defaultExpandIcon={<Icon icon={chevronRight} />}
-            >
-              {Object.entries(docs || {})
-                .map(([name, value], i) => makeItems(name, value, i.toString()))
-              }
-            </TreeView>
-          </Box>
+  return docs === null && docsError === null ? (
+    <Loader />
+  ) : !_.isEmpty(docsError) ? (
+    <Empty color="error">{docsError}</Empty>
+  ) : _.isEmpty(docs) ? (
+    <Empty>No documentation for type {docSpecs.kind.trim()}.</Empty>
+  ) : (
+    <Box p={4}>
+      <Typography>Showing documentation for: {docSpecs.kind.trim()}</Typography>
+      <TreeView
+        className={classes.root}
+        defaultCollapseIcon={<Icon icon={chevronDown} />}
+        defaultExpandIcon={<Icon icon={chevronRight} />}
+      >
+        {Object.entries(docs || {}).map(([name, value], i) => makeItems(name, value, i.toString()))}
+      </TreeView>
+    </Box>
   );
 }

--- a/frontend/src/components/common/EmptyContent.tsx
+++ b/frontend/src/components/common/EmptyContent.tsx
@@ -2,16 +2,19 @@ import Box from '@material-ui/core/Box';
 import Typography, { TypographyProps } from '@material-ui/core/Typography';
 import React from 'react';
 
-export default function Empty(props: React.PropsWithChildren<{color: TypographyProps['color']}>) {
+export default function Empty(props: React.PropsWithChildren<{ color: TypographyProps['color'] }>) {
   return (
     <Box padding={2}>
       {React.Children.map(props.children, child => {
         if (typeof child === 'string') {
-          return <Typography color={props.color} align="center">{child}</Typography>;
+          return (
+            <Typography color={props.color} align="center">
+              {child}
+            </Typography>
+          );
         }
         return child;
-      })
-      }
+      })}
     </Box>
   );
 }

--- a/frontend/src/components/common/Label.stories/DateLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/DateLabel.stories.tsx
@@ -10,9 +10,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<DateLabelProps> = (args) => (
-  <DateLabelComponent {...args} />
-);
+const Template: Story<DateLabelProps> = args => <DateLabelComponent {...args} />;
 
 export const DateLabelString = Template.bind({});
 DateLabelString.args = {

--- a/frontend/src/components/common/Label.stories/HeaderLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/HeaderLabel.stories.tsx
@@ -1,9 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
-import {
-  HeaderLabel as HeaderLabelComponent,
-  HeaderLabelProps,
-} from '../Label';
+import { HeaderLabel as HeaderLabelComponent, HeaderLabelProps } from '../Label';
 
 export default {
   title: 'Label',
@@ -11,9 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<HeaderLabelProps> = (args) => (
-  <HeaderLabelComponent {...args} />
-);
+const Template: Story<HeaderLabelProps> = args => <HeaderLabelComponent {...args} />;
 
 export const HeaderLabel = Template.bind({});
 HeaderLabel.args = {

--- a/frontend/src/components/common/Label.stories/HoverInfoLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/HoverInfoLabel.stories.tsx
@@ -1,9 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
-import {
-  HoverInfoLabel as HoverInfoLabelComponent,
-  HoverInfoLabelProps,
-} from '../Label';
+import { HoverInfoLabel as HoverInfoLabelComponent, HoverInfoLabelProps } from '../Label';
 
 export default {
   title: 'Label',
@@ -11,9 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<HoverInfoLabelProps> = (args) => (
-  <HoverInfoLabelComponent {...args} />
-);
+const Template: Story<HoverInfoLabelProps> = args => <HoverInfoLabelComponent {...args} />;
 
 export const HoverInfoLabel = Template.bind({});
 HoverInfoLabel.args = {

--- a/frontend/src/components/common/Label.stories/InfoLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/InfoLabel.stories.tsx
@@ -8,9 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<InfoLabelProps> = (args) => (
-  <InfoLabelComponent {...args} />
-);
+const Template: Story<InfoLabelProps> = args => <InfoLabelComponent {...args} />;
 
 export const InfoLabel = Template.bind({});
 InfoLabel.args = {

--- a/frontend/src/components/common/Label.stories/NameLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/NameLabel.stories.tsx
@@ -8,9 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<{}> = (args) => (
-  <NameLabelComponent {...args}>A name label</NameLabelComponent>
-);
+const Template: Story<{}> = args => <NameLabelComponent {...args}>A name label</NameLabelComponent>;
 
 export const NameLabel = Template.bind({
   component: NameLabelComponent,

--- a/frontend/src/components/common/Label.stories/StatusLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/StatusLabel.stories.tsx
@@ -1,9 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
-import {
-  StatusLabel as StatusLabelComponent,
-  StatusLabelProps,
-} from '../Label';
+import { StatusLabel as StatusLabelComponent, StatusLabelProps } from '../Label';
 
 export default {
   title: 'Label',
@@ -11,7 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<StatusLabelProps> = (args) => (
+const Template: Story<StatusLabelProps> = args => (
   <StatusLabelComponent {...args}>status</StatusLabelComponent>
 );
 

--- a/frontend/src/components/common/Label.stories/ValueLabel.stories.tsx
+++ b/frontend/src/components/common/Label.stories/ValueLabel.stories.tsx
@@ -8,7 +8,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const ValueLabelTemplate: Story<{}> = (args) => (
+const ValueLabelTemplate: Story<{}> = args => (
   <ValueLabelComponent {...args}>A ValueLabel is here</ValueLabelComponent>
 );
 

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -13,24 +13,24 @@ const useStyles = makeStyles(theme => ({
   nameLabel: {
     color: theme.palette.text.secondary,
     fontSize: '1.1em',
-    textAlign: 'right'
+    textAlign: 'right',
   },
   nameLabelItem: {
     textAlign: 'right',
-    flex: '0 0 200px'
+    flex: '0 0 200px',
   },
   valueLabel: {
     color: theme.palette.text.primary,
     fontSize: '1.1em',
-    wordBreak: 'break-word'
+    wordBreak: 'break-word',
   },
   statusLabel: {
     color: theme.palette.primary.contrastText,
     fontSize: '1.1em',
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
-    paddingTop: theme.spacing(.5),
-    paddingBottom: theme.spacing(.5),
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
     display: 'inline-block',
     textAlign: 'center',
   },
@@ -43,25 +43,15 @@ export interface InfoLabelProps {
 
 export function InfoLabel(props: React.PropsWithChildren<InfoLabelProps>) {
   const classes = useStyles();
-  const {name, value = null} = props;
+  const { name, value = null } = props;
 
   return (
-    <Grid
-      container
-      item
-      spacing={2}
-      justify="flex-start"
-      alignItems="flex-start"
-    >
+    <Grid container item spacing={2} justify="flex-start" alignItems="flex-start">
       <Grid item xs className={classes.nameLabelItem}>
         <NameLabel>{name}</NameLabel>{' '}
       </Grid>
       <Grid item xs>
-        {value !== null ?
-          <ValueLabel>{value}</ValueLabel>
-          :
-          props.children
-        }
+        {value !== null ? <ValueLabel>{value}</ValueLabel> : props.children}
       </Grid>
     </Grid>
   );
@@ -70,14 +60,18 @@ export function InfoLabel(props: React.PropsWithChildren<InfoLabelProps>) {
 export function NameLabel(props: React.PropsWithChildren<{}>) {
   const classes = useStyles();
   return (
-    <Typography className={classes.nameLabel} component="span">{props.children}</Typography>
+    <Typography className={classes.nameLabel} component="span">
+      {props.children}
+    </Typography>
   );
 }
 
 export function ValueLabel(props: React.PropsWithChildren<{}>) {
   const classes = useStyles();
   return (
-    <Typography className={classes.valueLabel} component="span">{props.children}</Typography>
+    <Typography className={classes.valueLabel} component="span">
+      {props.children}
+    </Typography>
   );
 }
 
@@ -94,8 +88,9 @@ export function StatusLabel(props: StatusLabelProps) {
   const statuses = ['success', 'warning', 'error'];
 
   // Assign to a status color if it exists.
-  const bgColor =
-    statuses.includes(status) ? theme.palette[status].light : theme.palette.normalEventBg;
+  const bgColor = statuses.includes(status)
+    ? theme.palette[status].light
+    : theme.palette.normalEventBg;
   const color = statuses.includes(status) ? theme.palette[status].main : theme.palette.text.primary;
 
   return (
@@ -113,15 +108,13 @@ export function StatusLabel(props: StatusLabelProps) {
 
 export function makeStatusLabel(label: string, successStatusName: string) {
   return (
-    <StatusLabel status={label === successStatusName ? 'success' : 'error'} >
-      {label}
-    </StatusLabel>
+    <StatusLabel status={label === successStatusName ? 'success' : 'error'}>{label}</StatusLabel>
   );
 }
 
 const useHeaderLabelStyles = makeStyles(theme => ({
   value: {
-    fontSize: '3rem;'
+    fontSize: '3rem;',
   },
   label: {
     textAlign: 'center',
@@ -142,23 +135,14 @@ export function HeaderLabel(props: HeaderLabelProps) {
   const { value, label, tooltip } = props;
 
   return (
-    <Grid
-      container
-      alignItems="center"
-      direction="column"
-    >
+    <Grid container alignItems="center" direction="column">
       <Grid item>
-        <Typography className={classes.label} display="inline">{label}</Typography>
-        {!!tooltip &&
-          <TooltipIcon>{tooltip}</TooltipIcon>
-        }
+        <Typography className={classes.label} display="inline">
+          {label}
+        </Typography>
+        {!!tooltip && <TooltipIcon>{tooltip}</TooltipIcon>}
       </Grid>
-      <Grid
-        item
-        container
-        alignItems="center"
-        justify="center"
-      >
+      <Grid item container alignItems="center" justify="center">
         <Grid item>
           <Typography className={classes.value}>{value}</Typography>
         </Grid>
@@ -177,21 +161,16 @@ export function HoverInfoLabel(props: HoverInfoLabelProps) {
   const { label, hoverInfo, icon = null } = props;
 
   return (
-    <Grid
-      container
-      spacing={1}
-    >
+    <Grid container spacing={1}>
+      <Grid item>{label}</Grid>
       <Grid item>
-        {label}
-      </Grid>
-      <Grid item>
-        {hoverInfo &&
+        {hoverInfo && (
           <LightTooltip title={hoverInfo}>
             <Box>
-              <Icon icon={icon || informationOutline} width="1rem" height="1rem"/>
+              <Icon icon={icon || informationOutline} width="1rem" height="1rem" />
             </Box>
           </LightTooltip>
-        }
+        )}
       </Grid>
     </Grid>
   );
@@ -203,11 +182,5 @@ export interface DateLabelProps {
 
 export function DateLabel(props: DateLabelProps) {
   const { date } = props;
-  return (
-    <HoverInfoLabel
-      label={timeAgo(date)}
-      hoverInfo={localeDate(date)}
-      icon={calendarIcon}
-    />
-  );
+  return <HoverInfoLabel label={timeAgo(date)} hoverInfo={localeDate(date)} icon={calendarIcon} />;
 }

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -34,7 +34,7 @@ export default function Link(props: React.PropsWithChildren<LinkProps | LinkObje
       to={{
         pathname: createRouteURL(routeName, params),
         search,
-        state
+        state,
       }}
     >
       {props.children}

--- a/frontend/src/components/common/Loader.tsx
+++ b/frontend/src/components/common/Loader.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 const useStyles = makeStyles({
   loaderContainer: {
     textAlign: 'center',
-  }
+  },
 });
 
 interface LoaderProps {
@@ -15,11 +15,10 @@ interface LoaderProps {
 
 export default function Loader(props: LoaderProps & CircularProgressProps) {
   const classes = useStyles();
-  const {noContainer = false, ...other} = props;
+  const { noContainer = false, ...other } = props;
   const progress = <CircularProgress {...other} />;
 
-  if (noContainer)
-    return progress;
+  if (noContainer) return progress;
 
   return (
     <Box className={classes.loaderContainer} py={3} px="auto">

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -30,7 +30,7 @@ const useStyle = makeStyles(theme => ({
   },
   containerFormControl: {
     minWidth: '11rem',
-  }
+  },
 }));
 
 export interface LogViewerProps extends DialogProps {
@@ -42,20 +42,13 @@ export interface LogViewerProps extends DialogProps {
 }
 
 export function LogViewer(props: LogViewerProps) {
-  const {
-    logs,
-    title = '',
-    downloadName = 'log',
-    onClose,
-    topActions = [],
-    ...other
-  } = props;
+  const { logs, title = '', downloadName = 'log', onClose, topActions = [], ...other } = props;
   const classes = useStyle();
   const logsBottomRef = React.useRef<HTMLDivElement>(null);
 
   function downloadLog() {
     const element = document.createElement('a');
-    const file = new Blob(logs, {type: 'text/plain'});
+    const file = new Blob(logs, { type: 'text/plain' });
     element.href = URL.createObjectURL(file);
     element.download = `${downloadName}.txt`;
     // Required for FireFox
@@ -68,44 +61,23 @@ export function LogViewer(props: LogViewerProps) {
     if (logsBottomRef && logsBottomRef.current) {
       logsBottomRef.current.scrollIntoView();
     }
-  },
-  [logs]);
+  }, [logs]);
 
   return (
-    <Dialog
-      maxWidth="lg"
-      scroll="paper"
-      fullWidth
-      onBackdropClick={onClose}
-      {...other}
-    >
+    <Dialog maxWidth="lg" scroll="paper" fullWidth onBackdropClick={onClose} {...other}>
       <DialogTitle>{title}</DialogTitle>
-      <DialogContent
-        className={classes.dialogContent}
-      >
-        <Grid
-          container
-          justify="space-between"
-          alignItems="center"
-          wrap="nowrap"
-        >
-          <Grid
-            item
-            container
-            spacing={1}
-          >
-            {topActions.map((component, i) =>
+      <DialogContent className={classes.dialogContent}>
+        <Grid container justify="space-between" alignItems="center" wrap="nowrap">
+          <Grid item container spacing={1}>
+            {topActions.map((component, i) => (
               <Grid item key={i}>
                 {component}
               </Grid>
-            )}
+            ))}
           </Grid>
           <Grid item xs>
             <Tooltip title="Download">
-              <IconButton
-                aria-label="download"
-                onClick={downloadLog}
-              >
+              <IconButton aria-label="download" onClick={downloadLog}>
                 <Icon icon={fileDownloadOutline} />
               </IconButton>
             </Tooltip>
@@ -113,18 +85,17 @@ export function LogViewer(props: LogViewerProps) {
         </Grid>
         <Box className={classes.terminal}>
           <pre>
-            {logs.map((item, i) =>
-              <Ansi className={classes.terminalCode} key={i} linkify={false}>{item}</Ansi>
-            )}
+            {logs.map((item, i) => (
+              <Ansi className={classes.terminalCode} key={i} linkify={false}>
+                {item}
+              </Ansi>
+            ))}
           </pre>
           <div ref={logsBottomRef} />
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button
-          onClick={onClose}
-          color="primary"
-        >
+        <Button onClick={onClose} color="primary">
           Close
         </Button>
       </DialogActions>

--- a/frontend/src/components/common/Resource.tsx
+++ b/frontend/src/components/common/Resource.tsx
@@ -19,7 +19,12 @@ import _ from 'lodash';
 import * as monaco from 'monaco-editor';
 import React from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-import { KubeCondition, KubeContainer, KubeObject, KubeObjectInterface } from '../../lib/k8s/cluster';
+import {
+  KubeCondition,
+  KubeContainer,
+  KubeObject,
+  KubeObjectInterface,
+} from '../../lib/k8s/cluster';
 import { createRouteURL, RouteURLProps } from '../../lib/router';
 import { localeDate } from '../../lib/util';
 import { useTypedSelector } from '../../redux/reducers/reducers';
@@ -61,7 +66,7 @@ export function MetadataDisplay(props: MetadataDisplayProps) {
     {
       name: 'Namespace',
       value: resource.metadata.namespace && resource.metadata.namespace,
-      hide: !resource.metadata.namespace
+      hide: !resource.metadata.namespace,
     },
     {
       name: 'Creation',
@@ -74,15 +79,14 @@ export function MetadataDisplay(props: MetadataDisplayProps) {
     },
     {
       name: 'Annotations',
-      value: resource.metadata.annotations &&
-        <MetadataDictGrid dict={resource.metadata.annotations} />,
+      value: resource.metadata.annotations && (
+        <MetadataDictGrid dict={resource.metadata.annotations} />
+      ),
       hide: !resource.metadata.annotations,
     },
   ] as NameValueTableRow[]).concat(extraRows || []);
 
-  return (
-    <NameValueTable rows={mainRows}/>
-  );
+  return <NameValueTable rows={mainRows} />;
 }
 
 interface MetadataDictGridProps {
@@ -101,15 +105,8 @@ export function MetadataDictGrid(props: MetadataDictGridProps) {
 
   const keys = Object.keys(dict || []);
 
-  const MetadataEntry = React.forwardRef((props: TypographyProps, ref:any) => {
-    return (
-      <Typography
-        noWrap
-        {...props}
-        className={classes.metadataValueLabel}
-        ref={ref}
-      />
-    );
+  const MetadataEntry = React.forwardRef((props: TypographyProps, ref: any) => {
+    return <Typography noWrap {...props} className={classes.metadataValueLabel} ref={ref} />;
   });
 
   function makeLabel(key: string | number) {
@@ -133,45 +130,35 @@ export function MetadataDictGrid(props: MetadataDictGridProps) {
     // If the full label is not being shown, use a tooltip to show the full text
     // to the user (so they select it, etc.).
     if (fullText.length !== shortText.length) {
-      labelComponent = (
-        <LightTooltip
-          title={fullText}
-          children={labelComponent}
-          interactive
-        />
-      );
+      labelComponent = <LightTooltip title={fullText} children={labelComponent} interactive />;
     }
     return labelComponent;
   }
 
   return (
-    <Grid
-      container
-      spacing={1}
-      justify="flex-start"
-    >
-      {keys.length > defaultNumShown &&
+    <Grid container spacing={1} justify="flex-start">
+      {keys.length > defaultNumShown && (
         <Grid item>
           <IconButton onClick={() => setExpanded(!expanded)} size="small">
             <Icon icon={expanded ? menuUp : menuDown} />
           </IconButton>
         </Grid>
-      }
+      )}
       <Grid
         container
         item
         justify="flex-start"
         spacing={1}
         style={{
-          maxWidth: '80%'
+          maxWidth: '80%',
         }}
       >
         {/* Limit the size to two entries until the user chooses to expand the whole section */}
-        {keys.slice(0, expanded ? keys.length : defaultNumShown).map((key, i) =>
+        {keys.slice(0, expanded ? keys.length : defaultNumShown).map((key, i) => (
           <Grid key={i} item zeroMinWidth>
             {makeLabel(key)}
           </Grid>
-        )}
+        ))}
       </Grid>
     </Grid>
   );
@@ -189,15 +176,11 @@ export function ResourceLink(props: ResourceLinkProps) {
     routeName = props.resource.kind,
     routeParams = props.resource.metadata as RouteURLProps,
     name = props.resource.metadata.name,
-    state
+    state,
   } = props;
 
   return (
-    <Link
-      routeName={routeName}
-      params={routeParams}
-      state={state}
-    >
+    <Link routeName={routeName} params={routeParams} state={state}>
       {name}
     </Link>
   );
@@ -228,54 +211,48 @@ export function MainInfoSection(props: MainInfoSectionProps) {
   const headerActions = useTypedSelector(state => state.ui.views.details.headerActions);
 
   function getHeaderActions() {
-    return React.Children.toArray(Object.values(headerActions).map(action =>
-      action({item: resource})));
+    return React.Children.toArray(
+      Object.values(headerActions).map(action => action({ item: resource }))
+    );
   }
 
   let defaultActions: MainInfoSectionProps['actions'] = [];
 
   if (!noDefaultActions && resource) {
-    defaultActions = [
-      <EditButton item={resource} />,
-      <DeleteButton item={resource} />
-    ];
+    defaultActions = [<EditButton item={resource} />, <DeleteButton item={resource} />];
   }
 
   return (
     <>
-      {resource &&
+      {resource && (
         <Button
           startIcon={<Icon icon={chevronLeft} />}
           size="small"
           component={RouterLink}
           to={backLink || createRouteURL(resource.listRoute)}
         >
-          <Typography style={{paddingTop: '3px'}}>Back</Typography>
+          <Typography style={{ paddingTop: '3px' }}>Back</Typography>
         </Button>
-      }
+      )}
       <SectionBox
         title={
           <SectionHeader
             title={title || (resource ? resource.kind : '')}
             headerStyle={headerStyle}
-            actions={
-              getHeaderActions().concat(React.Children.toArray(actions))
-                .concat(defaultActions)
-            }
+            actions={getHeaderActions()
+              .concat(React.Children.toArray(actions))
+              .concat(defaultActions)}
           />
         }
       >
-        {resource === null ?
+        {resource === null ? (
           <Loader />
-          :
+        ) : (
           <React.Fragment>
             {headerSection}
-            <MetadataDisplay
-              resource={resource}
-              extraRows={extraInfo}
-            />
+            <MetadataDisplay resource={resource} extraRows={extraInfo} />
           </React.Fragment>
-        }
+        )}
       </SectionBox>
     </>
   );
@@ -289,18 +266,12 @@ export function PageGrid(props: PageGridProps) {
   const { sections = [], children = [], ...other } = props;
   const childrenArray = React.Children.toArray(children).concat(sections);
   return (
-    <Grid
-      container
-      spacing={1}
-      justify="flex-start"
-      alignItems="stretch"
-      {...other}
-    >
-      {childrenArray.map((section, i) =>
+    <Grid container spacing={1} justify="flex-start" alignItems="stretch" {...other}>
+      {childrenArray.map((section, i) => (
         <Grid item key={i} xs={12}>
           {section}
         </Grid>
-      )}
+      ))}
     </Grid>
   );
 }
@@ -313,18 +284,10 @@ interface SectionGridProps {
 export function SectionGrid(props: SectionGridProps) {
   const { items } = props;
   return (
-    <Grid
-      container
-      justify="space-between"
-    >
+    <Grid container justify="space-between">
       {items.map((item, i) => {
         return (
-          <Grid
-            item
-            md={12}
-            xs={12}
-            key={i}
-          >
+          <Grid item md={12} xs={12} key={i}>
             {item}
           </Grid>
         );
@@ -349,7 +312,7 @@ export function DataField(props: TextFieldProps) {
     }
     editor.layout();
   }
-  let language = ((label as string).split('.').pop() as string);
+  let language = (label as string).split('.').pop() as string;
   if (language !== 'json') {
     language = 'yaml';
   }
@@ -357,20 +320,18 @@ export function DataField(props: TextFieldProps) {
     <>
       <Box borderTop={0} border={1}>
         <Box display="flex">
-          <Box width="10%" borderTop={1} height={'1px'}>
-          </Box>
+          <Box width="10%" borderTop={1} height={'1px'}></Box>
           <Box pb={1} mt={-1} px={0.5}>
             <InputLabel>{label}</InputLabel>
           </Box>
-          <Box width="100%" borderTop={1} height={'1px'}>
-          </Box>
+          <Box width="100%" borderTop={1} height={'1px'}></Box>
         </Box>
         <Box mt={1} px={1} pb={1}>
           <Editor
             value={value as string}
             language={language}
             onMount={handleEditorDidMount}
-            options = {{'readOnly': true, 'lineNumbers': 'off'}}
+            options={{ readOnly: true, lineNumbers: 'off' }}
             theme="vs-dark"
           />
         </Box>
@@ -388,11 +349,7 @@ export function SecretField(props: InputProps) {
   }
 
   return (
-    <Grid
-      container
-      alignItems="stretch"
-      spacing={2}
-    >
+    <Grid container alignItems="stretch" spacing={2}>
       <Grid item>
         <IconButton
           edge="end"
@@ -432,13 +389,7 @@ export function ConditionsTable(props: ConditionsTableProps) {
       status = condition.status === 'True' ? 'success' : 'error';
     }
 
-    return (
-      <StatusLabel
-        status={status}
-      >
-        {condition.type}
-      </StatusLabel>
-    );
+    return <StatusLabel status={status}>{condition.type}</StatusLabel>;
   }
 
   function getColumns() {
@@ -449,7 +400,7 @@ export function ConditionsTable(props: ConditionsTableProps) {
     }[] = [
       {
         label: 'Condition',
-        getter: makeStatusLabel
+        getter: makeStatusLabel,
       },
       {
         label: 'Status',
@@ -461,20 +412,19 @@ export function ConditionsTable(props: ConditionsTableProps) {
       },
       {
         label: 'Last Update',
-        getter: condition => condition.lastUpdateTime ? <DateLabel date={condition.lastUpdateTime as string} /> : '-',
-        hide: !showLastUpdate
+        getter: condition =>
+          condition.lastUpdateTime ? <DateLabel date={condition.lastUpdateTime as string} /> : '-',
+        hide: !showLastUpdate,
       },
       {
         label: 'Reason',
         getter: condition =>
-          condition.reason ?
-            <HoverInfoLabel
-              label={condition.reason}
-              hoverInfo={condition.message}
-            />
-            :
+          condition.reason ? (
+            <HoverInfoLabel label={condition.reason} hoverInfo={condition.message} />
+          ) : (
             '-'
-      }
+          ),
+      },
     ];
 
     // Allow to filter the columns by using a hide field
@@ -489,8 +439,8 @@ export function ConditionsTable(props: ConditionsTableProps) {
   );
 }
 
-export function ContainerInfo(props: {container: KubeContainer}) {
-  const {container} = props;
+export function ContainerInfo(props: { container: KubeContainer }) {
+  const { container } = props;
 
   function containerRows() {
     const env: { [name: string]: string } = {};
@@ -510,45 +460,40 @@ export function ContainerInfo(props: {container: KubeContainer}) {
       env[envVar.name] = value;
     });
 
-    return ([
+    return [
       {
         name: 'Image',
         value: container.image,
       },
       {
         name: 'Args',
-        value: container.args &&
-          <MetadataDictGrid dict={container.args as {[index: number]: string}} showKeys={false} />,
-        hide: !container.args
+        value: container.args && (
+          <MetadataDictGrid dict={container.args as { [index: number]: string }} showKeys={false} />
+        ),
+        hide: !container.args,
       },
       {
         name: 'Command',
         value: (container.command || []).join(' '),
-        hide: !container.command
+        hide: !container.command,
       },
       {
         name: 'Environment',
         value: <MetadataDictGrid dict={env} />,
         hide: _.isEmpty(env),
       },
-    ]);
+    ];
   }
 
   return (
     <Box py={1}>
-      <SectionHeader
-        noPadding
-        title={container.name}
-        headerStyle="normal"
-      />
-      <NameValueTable
-        rows={containerRows()}
-      />
+      <SectionHeader noPadding title={container.name} headerStyle="normal" />
+      <NameValueTable rows={containerRows()} />
     </Box>
   );
 }
 
-export function ContainersSection(props: {resource: KubeObjectInterface | null}) {
+export function ContainersSection(props: { resource: KubeObjectInterface | null }) {
   const { resource } = props;
 
   function getContainers() {
@@ -574,23 +519,24 @@ export function ContainersSection(props: {resource: KubeObjectInterface | null})
 
   return (
     <SectionBox title="Containers">
-      {numContainers === 0 ?
+      {numContainers === 0 ? (
         <Empty>No containers to show</Empty>
-        :
+      ) : (
         containers.map((container: any, i: number) => {
           return (
             <React.Fragment key={i}>
               <ContainerInfo container={container} />
               {/* Don't show the divider if this is the last container */}
-              { (i !== (numContainers - 1)) && <Divider /> }
+              {i !== numContainers - 1 && <Divider />}
             </React.Fragment>
           );
-        })}
+        })
+      )}
     </SectionBox>
   );
 }
 
-export function ReplicasSection(props: {resource: KubeObjectInterface | null }) {
+export function ReplicasSection(props: { resource: KubeObjectInterface | null }) {
   const { resource } = props;
 
   if (!resource) {

--- a/frontend/src/components/common/SectionBox.tsx
+++ b/frontend/src/components/common/SectionBox.tsx
@@ -12,30 +12,23 @@ export function SectionBox(props: SectionBoxProps) {
   const {
     title,
     children,
-    headerProps = {noPadding: false, headerStyle: 'subsection'},
+    headerProps = { noPadding: false, headerStyle: 'subsection' },
     ...otherProps
   } = props;
 
   let titleElem: React.ReactNode;
 
   if (typeof title === 'string') {
-    titleElem =
-      <SectionHeader
-        title={title as string}
-        {...headerProps}
-      />;
+    titleElem = <SectionHeader title={title as string} {...headerProps} />;
   } else {
     titleElem = title as JSX.Element;
   }
 
   return (
     <Box py={0}>
-      { title && titleElem }
+      {title && titleElem}
       <Paper>
-        <Box
-          px={2}
-          {...otherProps}
-        >
+        <Box px={2} {...otherProps}>
           {React.Children.toArray(children)}
         </Box>
       </Paper>

--- a/frontend/src/components/common/SectionFilterHeader.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.tsx
@@ -40,59 +40,50 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
     }
   });
 
-  React.useEffect(() => {
-    // We don't want the search to be used globally, but we're using Redux with it because
-    // this way we manage it the same way as with the other filters.
-    return function cleanup() {
-      dispatch(setSearchFilter(''));
-    };
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  []);
+  React.useEffect(
+    () => {
+      // We don't want the search to be used globally, but we're using Redux with it because
+      // this way we manage it the same way as with the other filters.
+      return function cleanup() {
+        dispatch(setSearchFilter(''));
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
   const actions = [];
 
   if (!showFilters) {
     actions.push(
-      <IconButton
-        aria-label="show-filter"
-        onClick={() => setShowFilters(!showFilters)}
-      >
+      <IconButton aria-label="show-filter" onClick={() => setShowFilters(!showFilters)}>
         <Icon icon={filterIcon} />
       </IconButton>
     );
   } else {
     actions.push(
-      <Grid
-        container
-        alignItems="flex-end"
-        justify="flex-end"
-        spacing={1}
-        wrap="nowrap"
-      >
-        { !noNamespaceFilter &&
+      <Grid container alignItems="flex-end" justify="flex-end" spacing={1} wrap="nowrap">
+        {!noNamespaceFilter && (
           <Grid item>
             <NamespacesAutocomplete />
           </Grid>
-        }
+        )}
         <Grid item>
           <TextField
             id="standard-search"
             label="Search"
             type="search"
-            InputLabelProps={{shrink: true}}
+            InputLabelProps={{ shrink: true }}
             placeholder="Filter"
             value={filter.search}
             autoFocus
-            onChange={event =>
-              dispatch(setSearchFilter(event.target.value))
-            }
+            onChange={event => dispatch(setSearchFilter(event.target.value))}
           />
         </Grid>
         <Grid item>
           <Button
             variant="contained"
-            endIcon={<Icon icon={filterVariantRemove} /> }
+            endIcon={<Icon icon={filterVariantRemove} />}
             onClick={resetFilters}
           >
             Clear
@@ -106,20 +97,21 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
     <React.Fragment>
       <SectionHeader
         {...headerProps}
-        actions={actions.length <= 1 ? actions : [
-          <Box>
-            <Grid
-              container
-              spacing={1}
-            >
-              {actions.map((action, i) =>
-                <Grid item key={i}>
-                  {action}
-                </Grid>
-              )}
-            </Grid>
-          </Box>
-        ]}
+        actions={
+          actions.length <= 1
+            ? actions
+            : [
+                <Box>
+                  <Grid container spacing={1}>
+                    {actions.map((action, i) => (
+                      <Grid item key={i}>
+                        {action}
+                      </Grid>
+                    ))}
+                  </Grid>
+                </Box>,
+              ]
+        }
       />
     </React.Fragment>
   );

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -11,11 +11,11 @@ export interface HeaderStyleProps {
 }
 
 const useStyles = makeStyles(theme => ({
-  sectionHeader: ({noPadding, headerStyle}: HeaderStyleProps) => ({
+  sectionHeader: ({ noPadding, headerStyle }: HeaderStyleProps) => ({
     padding: theme.spacing(noPadding ? 0 : 2),
     paddingTop: theme.spacing(noPadding ? 0 : 3),
     paddingRight: '0',
-    ...theme.palette.headerStyle[headerStyle || 'normal']
+    ...theme.palette.headerStyle[headerStyle || 'normal'],
   }),
   title: {
     fontWeight: 'bold',
@@ -30,8 +30,8 @@ export interface SectionHeaderProps {
 }
 
 export default function SectionHeader(props: SectionHeaderProps) {
-  const {noPadding = false, headerStyle = 'main'} = props;
-  const classes = useStyles({noPadding, headerStyle});
+  const { noPadding = false, headerStyle = 'main' } = props;
+  const classes = useStyles({ noPadding, headerStyle });
   const actions = props.actions || [];
 
   return (
@@ -42,35 +42,24 @@ export default function SectionHeader(props: SectionHeaderProps) {
       className={classes.sectionHeader}
       spacing={2}
     >
-      {props.title &&
-        <Grid
-          item
-        >
-          <Typography
-            variant="h6"
-            className={classes.title}
-            noWrap
-          >
+      {props.title && (
+        <Grid item>
+          <Typography variant="h6" className={classes.title} noWrap>
             {props.title}
           </Typography>
         </Grid>
-      }
-      {actions.length > 0 &&
+      )}
+      {actions.length > 0 && (
         <Grid item>
-          <Grid
-            item
-            container
-            alignItems="center"
-            justify="flex-end"
-          >
-            {actions.map((action, i) =>
+          <Grid item container alignItems="center" justify="flex-end">
+            {actions.map((action, i) => (
               <Grid item key={i}>
                 {action}
               </Grid>
-            )}
+            ))}
           </Grid>
         </Grid>
-      }
+      )}
     </Grid>
   );
 }

--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -9,7 +9,7 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<SimpleTableProps> = (args) => <SimpleTable {...args} />;
+const Template: Story<SimpleTableProps> = args => <SimpleTable {...args} />;
 
 const fixtureData = {
   rowsPerPage: [15, 25, 50],

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -21,7 +21,7 @@ import Loader from './Loader';
 const useTableStyle = makeStyles(theme => ({
   headerCell: {
     fontWeight: 'bold',
-    paddingBottom: theme.spacing(.5),
+    paddingBottom: theme.spacing(0.5),
   },
   table: {
     '& .MuiTableCell-root': {
@@ -32,12 +32,12 @@ const useTableStyle = makeStyles(theme => ({
         '& .MuiTableCell-root': {
           borderBottom: 'none',
         },
-      }
+      },
     },
     '& .MuiTableCell-head': {
       color: theme.palette.tables.headerText,
-    }
-  }
+    },
+  },
 }));
 
 type sortFunction = (arg1: any, arg2: any) => number;
@@ -68,25 +68,26 @@ export interface SimpleTableProps {
   rowsPerPage?: number[];
   emptyMessage?: string;
   errorMessage?: string | null;
-  defaultSortingColumn? : number;
+  defaultSortingColumn?: number;
 }
 
 interface ColumnSortButtonProps {
-   isDefaultSorted: boolean;
-   isIncreasingOrder: boolean;
-   clickHandler: (isIncreasingOrder: boolean) => void;
+  isDefaultSorted: boolean;
+  isIncreasingOrder: boolean;
+  clickHandler: (isIncreasingOrder: boolean) => void;
 }
 
 function ColumnSortButtons(props: ColumnSortButtonProps) {
-  const {isDefaultSorted, isIncreasingOrder, clickHandler} = props;
-  return isDefaultSorted ?
+  const { isDefaultSorted, isIncreasingOrder, clickHandler } = props;
+  return isDefaultSorted ? (
     <IconButton size="small" onClick={() => clickHandler(!isIncreasingOrder)}>
-      <Icon icon={isIncreasingOrder ? menuUp : menuDown}/>
+      <Icon icon={isIncreasingOrder ? menuUp : menuDown} />
     </IconButton>
-    :
+  ) : (
     <IconButton size="small" onClick={() => clickHandler(true)}>
-      <Icon icon={menuSwap}/>
-    </IconButton>;
+      <Icon icon={menuSwap} />
+    </IconButton>
+  );
 }
 
 export default function SimpleTable(props: SimpleTableProps) {
@@ -96,7 +97,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     filterFunction = null,
     emptyMessage = null,
     errorMessage = null,
-    defaultSortingColumn
+    defaultSortingColumn,
   } = props;
   const [page, setPage] = React.useState(0);
   const [currentData, setCurrentData] = React.useState(data);
@@ -104,11 +105,13 @@ export default function SimpleTable(props: SimpleTableProps) {
   const rowsPerPageOptions = props.rowsPerPage || [5, 10, 50];
   const [rowsPerPage, setRowsPerPage] = React.useState(rowsPerPageOptions[0]);
   const classes = useTableStyle();
-  const [isIncreasingOrder, setIsIncreasingOrder] =
-    React.useState(!defaultSortingColumn || defaultSortingColumn > 0);
+  const [isIncreasingOrder, setIsIncreasingOrder] = React.useState(
+    !defaultSortingColumn || defaultSortingColumn > 0
+  );
   // We use a -1 value here if no sorting should be done by default.
-  const [sortColIndex, setSortColIndex] =
-    React.useState(defaultSortingColumn ? Math.abs(defaultSortingColumn) - 1 : -1);
+  const [sortColIndex, setSortColIndex] = React.useState(
+    defaultSortingColumn ? Math.abs(defaultSortingColumn) - 1 : -1
+  );
 
   function handleChangePage(_event: any, newPage: number) {
     setPage(newPage);
@@ -119,25 +122,27 @@ export default function SimpleTable(props: SimpleTableProps) {
     setPage(0);
   }
 
-  React.useEffect(() => {
-    if (currentData === data) {
-      if (page !== 0) {
-        setPage(0);
+  React.useEffect(
+    () => {
+      if (currentData === data) {
+        if (page !== 0) {
+          setPage(0);
+        }
+        return;
       }
-      return;
-    }
 
-    // If the currentData is not up to date and we are in the first page, then update
-    // it directly. Otherwise it will require user's intervention.
-    if ((!currentData || currentData.length === 0) || page === 0) {
-      setCurrentData(data);
-      setDisplayData(getSortData() || data);
-    }
-  },
-  // eslint-disable-next-line
-  [data, currentData]);
+      // If the currentData is not up to date and we are in the first page, then update
+      // it directly. Otherwise it will require user's intervention.
+      if (!currentData || currentData.length === 0 || page === 0) {
+        setCurrentData(data);
+        setDisplayData(getSortData() || data);
+      }
+    },
+    // eslint-disable-next-line
+    [data, currentData]
+  );
 
-  function defaultSortingFunction(column : SimpleTableGetterColumn) {
+  function defaultSortingFunction(column: SimpleTableGetterColumn) {
     function defaultSortingReal(item1: any, item2: any) {
       const value1 = column.getter(item1);
       const value2 = column.getter(item2);
@@ -163,31 +168,34 @@ export default function SimpleTable(props: SimpleTableProps) {
     const columnAskingForSort = columns[sortColIndex];
     const sortFunction = columnAskingForSort?.sort;
 
-    if (typeof sortFunction === 'boolean' && sortFunction){
-      setDisplayData(data.slice().sort(defaultSortingFunction(columnAskingForSort as
-        SimpleTableGetterColumn)));
+    if (typeof sortFunction === 'boolean' && sortFunction) {
+      setDisplayData(
+        data.slice().sort(defaultSortingFunction(columnAskingForSort as SimpleTableGetterColumn))
+      );
       return;
     }
 
     if (typeof sortFunction === 'function') {
       applySort = (arg1: any, arg2: any) => {
         const orderChanger = isIncreasingOrder ? 1 : -1;
-        return sortFunction(arg1, arg2) as number * orderChanger;
+        return (sortFunction(arg1, arg2) as number) * orderChanger;
       };
       const sortedData = data.slice().sort(applySort);
       return sortedData;
     }
   }
 
-  React.useEffect(() => {
-    const sortedData = getSortData();
-    if (!sortedData) {
-      return;
-    }
-    setDisplayData(sortedData);
-  },
-  // eslint-disable-next-line
-  [sortColIndex, isIncreasingOrder, currentData]);
+  React.useEffect(
+    () => {
+      const sortedData = getSortData();
+      if (!sortedData) {
+        return;
+      }
+      setDisplayData(sortedData);
+    },
+    // eslint-disable-next-line
+    [sortColIndex, isIncreasingOrder, currentData]
+  );
 
   function getPagedRows() {
     const startIndex = page * rowsPerPage;
@@ -196,9 +204,7 @@ export default function SimpleTable(props: SimpleTableProps) {
 
   if (displayData === null) {
     if (!!errorMessage) {
-      return (
-        <Empty color="error">{errorMessage}</Empty>
-      );
+      return <Empty color="error">{errorMessage}</Empty>;
     }
 
     return <Loader />;
@@ -215,37 +221,40 @@ export default function SimpleTable(props: SimpleTableProps) {
     setSortColIndex(index);
   }
 
-  return (
-    (!currentData || currentData.length === 0) ?
-      <Empty>{emptyMessage || 'No data to be shown.'}</Empty>
-      :
-      <React.Fragment>
-        { // Show a refresh button if the data is not up to date, so we allow the user to keep
-          // reading the current data without "losing" it or being sent to the first page
-          (currentData !== data) &&
+  return !currentData || currentData.length === 0 ? (
+    <Empty>{emptyMessage || 'No data to be shown.'}</Empty>
+  ) : (
+    <React.Fragment>
+      {
+        // Show a refresh button if the data is not up to date, so we allow the user to keep
+        // reading the current data without "losing" it or being sent to the first page
+        currentData !== data && (
           <Box textAlign="center" p={2}>
             <Button
               variant="contained"
-              startIcon={<Icon icon={refreshIcon} /> }
-              onClick={() => { setCurrentData(data); }}
+              startIcon={<Icon icon={refreshIcon} />}
+              onClick={() => {
+                setCurrentData(data);
+              }}
             >
               Refresh
             </Button>
           </Box>
-        }
-        <Table className={classes.table}>
-          <TableHead>
-            <TableRow>
-              {columns.map(({label, cellProps = {}, sort}, i) => {
-                const {className = '', ...otherProps} = cellProps;
-                return (
-                  <TableCell
-                    key={`tabletitle_${i}`}
-                    className={classes.headerCell + ' ' + className}
-                    {...otherProps}
-                  >
-                    {label}
-                    {sort &&
+        )
+      }
+      <Table className={classes.table}>
+        <TableHead>
+          <TableRow>
+            {columns.map(({ label, cellProps = {}, sort }, i) => {
+              const { className = '', ...otherProps } = cellProps;
+              return (
+                <TableCell
+                  key={`tabletitle_${i}`}
+                  className={classes.headerCell + ' ' + className}
+                  {...otherProps}
+                >
+                  {label}
+                  {sort && (
                     <ColumnSortButtons
                       isIncreasingOrder={Boolean(isIncreasingOrder)}
                       isDefaultSorted={sortColIndex === i}
@@ -253,61 +262,56 @@ export default function SimpleTable(props: SimpleTableProps) {
                         sortClickHandler(isIncreasingOrder, i)
                       }
                     />
-                    }
-                  </TableCell>
-                );
-              })}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredData.length > 0 ?
-              getPagedRows().map((row: any, i: number) =>
-                <TableRow key={i}>
-                  {columns.map((col, i) =>
-                    <TableCell key={`cell_${i}`}>
-                      {i === 0 && row.color &&
+                  )}
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {filteredData.length > 0 ? (
+            getPagedRows().map((row: any, i: number) => (
+              <TableRow key={i}>
+                {columns.map((col, i) => (
+                  <TableCell key={`cell_${i}`}>
+                    {i === 0 && row.color && (
                       <React.Fragment>
-                        <InlineIcon
-                          icon={squareIcon}
-                          color={row.color}
-                          height="15"
-                          width="15"
-                        />
+                        <InlineIcon icon={squareIcon} color={row.color} height="15" width="15" />
                         &nbsp;
                       </React.Fragment>
-                      }
-                      { ('datum' in col) ? row[col.datum] : col.getter(row) }
-                    </TableCell>
-                  )}
-                </TableRow>
-              )
-              :
-              <TableRow>
-                <TableCell colSpan={columns.length}>
-                  <Empty>No data matching the filter criteria.</Empty>
-                </TableCell>
+                    )}
+                    {'datum' in col ? row[col.datum] : col.getter(row)}
+                  </TableCell>
+                ))}
               </TableRow>
-            }
-          </TableBody>
-        </Table>
-        {filteredData.length > rowsPerPageOptions[0] &&
-          <TablePagination
-            rowsPerPageOptions={rowsPerPageOptions}
-            component="div"
-            count={filteredData.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            backIconButtonProps={{
-              'aria-label': 'previous page',
-            }}
-            nextIconButtonProps={{
-              'aria-label': 'next page',
-            }}
-            onChangePage={handleChangePage}
-            onChangeRowsPerPage={handleChangeRowsPerPage}
-          />
-        }
-      </React.Fragment>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length}>
+                <Empty>No data matching the filter criteria.</Empty>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      {filteredData.length > rowsPerPageOptions[0] && (
+        <TablePagination
+          rowsPerPageOptions={rowsPerPageOptions}
+          component="div"
+          count={filteredData.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          backIconButtonProps={{
+            'aria-label': 'previous page',
+          }}
+          nextIconButtonProps={{
+            'aria-label': 'next page',
+          }}
+          onChangePage={handleChangePage}
+          onChangeRowsPerPage={handleChangeRowsPerPage}
+        />
+      )}
+    </React.Fragment>
   );
 }
 
@@ -331,9 +335,9 @@ const useStyles = makeStyles(theme => ({
         '& .MuiTableCell-root': {
           borderBottom: 'none',
         },
-      }
-    }
-  }
+      },
+    },
+  },
 }));
 
 export interface NameValueTableRow {
@@ -353,20 +357,13 @@ export function NameValueTable(props: NameValueTableProps) {
   return (
     <Table className={classes.table}>
       <TableBody>
-        {rows.map(({name, value, hide = false}, i) => {
-          if (hide)
-            return null;
+        {rows.map(({ name, value, hide = false }, i) => {
+          if (hide) return null;
           return (
             <TableRow key={i}>
-              <TableCell className={classes.metadataNameCell}>
-                {name}
-              </TableCell>
+              <TableCell className={classes.metadataNameCell}>{name}</TableCell>
               <TableCell scope="row" className={classes.metadataCell}>
-                {(typeof value === 'string') ?
-                  <ValueLabel>{value}</ValueLabel>
-                  :
-                  value
-                }
+                {typeof value === 'string' ? <ValueLabel>{value}</ValueLabel> : value}
               </TableCell>
             </TableRow>
           );

--- a/frontend/src/components/common/Tab.tsx
+++ b/frontend/src/components/common/Tab.tsx
@@ -25,14 +25,10 @@ export interface TabsProps {
 }
 
 export default function Tabs(props: TabsProps) {
-  const {
-    tabs,
-    tabProps = {},
-    defaultIndex = 0,
-    onTabChanged = null
-  } = props;
+  const { tabs, tabProps = {}, defaultIndex = 0, onTabChanged = null } = props;
   const [tabIndex, setTabIndex] = React.useState<TabsProps['defaultIndex']>(
-    defaultIndex && Math.min(defaultIndex as number, 0));
+    defaultIndex && Math.min(defaultIndex as number, 0)
+  );
 
   function handleTabChange(event: any, newValue: number) {
     setTabIndex(newValue);
@@ -40,17 +36,19 @@ export default function Tabs(props: TabsProps) {
     if (onTabChanged !== null) {
       onTabChanged(newValue);
     }
-  };
+  }
 
-  React.useEffect(() => {
-    if (defaultIndex === null) {
-      setTabIndex(false);
-      return;
-    }
-    setTabIndex(defaultIndex);
-  },
-  // eslint-disable-next-line
-  [defaultIndex])
+  React.useEffect(
+    () => {
+      if (defaultIndex === null) {
+        setTabIndex(false);
+        return;
+      }
+      setTabIndex(defaultIndex);
+    },
+    // eslint-disable-next-line
+    [defaultIndex]
+  );
 
   return (
     <React.Fragment>
@@ -62,23 +60,15 @@ export default function Tabs(props: TabsProps) {
         aria-label="full width tabs example"
         {...tabProps}
       >
-        {tabs.map(({label}, i) =>
-          <Tab
-            key={i}
-            label={label}
-            {...a11yProps(i)}
-          />
-        )}
+        {tabs.map(({ label }, i) => (
+          <Tab key={i} label={label} {...a11yProps(i)} />
+        ))}
       </MuiTabs>
-      {tabs.map(({component}, i) =>
-        <TabPanel
-          key={i}
-          tabIndex={Number(tabIndex)}
-          index={i}
-        >
+      {tabs.map(({ component }, i) => (
+        <TabPanel key={i} tabIndex={Number(tabIndex)} index={i}>
           {component}
         </TabPanel>
-      )}
+      ))}
     </React.Fragment>
   );
 }

--- a/frontend/src/components/common/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs.stories.tsx
@@ -8,7 +8,7 @@ export default {
   argTypes: { onTabChanged: { action: 'tab changed' } },
 } as Meta;
 
-const Template: Story<TabsProps> = (args) => <Tabs {...args} />;
+const Template: Story<TabsProps> = args => <Tabs {...args} />;
 
 export const BasicTabs = Template.bind({});
 BasicTabs.args = {

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -24,7 +24,7 @@ const useStyle = makeStyles(theme => ({
   },
   containerFormControl: {
     minWidth: '11rem',
-  }
+  },
 }));
 
 interface TerminalProps extends DialogProps {
@@ -39,7 +39,7 @@ export default function Terminal(props: TerminalProps) {
   const [container, setContainer] = React.useState<string | null>(null);
 
   function getDefaultContainer() {
-    return (item.spec.containers.length > 0) ? item.spec.containers[0].name : '';
+    return item.spec.containers.length > 0 ? item.spec.containers[0].name : '';
   }
 
   // @todo: Give the real exec type when we have it.
@@ -94,63 +94,54 @@ export default function Terminal(props: TerminalProps) {
     xterm.write(text);
   }
 
-  React.useEffect(() => {
-    // We need a valid container ref for the terminal to add itself to it.
-    if (terminalContainerRef === null) {
-      return;
-    }
+  React.useEffect(
+    () => {
+      // We need a valid container ref for the terminal to add itself to it.
+      if (terminalContainerRef === null) {
+        return;
+      }
 
-    // Don't do anything until the pod's container is assigned. We used the pod's late
-    // assignment to prevent calling exec before the dialog is opened.
-    if (container === null) {
-      return;
-    }
+      // Don't do anything until the pod's container is assigned. We used the pod's late
+      // assignment to prevent calling exec before the dialog is opened.
+      if (container === null) {
+        return;
+      }
 
-    const xterm = new XTerminal({rows: 40, cols: 80});
-    xterm.writeln('Connecting…\n');
+      const xterm = new XTerminal({ rows: 40, cols: 80 });
+      xterm.writeln('Connecting…\n');
 
-    const exec = item.exec(container, (items: ArrayBuffer) => onData(xterm, items));
+      const exec = item.exec(container, (items: ArrayBuffer) => onData(xterm, items));
 
-    setupTerminal(terminalContainerRef, xterm, exec);
+      setupTerminal(terminalContainerRef, xterm, exec);
 
-    return function cleanup() {
-      xterm.dispose();
-      exec.cancel();
-    };
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [container, terminalContainerRef]);
+      return function cleanup() {
+        xterm.dispose();
+        exec.cancel();
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [container, terminalContainerRef]
+  );
 
-  React.useEffect(() => {
-    if (props.open && container === null) {
-      setContainer(getDefaultContainer());
-    }
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [props.open]);
+  React.useEffect(
+    () => {
+      if (props.open && container === null) {
+        setContainer(getDefaultContainer());
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [props.open]
+  );
 
   function handleContainerChange(event: any) {
     setContainer(event.target.value);
   }
 
   return (
-    <Dialog
-      maxWidth="lg"
-      scroll="paper"
-      fullWidth
-      onBackdropClick={onClose}
-      keepMounted
-      {...other}
-    >
+    <Dialog maxWidth="lg" scroll="paper" fullWidth onBackdropClick={onClose} keepMounted {...other}>
       <DialogTitle>Terminal: {item.metadata.name}</DialogTitle>
-      <DialogContent
-        className={classes.dialogContent}
-      >
-        <Grid
-          container
-          direction="column"
-          spacing={1}
-        >
+      <DialogContent className={classes.dialogContent}>
+        <Grid container direction="column" spacing={1}>
           <Grid item>
             <FormControl className={classes.containerFormControl}>
               <InputLabel shrink id="container-name-chooser-label">
@@ -159,25 +150,25 @@ export default function Terminal(props: TerminalProps) {
               <Select
                 labelId="container-name-chooser-label"
                 id="container-name-chooser"
-                value={ container !== null ? container : getDefaultContainer() }
+                value={container !== null ? container : getDefaultContainer()}
                 onChange={handleContainerChange}
               >
-                {item && item.spec.containers.map(({name}) =>
-                  <MenuItem value={name} key={name}>{name}</MenuItem>
-                )}
+                {item &&
+                  item.spec.containers.map(({ name }) => (
+                    <MenuItem value={name} key={name}>
+                      {name}
+                    </MenuItem>
+                  ))}
               </Select>
             </FormControl>
           </Grid>
           <Grid item>
-            <div id='xterm' ref={x => setTerminalContainerRef(x)} className='terminal' />
+            <div id="xterm" ref={x => setTerminalContainerRef(x)} className="terminal" />
           </Grid>
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button
-          onClick={onClose}
-          color="primary"
-        >
+        <Button onClick={onClose} color="primary">
           Close
         </Button>
       </DialogActions>

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -33,12 +33,9 @@ export function TooltipIcon(props: TooltipIconProps) {
   const classes = useContainerStyles({});
   const { children, icon = informationOutline } = props;
 
-  const IconReffed = React.forwardRef((props: IconifyIcon, ref:any) => {
+  const IconReffed = React.forwardRef((props: IconifyIcon, ref: any) => {
     return (
-      <Container
-        ref={ref}
-        className={classes.container}
-      >
+      <Container ref={ref} className={classes.container}>
         <Icon {...props} />
       </Container>
     );

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -19,4 +19,3 @@ export { default as Tab } from './Tab';
 export * from './Terminal';
 export { default as Terminal } from './Terminal';
 export * from './Tooltip';
-

--- a/frontend/src/components/configmap/Details.tsx
+++ b/frontend/src/components/configmap/Details.tsx
@@ -14,19 +14,21 @@ export default function ConfigDetails() {
 
   ConfigMap.useApiGet(setItem, name, namespace);
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
       <MainInfoSection resource={item} />
       <SectionBox title="Data">
-        {!itemData ?
+        {!itemData ? (
           <Empty>No data in this config map</Empty>
-          : Object.keys(itemData).map((key, i) =>
+        ) : (
+          Object.keys(itemData).map((key, i) => (
             <Box py={2} key={i}>
               <DataField label={key} value={itemData[key]} />
             </Box>
-          )
-        }
+          ))
+        )}
       </SectionBox>
     </PageGrid>
   );

--- a/frontend/src/components/configmap/List.tsx
+++ b/frontend/src/components/configmap/List.tsx
@@ -11,13 +11,7 @@ export default function ConfigMapList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Config Maps"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Config Maps" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -25,8 +19,7 @@ export default function ConfigMapList() {
         columns={[
           {
             label: 'Name',
-            getter: (configMap) =>
-              <Link kubeObject={configMap} />,
+            getter: configMap => <Link kubeObject={configMap} />,
             sort: (c1: ConfigMap, c2: ConfigMap) => {
               if (c1.metadata.name < c2.metadata.name) {
                 return -1;
@@ -34,18 +27,18 @@ export default function ConfigMapList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (configMap) => configMap.getNamespace(),
+            getter: configMap => configMap.getNamespace(),
           },
           {
             label: 'Age',
-            getter: (configMap) => configMap.getAge(),
+            getter: configMap => configMap.getAge(),
             sort: (c1: ConfigMap, c2: ConfigMap) =>
               new Date(c2.metadata.creationTimestamp).getTime() -
-              new Date(c1.metadata.creationTimestamp).getTime()
+              new Date(c1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={configMaps}

--- a/frontend/src/components/crd/Details.tsx
+++ b/frontend/src/components/crd/Details.tsx
@@ -24,8 +24,8 @@ function getAPIForCRD(item: KubeCRD) {
 
 const useStyle = makeStyles({
   link: {
-    cursor: 'pointer'
-  }
+    cursor: 'pointer',
+  },
 });
 
 export default function CustomResourceDefinitionDetails() {
@@ -43,39 +43,40 @@ export default function CustomResourceDefinitionDetails() {
       promise = getAPIForCRD(item.jsonData).list(setObjects);
     }
 
-    return function cleanup () {
+    return function cleanup() {
       if (promise) {
         promise.then((cancellable: () => void) => cancellable());
       }
     };
-  },
-  [item]);
+  }, [item]);
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
       <MainInfoSection
         resource={item}
-
-        extraInfo={item && [
-          {
-            name: 'Group',
-            value: item.spec.group,
-          },
-          {
-            name: 'Version',
-            value: item.spec.version,
-          },
-          {
-            name: 'Scope',
-            value: item.spec.scope,
-          },
-          {
-            name: 'Subresources',
-            value: item.spec.subresources && Object.keys(item.spec.subresources).join(' & '),
-            hide: !item.spec.subresources
-          },
-        ]}
+        extraInfo={
+          item && [
+            {
+              name: 'Group',
+              value: item.spec.group,
+            },
+            {
+              name: 'Version',
+              value: item.spec.version,
+            },
+            {
+              name: 'Scope',
+              value: item.spec.scope,
+            },
+            {
+              name: 'Subresources',
+              value: item.spec.subresources && Object.keys(item.spec.subresources).join(' & '),
+              hide: !item.spec.subresources,
+            },
+          ]
+        }
       />
       <SectionBox title="Accepted Names">
         <SimpleTable
@@ -83,7 +84,7 @@ export default function CustomResourceDefinitionDetails() {
           columns={[
             {
               label: 'Plural',
-              datum: 'plural'
+              datum: 'plural',
             },
             {
               label: 'Singular',
@@ -96,7 +97,7 @@ export default function CustomResourceDefinitionDetails() {
             {
               label: 'List Kind',
               datum: 'listKind',
-            }
+            },
           ]}
         />
       </SectionBox>
@@ -106,7 +107,7 @@ export default function CustomResourceDefinitionDetails() {
           columns={[
             {
               label: 'Name',
-              datum: 'name'
+              datum: 'name',
             },
             {
               label: 'Served',
@@ -115,15 +116,12 @@ export default function CustomResourceDefinitionDetails() {
             {
               label: 'Storage',
               getter: version => version.storage.toString(),
-            }
+            },
           ]}
         />
       </SectionBox>
       <SectionBox title="Conditions">
-        <ConditionsTable
-          resource={item.jsonData}
-          showLastUpdate={false}
-        />
+        <ConditionsTable resource={item.jsonData} showLastUpdate={false} />
       </SectionBox>
       <SectionBox title="Objects">
         <SimpleTable
@@ -131,13 +129,11 @@ export default function CustomResourceDefinitionDetails() {
           columns={[
             {
               label: 'Name',
-              getter: obj =>
-                <Link
-                  className={classes.link}
-                  onClick={() => setObjToShow(obj)}
-                >
+              getter: obj => (
+                <Link className={classes.link} onClick={() => setObjToShow(obj)}>
                   {obj.metadata.name}
                 </Link>
+              ),
             },
             {
               label: 'Namespace',
@@ -146,15 +142,11 @@ export default function CustomResourceDefinitionDetails() {
             {
               label: 'Created',
               getter: obj => timeAgo(obj.metadata.creationTimestamp),
-            }
+            },
           ]}
         />
       </SectionBox>
-      <ViewDialog
-        item={objToShow}
-        open={!!objToShow}
-        onClose={() => setObjToShow(null)}
-      />
+      <ViewDialog item={objToShow} open={!!objToShow} onClose={() => setObjToShow(null)} />
     </PageGrid>
   );
 }

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -12,12 +12,7 @@ export default function CustomResourceDefinitionList() {
 
   return (
     <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Custom Resource Definitions"
-          noNamespaceFilter
-        />
-      }
+      title={<SectionFilterHeader title="Custom Resource Definitions" noNamespaceFilter />}
     >
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
@@ -26,7 +21,7 @@ export default function CustomResourceDefinitionList() {
         columns={[
           {
             label: 'Name',
-            getter: (crd) =>
+            getter: crd => (
               <Link
                 routeName="crd"
                 params={{
@@ -35,18 +30,19 @@ export default function CustomResourceDefinitionList() {
               >
                 {crd.spec.names.kind}
               </Link>
+            ),
           },
           {
             label: 'Group',
-            getter: (crd) => crd.spec.group
+            getter: crd => crd.spec.group,
           },
           {
             label: 'Scope',
-            getter: (crd) => crd.spec.scope
+            getter: crd => crd.spec.scope,
           },
           {
             label: 'Full name',
-            getter: (crd) => crd.metadata.name,
+            getter: crd => crd.metadata.name,
             sort: (c1: CRD, c2: CRD) => {
               if (c1.metadata.name < c2.metadata.name) {
                 return -1;
@@ -54,14 +50,14 @@ export default function CustomResourceDefinitionList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Age',
-            getter: (crd) => timeAgo(crd.metadata.creationTimestamp),
-            sort: (c1: CRD, c2:CRD) =>
+            getter: crd => timeAgo(crd.metadata.creationTimestamp),
+            sort: (c1: CRD, c2: CRD) =>
               new Date(c2.metadata.creationTimestamp).getTime() -
-              new Date(c1.metadata.creationTimestamp).getTime()
+              new Date(c1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={crds}

--- a/frontend/src/components/cronjob/List.tsx
+++ b/frontend/src/components/cronjob/List.tsx
@@ -11,7 +11,7 @@ export default function CronJobList() {
   const filterFunc = useFilterFunc();
 
   function getSchedule(cronJob: CronJob) {
-    const {schedule} = cronJob.spec.schedule;
+    const { schedule } = cronJob.spec.schedule;
     if (!schedule.startsWith('@')) {
       return 'never';
     }
@@ -19,23 +19,16 @@ export default function CronJobList() {
   }
 
   function getLastScheduleTime(cronJob: CronJob) {
-    const {lastScheduleTime} = cronJob.status;
+    const { lastScheduleTime } = cronJob.status;
     if (!lastScheduleTime) {
       return 'N/A';
     }
     const oneDay = 24 * 60 * 60 * 1000;
     return `${new Date().getTime() - new Date(lastScheduleTime).getTime() / oneDay} days`;
-
   }
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Cron Jobs"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Cron Jobs" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -43,7 +36,7 @@ export default function CronJobList() {
         columns={[
           {
             label: 'Name',
-            getter: (cronJob) => <Link kubeObject={cronJob} />,
+            getter: cronJob => <Link kubeObject={cronJob} />,
             sort: (c1: CronJob, c2: CronJob) => {
               if (c1.metadata.name < c2.metadata.name) {
                 return -1;
@@ -51,31 +44,31 @@ export default function CronJobList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (cronJob) => cronJob.getNamespace()
+            getter: cronJob => cronJob.getNamespace(),
           },
           {
             label: 'Schedule',
-            getter: (cronJob) => getSchedule(cronJob)
+            getter: cronJob => getSchedule(cronJob),
           },
           {
             label: 'Suspend',
-            getter: (cronJob) => cronJob.spec.schedule.toString()
+            getter: cronJob => cronJob.spec.schedule.toString(),
           },
           {
             label: 'Last Schedule',
-            getter: (cronJob) => getLastScheduleTime(cronJob)
+            getter: cronJob => getLastScheduleTime(cronJob),
           },
           {
             label: 'Age',
-            getter: (cronJob) => cronJob.getAge(),
+            getter: cronJob => cronJob.getAge(),
             sort: (c1: CronJob, c2: CronJob) =>
               new Date(c2.metadata.creationTimestamp).getTime() -
-              new Date(c1.metadata.creationTimestamp).getTime()
-          }
+              new Date(c1.metadata.creationTimestamp).getTime(),
+          },
         ]}
         data={cronJobs}
         defaultSortingColumn={6}

--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -13,20 +13,20 @@ export default function DaemonSetDetails() {
     <PageGrid>
       <MainInfoSection
         resource={item}
-        extraInfo={item && [
-          {
-            name: 'Update Strategy',
-            value: item?.spec.updateStrategy.type,
-          },
-          {
-            name: 'Selector',
-            value: <MetadataDictGrid dict={item.spec.selector.matchLabels || {}} />,
-          },
-        ]}
+        extraInfo={
+          item && [
+            {
+              name: 'Update Strategy',
+              value: item?.spec.updateStrategy.type,
+            },
+            {
+              name: 'Selector',
+              value: <MetadataDictGrid dict={item.spec.selector.matchLabels || {}} />,
+            },
+          ]
+        }
       />
-      <ContainersSection
-        resource={item?.jsonData}
-      />
+      <ContainersSection resource={item?.jsonData} />
     </PageGrid>
   );
 }

--- a/frontend/src/components/daemonset/List.tsx
+++ b/frontend/src/components/daemonset/List.tsx
@@ -11,13 +11,7 @@ export default function DaemonSetList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Daemon Sets"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Daemon Sets" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -25,7 +19,7 @@ export default function DaemonSetList() {
         columns={[
           {
             label: 'Name',
-            getter: (daemonSet) => <Link kubeObject={daemonSet} />,
+            getter: daemonSet => <Link kubeObject={daemonSet} />,
             sort: (d1: DaemonSet, d2: DaemonSet) => {
               if (d1.metadata.name < d2.metadata.name) {
                 return -1;
@@ -33,22 +27,22 @@ export default function DaemonSetList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (daemonSet) => daemonSet.getNamespace()
+            getter: daemonSet => daemonSet.getNamespace(),
           },
           {
             label: 'Pods',
-            getter: (daemonSet) => daemonSet.status.currentNumberScheduled
+            getter: daemonSet => daemonSet.status.currentNumberScheduled,
           },
           {
             label: 'Age',
-            getter: (daemonSet) => daemonSet.getAge(),
+            getter: daemonSet => daemonSet.getAge(),
             sort: (d1: DaemonSet, d2: DaemonSet) =>
               new Date(d2.metadata.creationTimestamp).getTime() -
-              new Date(d1.metadata.creationTimestamp).getTime()
+              new Date(d1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={daemonSets}

--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -18,40 +18,37 @@ export default function DeploymentsList() {
   }
 
   function renderConditions(deployment: Deployment) {
-    const {conditions} = deployment.status;
+    const { conditions } = deployment.status;
     if (!conditions) {
       return null;
     }
 
-    return conditions.sort((c1: any, c2: any) => {
-      if (c1.type < c2.type) {
-        return -1;
-      } else if (c1.type > c2.type) {
-        return 1;
-      } else {
-        return 0;
-      }
-    }).map((condition: any) => {
-      const {type, message} = condition;
-      return (
-        <Box pr={0.5} display="inline-block">
-          <StatusLabel status=''>
-            <span title={message} key={type}>
-              {type}
-            </span>
-          </StatusLabel>
-        </Box>);
-    });
+    return conditions
+      .sort((c1: any, c2: any) => {
+        if (c1.type < c2.type) {
+          return -1;
+        } else if (c1.type > c2.type) {
+          return 1;
+        } else {
+          return 0;
+        }
+      })
+      .map((condition: any) => {
+        const { type, message } = condition;
+        return (
+          <Box pr={0.5} display="inline-block">
+            <StatusLabel status="">
+              <span title={message} key={type}>
+                {type}
+              </span>
+            </StatusLabel>
+          </Box>
+        );
+      });
   }
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Deployments"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Deployments" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -59,7 +56,7 @@ export default function DeploymentsList() {
         columns={[
           {
             label: 'Name',
-            getter: (deployment) => <Link kubeObject={deployment} />,
+            getter: deployment => <Link kubeObject={deployment} />,
             sort: (d1: Deployment, d2: Deployment) => {
               if (d1.metadata.name < d2.metadata.name) {
                 return -1;
@@ -67,30 +64,30 @@ export default function DeploymentsList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (deployment) => deployment.getNamespace()
+            getter: deployment => deployment.getNamespace(),
           },
           {
             label: 'Pods',
-            getter: (deployment) => renderPods(deployment)
+            getter: deployment => renderPods(deployment),
           },
           {
             label: 'Replicas',
-            getter: (deployment) => deployment.spec.replicas || 0
+            getter: deployment => deployment.spec.replicas || 0,
           },
           {
             label: 'Conditions',
-            getter: (deployment) => renderConditions(deployment)
+            getter: deployment => renderConditions(deployment),
           },
           {
             label: 'Age',
-            getter: (deployment) => deployment.getAge(),
+            getter: deployment => deployment.getAge(),
             sort: (d1: Deployment, d2: Deployment) =>
               new Date(d2.metadata.creationTimestamp).getTime() -
-              new Date(d1.metadata.creationTimestamp).getTime()
+              new Date(d1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={deployments}

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -21,21 +21,20 @@ export default function IngressDetails() {
         servicePort: string;
       };
     }[] = [];
-    item?.spec.rules.forEach(({host, http}) => {
+    item?.spec.rules.forEach(({ host, http }) => {
       http.paths.forEach(pathData => {
-        data.push({...pathData, host: host});
+        data.push({ ...pathData, host: host });
       });
     });
 
     return data;
   }
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
-      <MainInfoSection
-        resource={item}
-      />
+      <MainInfoSection resource={item} />
       <SectionBox title="Rules">
         <SimpleTable
           rowsPerPage={[15, 25, 50]}
@@ -43,19 +42,19 @@ export default function IngressDetails() {
           columns={[
             {
               label: 'Host',
-              getter: (data) => data.host
+              getter: data => data.host,
             },
             {
               label: 'Path',
-              getter: (data) => data.path || ''
+              getter: data => data.path || '',
             },
             {
               label: 'Service',
-              getter: (data) => data.backend.serviceName
+              getter: data => data.backend.serviceName,
             },
             {
               label: 'Port',
-              getter: (data) => data.backend.servicePort
+              getter: data => data.backend.servicePort,
             },
           ]}
           data={getHostsData()}

--- a/frontend/src/components/ingress/List.tsx
+++ b/frontend/src/components/ingress/List.tsx
@@ -11,13 +11,7 @@ export default function IngressList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Ingresses"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Ingresses" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -25,31 +19,30 @@ export default function IngressList() {
         columns={[
           {
             label: 'Name',
-            getter: (ingress) =>
-              <Link kubeObject={ingress} />,
+            getter: ingress => <Link kubeObject={ingress} />,
             sort: (i1: Ingress, i2: Ingress) => {
               if (i1.metadata.name < i2.metadata.name) {
                 return -1;
-              } else if (i1.metadata.name > i2.metadata.name){
+              } else if (i1.metadata.name > i2.metadata.name) {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (ingress) => ingress.getNamespace()
+            getter: ingress => ingress.getNamespace(),
           },
           {
             label: 'Hosts',
-            getter: (ingress) => ingress.getHosts()
+            getter: ingress => ingress.getHosts(),
           },
           {
             label: 'Age',
-            getter: (ingress) => timeAgo(ingress.metadata.creationTimestamp),
-            sort: (i1: Ingress, i2:Ingress) =>
+            getter: ingress => timeAgo(ingress.metadata.creationTimestamp),
+            sort: (i1: Ingress, i2: Ingress) =>
               new Date(i2.metadata.creationTimestamp).getTime() -
-              new Date(i1.metadata.creationTimestamp).getTime()
+              new Date(i1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={ingresses}

--- a/frontend/src/components/job/List.tsx
+++ b/frontend/src/components/job/List.tsx
@@ -15,22 +15,16 @@ export default function JobsList() {
   }
 
   function getCondition(job: Job) {
-    const {conditions} = job.status;
+    const { conditions } = job.status;
     if (!conditions) {
       return null;
     }
 
-    return conditions.find(({status}: {status: string}) => status === 'True').type;
+    return conditions.find(({ status }: { status: string }) => status === 'True').type;
   }
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Jobs"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Jobs" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -38,7 +32,7 @@ export default function JobsList() {
         columns={[
           {
             label: 'Name',
-            getter: (job) => <Link kubeObject={job} />,
+            getter: job => <Link kubeObject={job} />,
             sort: (j1: Job, j2: Job) => {
               if (j1.metadata.name < j2.metadata.name) {
                 return -1;
@@ -46,27 +40,27 @@ export default function JobsList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (job) => job.getNamespace()
+            getter: job => job.getNamespace(),
           },
           {
             label: 'Completions',
-            getter: (job) => getCompletions(job)
+            getter: job => getCompletions(job),
           },
           {
             label: 'Conditions',
-            getter: (job) => getCondition(job)
+            getter: job => getCondition(job),
           },
           {
             label: 'Age',
-            getter: (job) => job.getAge(),
+            getter: job => job.getAge(),
             sort: (j1: Job, j2: Job) =>
               new Date(j2.metadata.creationTimestamp).getTime() -
-              new Date(j1.metadata.creationTimestamp).getTime()
-          }
+              new Date(j1.metadata.creationTimestamp).getTime(),
+          },
         ]}
         data={jobs}
         defaultSortingColumn={5}

--- a/frontend/src/components/namespace/Details.tsx
+++ b/frontend/src/components/namespace/Details.tsx
@@ -12,20 +12,20 @@ export default function NamespaceDetails() {
 
   function makeStatusLabel(namespace: Namespace | null) {
     const status = namespace?.status.phase;
-    return (
-      <StatusLabel status={status === 'Active' ? 'success' : 'error'}>
-        {status}
-      </StatusLabel>
-    );
+    return <StatusLabel status={status === 'Active' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && [{
-        name: 'Status',
-        value: makeStatusLabel(item),
-      }]}
+      extraInfo={
+        item && [
+          {
+            name: 'Status',
+            value: makeStatusLabel(item),
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -13,22 +13,12 @@ export default function NamespacesList() {
 
   function makeStatusLabel(namespace: Namespace) {
     const status = namespace.status.phase;
-    return (
-      <StatusLabel status={status === 'Active' ? 'success' : 'error'}>
-        {status}
-      </StatusLabel>
-    );
+    return <StatusLabel status={status === 'Active' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
   return (
     <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Namespaces"
-          noNamespaceFilter
-          headerStyle="main"
-        />
-      }
+      title={<SectionFilterHeader title="Namespaces" noNamespaceFilter headerStyle="main" />}
     >
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
@@ -37,8 +27,7 @@ export default function NamespacesList() {
         columns={[
           {
             label: 'Name',
-            getter: (namespace) =>
-              <Link kubeObject={namespace} />,
+            getter: namespace => <Link kubeObject={namespace} />,
             sort: (n1: Namespace, n2: Namespace) => {
               if (n1.metadata.name < n2.metadata.name) {
                 return -1;
@@ -46,18 +35,18 @@ export default function NamespacesList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Status',
-            getter: makeStatusLabel
+            getter: makeStatusLabel,
           },
           {
             label: 'Age',
-            getter: (namespace) => namespace.getAge(),
+            getter: namespace => namespace.getAge(),
             sort: (n1: Namespace, n2: Namespace) =>
               new Date(n2.metadata.creationTimestamp).getTime() -
-              new Date(n1.metadata.creationTimestamp).getTime()
+              new Date(n1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={namespaces}

--- a/frontend/src/components/node/Charts.tsx
+++ b/frontend/src/components/node/Charts.tsx
@@ -9,7 +9,7 @@ import { PercentageBar } from '../common/Chart';
 interface UsageBarChartProps {
   node: Node;
   nodeMetrics: KubeMetrics[] | null;
-  resourceType: keyof (KubeMetrics['usage']);
+  resourceType: keyof KubeMetrics['usage'];
   noMetrics?: boolean;
 }
 
@@ -31,22 +31,18 @@ export function UsageBarChart(props: UsageBarChartProps) {
   function tooltipFunc() {
     return (
       <Typography>
-        {getResourceStr(used, resourceType)} of {getResourceStr(capacity, resourceType)}{' '}
-        ({getPercentStr(used, capacity)})
+        {getResourceStr(used, resourceType)} of {getResourceStr(capacity, resourceType)} (
+        {getPercentStr(used, capacity)})
       </Typography>
     );
   }
 
-  return ( noMetrics ?
+  return noMetrics ? (
     <>
-      <Typography display="inline" >{getResourceStr(capacity, resourceType)}</Typography>
+      <Typography display="inline">{getResourceStr(capacity, resourceType)}</Typography>
       <TooltipIcon>Install the metrics-server to get usage data.</TooltipIcon>
     </>
-    :
-    <PercentageBar
-      data={data}
-      total={capacity}
-      tooltipFunc={tooltipFunc}
-    />
+  ) : (
+    <PercentageBar data={data} total={capacity} tooltipFunc={tooltipFunc} />
   );
 }

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -24,7 +24,7 @@ export default function NodeDetails() {
   const noMetrics = metricsError?.status === 404;
 
   function getAddresses(item: Node) {
-    return item.status.addresses.map(({type, address}) => {
+    return item.status.addresses.map(({ type, address }) => {
       return {
         name: type,
         value: address,
@@ -32,30 +32,26 @@ export default function NodeDetails() {
     });
   }
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
       <MainInfoSection
-
-        headerSection={
-          <ChartsSection
-            node={item}
-            metrics={nodeMetrics}
-            noMetrics={noMetrics}
-          />
-        }
+        headerSection={<ChartsSection node={item} metrics={nodeMetrics} noMetrics={noMetrics} />}
         resource={item}
-        extraInfo={item && [
-          {
-            name: 'Ready',
-            value: <NodeReadyLabel node={item} />
-          },
-          {
-            name: 'Pod CIDR',
-            value: item.spec.podCIDR,
-          },
-          ...getAddresses(item)
-        ]}
+        extraInfo={
+          item && [
+            {
+              name: 'Ready',
+              value: <NodeReadyLabel node={item} />,
+            },
+            {
+              name: 'Pod CIDR',
+              value: item.spec.podCIDR,
+            },
+            ...getAddresses(item),
+          ]
+        }
       />
       <SystemInfoSection node={item} />
     </PageGrid>
@@ -76,9 +72,9 @@ function ChartsSection(props: ChartsSectionProps) {
       return '…';
     }
 
-    const readyInfo = node.status.conditions.find(({type}) => type === 'Ready');
+    const readyInfo = node.status.conditions.find(({ type }) => type === 'Ready');
     if (readyInfo) {
-      return timeAgo((readyInfo.lastTransitionTime as string));
+      return timeAgo(readyInfo.lastTransitionTime as string);
     }
 
     return 'Not ready yet!';
@@ -90,21 +86,14 @@ function ChartsSection(props: ChartsSectionProps) {
         container
         justify="space-around"
         style={{
-          marginBottom: '2rem'
+          marginBottom: '2rem',
         }}
       >
         <Grid item>
-          <HeaderLabel
-            value={getUptime()}
-            label="Uptime"
-          />
+          <HeaderLabel value={getUptime()} label="Uptime" />
         </Grid>
         <Grid item>
-          <CpuCircularChart
-            items={node && [node]}
-            itemsMetrics={metrics}
-            noMetrics={noMetrics}
-          />
+          <CpuCircularChart items={node && [node]} itemsMetrics={metrics} noMetrics={noMetrics} />
         </Grid>
         <Grid item>
           <MemoryCircularChart
@@ -146,15 +135,15 @@ function SystemInfoSection(props: SystemInfoSectionProps) {
         rows={[
           {
             name: 'Architecture',
-            value: node.status.nodeInfo.architecture
+            value: node.status.nodeInfo.architecture,
           },
           {
             name: 'Boot ID',
-            value: node.status.nodeInfo.bootID
+            value: node.status.nodeInfo.bootID,
           },
           {
             name: 'System UUID',
-            value: node.status.nodeInfo.systemUUID
+            value: node.status.nodeInfo.systemUUID,
           },
           {
             name: 'OS',
@@ -162,7 +151,7 @@ function SystemInfoSection(props: SystemInfoSectionProps) {
           },
           {
             name: 'Image',
-            value: node.status.nodeInfo.osImage
+            value: node.status.nodeInfo.osImage,
           },
           {
             name: 'Kernel Version',
@@ -174,15 +163,15 @@ function SystemInfoSection(props: SystemInfoSectionProps) {
           },
           {
             name: 'Kube Proxy Version',
-            value: node.status.nodeInfo.kubeProxyVersion
+            value: node.status.nodeInfo.kubeProxyVersion,
           },
           {
             name: 'Kubelet Version',
-            value: node.status.nodeInfo.kubeletVersion
+            value: node.status.nodeInfo.kubeletVersion,
           },
           {
             name: 'Container Runtime Version',
-            value: node.status.nodeInfo.containerRuntimeVersion
+            value: node.status.nodeInfo.containerRuntimeVersion,
           },
         ]}
       />
@@ -196,8 +185,9 @@ interface NodeReadyLabelProps {
 
 export function NodeReadyLabel(props: NodeReadyLabelProps) {
   const { node } = props;
-  const isReady = !!node.status.conditions
-    .find(condition => condition.type === 'Ready' && condition.status === 'True');
+  const isReady = !!node.status.conditions.find(
+    condition => condition.type === 'Ready' && condition.status === 'True'
+  );
 
   let status: StatusLabelProps['status'] = '';
   let label = null;
@@ -209,9 +199,5 @@ export function NodeReadyLabel(props: NodeReadyLabelProps) {
     label = 'No';
   }
 
-  return (
-    <StatusLabel status={status}>
-      {label}
-    </StatusLabel>
-  );
+  return <StatusLabel status={status}>{label}</StatusLabel>;
 }

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -24,14 +24,7 @@ export default function NodeList() {
   const noMetrics = metricsError?.status === 404;
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Nodes"
-          noNamespaceFilter
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Nodes" noNamespaceFilter />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -39,7 +32,7 @@ export default function NodeList() {
         columns={[
           {
             label: 'Name',
-            getter: (node) => <Link kubeObject={node} />,
+            getter: node => <Link kubeObject={node} />,
             sort: (n1: Node, n2: Node) => {
               if (n1.metadata.name < n2.metadata.name) {
                 return -1;
@@ -47,44 +40,46 @@ export default function NodeList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Ready',
-            getter: (node) => <NodeReadyLabel node={node} />
+            getter: node => <NodeReadyLabel node={node} />,
           },
           {
             label: 'CPU',
             cellProps: {
               className: classes.chartCell,
             },
-            getter: (node) =>
+            getter: node => (
               <UsageBarChart
                 node={node}
                 nodeMetrics={nodeMetrics}
                 resourceType="cpu"
                 noMetrics={noMetrics}
               />
+            ),
           },
           {
             label: 'Memory',
             cellProps: {
               className: classes.chartCell,
             },
-            getter: (node) =>
+            getter: node => (
               <UsageBarChart
                 node={node}
                 nodeMetrics={nodeMetrics}
                 resourceType="memory"
                 noMetrics={noMetrics}
               />
+            ),
           },
           {
             label: 'Age',
-            getter: (node) => node.getAge(),
-            sort: (n1: Node, n2:Node) =>
+            getter: node => node.getAge(),
+            sort: (n1: Node, n2: Node) =>
               new Date(n2.metadata.creationTimestamp).getTime() -
-              new Date(n1.metadata.creationTimestamp).getTime()
+              new Date(n1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={nodes}

--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -15,34 +15,32 @@ const defaultOauthPopupProps = {
   width: 500,
   height: 500,
   url: '',
-  title: ''
+  title: '',
 };
 
-const OauthPopup: React.FC<OauthPopupProps> = (props) => {
+const OauthPopup: React.FC<OauthPopupProps> = props => {
   let externalWindow: Window | null;
 
-  React.useEffect(() => {
-    return () => {
-      if (externalWindow) {
-        externalWindow.close();
-      }
-    };
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  []);
+  React.useEffect(
+    () => {
+      return () => {
+        if (externalWindow) {
+          externalWindow.close();
+        }
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
   const createPopup = () => {
-    const {url, title, width, height, onCode} = {...defaultOauthPopupProps, ...props};
-    const left = window.screenX + (window.outerWidth - width as number) / 2;
-    const top = window.screenY + (window.outerHeight - height as number) / 2.5;
+    const { url, title, width, height, onCode } = { ...defaultOauthPopupProps, ...props };
+    const left = window.screenX + ((window.outerWidth - width) as number) / 2;
+    const top = window.screenY + ((window.outerHeight - height) as number) / 2.5;
 
     const windowFeatures = `toolbar=0,scrollbars=1,status=1,resizable=0,location=1,menuBar=0,width=${width},height=${height},top=${top},left=${left}`;
 
-    externalWindow = window.open(
-        url,
-        title,
-        windowFeatures
-    );
+    externalWindow = window.open(url, title, windowFeatures);
 
     const storageListener = () => {
       try {
@@ -65,22 +63,22 @@ const OauthPopup: React.FC<OauthPopupProps> = (props) => {
 
     if (externalWindow) {
       try {
-        externalWindow.addEventListener('beforeunload', () => {
-          if (!!props.onClose){
-            props.onClose();
-          }
-        }, false);
-      } catch (e){
+        externalWindow.addEventListener(
+          'beforeunload',
+          () => {
+            if (!!props.onClose) {
+              props.onClose();
+            }
+          },
+          false
+        );
+      } catch (e) {
         console.log('error occured while adding beforeunload event listener');
       }
     }
   };
 
-  return (
-    <div onClick={createPopup}>
-      {props.children}
-    </div>
-  );
+  return <div onClick={createPopup}>{props.children}</div>;
 };
 
 export default OauthPopup;

--- a/frontend/src/components/oidcauth/index.tsx
+++ b/frontend/src/components/oidcauth/index.tsx
@@ -12,9 +12,7 @@ const OIDCAuth: FunctionComponent<{}> = () => {
   localStorage.setItem('auth_status', 'success');
   setToken(cluster as string, token);
 
-  return (
-    <Typography color="textPrimary">Redirecting to main page.....</Typography>
-  );
+  return <Typography color="textPrimary">Redirecting to main page.....</Typography>;
 };
 
 export default OIDCAuth;

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -19,7 +19,7 @@ import Terminal from '../common/Terminal';
 const useStyle = makeStyles({
   containerFormControl: {
     minWidth: '11rem',
-  }
+  },
 });
 
 interface PodLogViewerProps extends Omit<LogViewerProps, 'logs'> {
@@ -34,31 +34,33 @@ function PodLogViewer(props: PodLogViewerProps) {
   const [logs, setLogs] = React.useState<string[]>([]);
 
   function getDefaultContainer() {
-    return (item.spec.containers.length > 0) ? item.spec.containers[0].name : '';
+    return item.spec.containers.length > 0 ? item.spec.containers[0].name : '';
   }
 
-  const options = {leading: true, trailing: true, maxWait: 1000};
+  const options = { leading: true, trailing: true, maxWait: 1000 };
   function setLogsDebounced(args: string[]) {
     setLogs([]);
     setLogs(args);
   }
   const debouncedSetState = _.debounce(setLogsDebounced, 500, options);
 
-  React.useEffect(() => {
-    let callback: any = null;
+  React.useEffect(
+    () => {
+      let callback: any = null;
 
-    if (props.open) {
-      callback = item.getLogs(container, lines, false, debouncedSetState);
-    }
-
-    return function cleanup() {
-      if (callback) {
-        callback();
+      if (props.open) {
+        callback = item.getLogs(container, lines, false, debouncedSetState);
       }
-    };
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [container, lines, open]);
+
+      return function cleanup() {
+        if (callback) {
+          callback();
+        }
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [container, lines, open]
+  );
 
   function handleContainerChange(event: any) {
     setContainer(event.target.value);
@@ -86,9 +88,12 @@ function PodLogViewer(props: PodLogViewerProps) {
             value={container}
             onChange={handleContainerChange}
           >
-            {item && item.spec.containers.map(({name}) =>
-              <MenuItem value={name} key={name}>{name}</MenuItem>
-            )}
+            {item &&
+              item.spec.containers.map(({ name }) => (
+                <MenuItem value={name} key={name}>
+                  {name}
+                </MenuItem>
+              ))}
           </Select>
         </FormControl>,
         <FormControl className={classes.containerFormControl}>
@@ -101,11 +106,13 @@ function PodLogViewer(props: PodLogViewerProps) {
             value={lines}
             onChange={handleLinesChange}
           >
-            {[100, 1000, 2500].map((i) =>
-              <MenuItem value={i} key={i}>{i}</MenuItem>
-            )}
+            {[100, 1000, 2500].map(i => (
+              <MenuItem value={i} key={i}>
+                {i}
+              </MenuItem>
+            ))}
           </Select>
-        </FormControl>
+        </FormControl>,
       ]}
       {...other}
     />
@@ -125,57 +132,48 @@ export default function PodDetails() {
       <PageGrid>
         <MainInfoSection
           resource={item}
-          actions={item && [
-            <Tooltip title="Show Logs">
-              <IconButton
-                aria-label="delete"
-                onClick={() => setShowLogs(true)}
-              >
-                <Icon icon={fileDocumentBoxOutline} />
-              </IconButton>
-            </Tooltip>,
-            <Tooltip title="Terminal / Exec">
-              <IconButton
-                aria-label="delete"
-                onClick={() => setShowTerminal(true)}
-              >
-                <Icon icon={consoleIcon} />
-              </IconButton>
-            </Tooltip>
-          ]}
-          extraInfo={item && [
-            {
-              name: 'State',
-              value: item.status.phase
-            },
-            {
-              name: 'Host IP',
-              value: item.status.hostIP,
-            },
-            {
-              name: 'Pod IP',
-              value: item.status.podIP,
-            }
-          ]}
+          actions={
+            item && [
+              <Tooltip title="Show Logs">
+                <IconButton aria-label="delete" onClick={() => setShowLogs(true)}>
+                  <Icon icon={fileDocumentBoxOutline} />
+                </IconButton>
+              </Tooltip>,
+              <Tooltip title="Terminal / Exec">
+                <IconButton aria-label="delete" onClick={() => setShowTerminal(true)}>
+                  <Icon icon={consoleIcon} />
+                </IconButton>
+              </Tooltip>,
+            ]
+          }
+          extraInfo={
+            item && [
+              {
+                name: 'State',
+                value: item.status.phase,
+              },
+              {
+                name: 'Host IP',
+                value: item.status.hostIP,
+              },
+              {
+                name: 'Pod IP',
+                value: item.status.podIP,
+              },
+            ]
+          }
         />
         {item && <ContainersSection resource={item?.jsonData} />}
       </PageGrid>
-      {item &&
-        [
-          <PodLogViewer
-            key="logs"
-            open={showLogs}
-            item={item}
-            onClose={ () => setShowLogs(false) }
-          />,
-          <Terminal
-            key="terminal"
-            open={showTerminal}
-            item={item}
-            onClose={ () => setShowTerminal(false) }
-          />
-        ]
-      }
+      {item && [
+        <PodLogViewer key="logs" open={showLogs} item={item} onClose={() => setShowLogs(false)} />,
+        <Terminal
+          key="terminal"
+          open={showTerminal}
+          item={item}
+          onClose={() => setShowTerminal(false)}
+        />,
+      ]}
     </React.Fragment>
   );
 }

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -26,21 +26,11 @@ export default function PodList() {
       status = 'success';
     }
 
-    return (
-      <StatusLabel status={status}>
-        {phase}
-      </StatusLabel>
-    );
+    return <StatusLabel status={status}>{phase}</StatusLabel>;
   }
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Pods"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Pods" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -48,7 +38,7 @@ export default function PodList() {
         columns={[
           {
             label: 'Name',
-            getter: (pod) => <Link kubeObject={pod} />,
+            getter: pod => <Link kubeObject={pod} />,
             sort: (p1: Pod, p2: Pod) => {
               if (p1.metadata.name < p2.metadata.name) {
                 return -1;
@@ -56,26 +46,26 @@ export default function PodList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (pod: Pod) => pod.getNamespace()
+            getter: (pod: Pod) => pod.getNamespace(),
           },
           {
             label: 'Restarts',
-            getter: (pod: Pod) => getRestartCount(pod)
+            getter: (pod: Pod) => getRestartCount(pod),
           },
           {
             label: 'Status',
-            getter: makeStatusLabel
+            getter: makeStatusLabel,
           },
           {
             label: 'Age',
             getter: (pod: Pod) => pod.getAge(),
             sort: (p1: Pod, p2: Pod) =>
               new Date(p2.metadata.creationTimestamp).getTime() -
-              new Date(p1.metadata.creationTimestamp).getTime()
+              new Date(p1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={pods}

--- a/frontend/src/components/replicaset/List.tsx
+++ b/frontend/src/components/replicaset/List.tsx
@@ -15,13 +15,7 @@ export default function ReplicaSetList() {
   }
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Replica Sets"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Replica Sets" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -29,7 +23,7 @@ export default function ReplicaSetList() {
         columns={[
           {
             label: 'Name',
-            getter: (replicaSet) => <Link kubeObject={replicaSet} />,
+            getter: replicaSet => <Link kubeObject={replicaSet} />,
             sort: (r1: ReplicaSet, r2: ReplicaSet) => {
               if (r1.metadata.name < r2.metadata.name) {
                 return -1;
@@ -37,26 +31,26 @@ export default function ReplicaSetList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (replicaSet) => replicaSet.getNamespace()
+            getter: replicaSet => replicaSet.getNamespace(),
           },
           {
             label: 'Generation',
-            getter: (replicaSet) => replicaSet.status.observedGeneration
+            getter: replicaSet => replicaSet.status.observedGeneration,
           },
           {
             label: 'Replicas',
-            getter: (replicaSet) => getReplicas(replicaSet)
+            getter: replicaSet => getReplicas(replicaSet),
           },
           {
             label: 'Age',
-            getter: (replicaSet) => replicaSet.getAge(),
+            getter: replicaSet => replicaSet.getAge(),
             sort: (r1: ReplicaSet, r2: ReplicaSet) =>
               new Date(r2.metadata.creationTimestamp).getTime() -
-              new Date(r1.metadata.creationTimestamp).getTime()
+              new Date(r1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={replicaSets}

--- a/frontend/src/components/role/BindingDetails.tsx
+++ b/frontend/src/components/role/BindingDetails.tsx
@@ -8,10 +8,10 @@ import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
 export default function RoleBindingDetails() {
-  const {
-    namespace = undefined,
-    name
-  } = useParams<{ namespace: string | undefined; name: string }>();
+  const { namespace = undefined, name } = useParams<{
+    namespace: string | undefined;
+    name: string;
+  }>();
   const [item, setItem] = React.useState<RoleBinding | null>(null);
 
   let cls = RoleBinding;
@@ -21,11 +21,11 @@ export default function RoleBindingDetails() {
 
   cls.useApiGet(setItem, name, namespace);
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
       <MainInfoSection
-
         resource={item}
         extraInfo={[
           {
@@ -39,7 +39,7 @@ export default function RoleBindingDetails() {
           {
             name: 'Ref. API Group',
             value: item.roleRef.apiGroup,
-          }
+          },
         ]}
       />
       <SectionBox title="Binding Info">

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -14,13 +14,14 @@ interface RoleBindingDict {
 export default function RoleBindingList() {
   const [bindings, setBindings] = React.useState<RoleBindingDict | null>(null);
   const [roleBindingError, onRoleBindingError] = useErrorState(setupRoleBindings);
-  const [clusterRoleBindingError, onClusterRoleBindingError] =
-    useErrorState(setupClusterRoleBindings);
+  const [clusterRoleBindingError, onClusterRoleBindingError] = useErrorState(
+    setupClusterRoleBindings
+  );
   const filterFunc = useFilterFunc();
 
   function setRoleBindings(newBindings: RoleBinding[] | null, kind: string) {
     const currentBindings: RoleBindingDict = bindings || {};
-    const data = {...currentBindings};
+    const data = { ...currentBindings };
 
     data[kind] = newBindings;
 
@@ -64,13 +65,7 @@ export default function RoleBindingList() {
   ClusterRoleBinding.useApiList(setupClusterRoleBindings, onClusterRoleBindingError);
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Role Bindings"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Role Bindings" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -78,12 +73,11 @@ export default function RoleBindingList() {
         columns={[
           {
             label: 'Type',
-            getter: (item) => item.kind
+            getter: item => item.kind,
           },
           {
             label: 'Name',
-            getter: (item) =>
-              <Link kubeObject={item} />,
+            getter: item => <Link kubeObject={item} />,
             sort: (r1: RoleBinding, r2: RoleBinding) => {
               if (r1.metadata.name < r2.metadata.name) {
                 return -1;
@@ -91,18 +85,18 @@ export default function RoleBindingList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (item) => item.getNamespace() || 'All namespaces'
+            getter: item => item.getNamespace() || 'All namespaces',
           },
           {
             label: 'Age',
-            getter: (item) => item.getAge(),
+            getter: item => item.getAge(),
             sort: (r1: RoleBinding, r2: RoleBinding) =>
               new Date(r2.metadata.creationTimestamp).getTime() -
-              new Date(r1.metadata.creationTimestamp).getTime()
+              new Date(r1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={getJointItems()}

--- a/frontend/src/components/role/Details.tsx
+++ b/frontend/src/components/role/Details.tsx
@@ -8,10 +8,10 @@ import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
 export default function RoleDetails() {
-  const {
-    namespace = undefined,
-    name
-  } = useParams<{ namespace: string | undefined; name: string }>();
+  const { namespace = undefined, name } = useParams<{
+    namespace: string | undefined;
+    name: string;
+  }>();
   const [item, setItem] = React.useState<Role | null>(null);
 
   let cls = Role;
@@ -21,32 +21,30 @@ export default function RoleDetails() {
 
   cls.useApiGet(setItem, name!, namespace);
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
-      <MainInfoSection
-
-        resource={item}
-      />
+      <MainInfoSection resource={item} />
       <SectionBox title="Rules">
         <SimpleTable
           columns={[
             {
               label: 'API Groups',
-              getter: ({apiGroups = []}) => apiGroups.join(', ')
+              getter: ({ apiGroups = [] }) => apiGroups.join(', '),
             },
             {
               label: 'Resources',
-              getter: ({resources = []}) => resources.join(', ')
+              getter: ({ resources = [] }) => resources.join(', '),
             },
             {
               label: 'Non Resources',
-              getter: ({nonResources = []}) => nonResources.join(', ')
+              getter: ({ nonResources = [] }) => nonResources.join(', '),
             },
             {
               label: 'Verbs',
-              getter: ({verbs = []}) => verbs.join(', ')
-            }
+              getter: ({ verbs = [] }) => verbs.join(', '),
+            },
           ]}
           data={item.rules}
         />

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -19,7 +19,7 @@ export default function RoleList() {
 
   function setupRolesWithKind(newRoles: Role[] | null, kind: string) {
     const currentRoles: RolesDict = roles || {};
-    const data = {...currentRoles};
+    const data = { ...currentRoles };
 
     data[kind] = newRoles;
     setRoles(data);
@@ -63,13 +63,7 @@ export default function RoleList() {
   ClusterRole.useApiList(setupClusterRoles, setClusterRolesError);
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Roles"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Roles" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -77,20 +71,21 @@ export default function RoleList() {
         columns={[
           {
             label: 'Type',
-            getter: (item) => item.kind
+            getter: item => item.kind,
           },
           {
             label: 'Name',
-            getter: (item) =>
+            getter: item => (
               <Link
                 routeName={item.metadata.namespace ? 'role' : 'clusterrole'}
                 params={{
                   namespace: item.metadata.namespace || '',
-                  name: item.metadata.name
+                  name: item.metadata.name,
                 }}
               >
                 {item.metadata.name}
-              </Link>,
+              </Link>
+            ),
             sort: (r1: Role, r2: Role) => {
               if (r1.metadata.name < r2.metadata.name) {
                 return -1;
@@ -98,18 +93,18 @@ export default function RoleList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (item) => item.metadata.namespace
+            getter: item => item.metadata.namespace,
           },
           {
             label: 'Age',
-            getter: (item) => timeAgo(item.metadata.creationTimestamp),
+            getter: item => timeAgo(item.metadata.creationTimestamp),
             sort: (r1: Role, r2: Role) =>
               new Date(r2.metadata.creationTimestamp).getTime() -
-              new Date(r1.metadata.creationTimestamp).getTime()
+              new Date(r1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={getJointItems()}

--- a/frontend/src/components/secret/Details.tsx
+++ b/frontend/src/components/secret/Details.tsx
@@ -13,12 +13,13 @@ export default function SecretDetails() {
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && _.map(item.data, (value, key) => (
-        {
+      extraInfo={
+        item &&
+        _.map(item.data, (value, key) => ({
           name: key,
-          value: <SecretField value={value} />
-        }
-      ))}
+          value: <SecretField value={value} />,
+        }))
+      }
     />
   );
 }

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -11,13 +11,7 @@ export default function SecretList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Secrets"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Secrets" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -25,7 +19,7 @@ export default function SecretList() {
         columns={[
           {
             label: 'Name',
-            getter: (secret) => <Link kubeObject={secret} />,
+            getter: secret => <Link kubeObject={secret} />,
             sort: (s1: Secret, s2: Secret) => {
               if (s1.metadata.name < s2.metadata.name) {
                 return -1;
@@ -33,22 +27,22 @@ export default function SecretList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (secret) => secret.getNamespace()
+            getter: secret => secret.getNamespace(),
           },
           {
             label: 'Type',
-            getter: (secret) => secret.type
+            getter: secret => secret.type,
           },
           {
             label: 'Age',
-            getter: (secret) => secret.getAge(),
+            getter: secret => secret.getAge(),
             sort: (s1: Secret, s2: Secret) =>
               new Date(s2.metadata.creationTimestamp).getTime() -
-              new Date(s1.metadata.creationTimestamp).getTime()
+              new Date(s1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={secrets}

--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -15,26 +15,28 @@ export default function ServiceDetails() {
 
   Service.useApiGet(setItem, name, namespace);
 
-  return (
-    !item ? <Loader /> :
+  return !item ? (
+    <Loader />
+  ) : (
     <PageGrid>
       <MainInfoSection
-
         resource={item}
-        extraInfo={item && [
-          {
-            name: 'Type',
-            value: item.spec.type,
-          },
-          {
-            name: 'Cluster IP',
-            value: item.spec.clusterIP,
-          },
-          {
-            name: 'Selector',
-            value: <MetadataDictGrid dict={item.spec.selector} />,
-          },
-        ]}
+        extraInfo={
+          item && [
+            {
+              name: 'Type',
+              value: item.spec.type,
+            },
+            {
+              name: 'Cluster IP',
+              value: item.spec.clusterIP,
+            },
+            {
+              name: 'Selector',
+              value: <MetadataDictGrid dict={item.spec.selector} />,
+            },
+          ]
+        }
       />
       <SectionBox title="Ports">
         <SimpleTable
@@ -50,12 +52,13 @@ export default function ServiceDetails() {
             },
             {
               label: 'Ports',
-              getter: ({port, targetPort}) =>
+              getter: ({ port, targetPort }) => (
                 <React.Fragment>
                   <ValueLabel>{port}</ValueLabel>
                   <InlineIcon icon={chevronRight} />
                   <ValueLabel>{targetPort}</ValueLabel>
                 </React.Fragment>
+              ),
             },
           ]}
         />

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -11,13 +11,7 @@ export default function ServiceList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Services"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Services" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -25,7 +19,7 @@ export default function ServiceList() {
         columns={[
           {
             label: 'Name',
-            getter: (service) => <Link kubeObject={service} />,
+            getter: service => <Link kubeObject={service} />,
             sort: (s1: Service, s2: Service) => {
               if (s1.metadata.name < s2.metadata.name) {
                 return -1;
@@ -33,26 +27,26 @@ export default function ServiceList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (service) => service.getNamespace()
+            getter: service => service.getNamespace(),
           },
           {
             label: 'Type',
-            getter: (service) => service.spec.type
+            getter: service => service.spec.type,
           },
           {
             label: 'Cluster IP',
-            getter: (service) => service.spec.clusterIP
+            getter: service => service.spec.clusterIP,
           },
           {
             label: 'Age',
-            getter: (service) => service.getAge(),
+            getter: service => service.getAge(),
             sort: (s1: Service, s2: Service) =>
               new Date(s2.metadata.creationTimestamp).getTime() -
-              new Date(s1.metadata.creationTimestamp).getTime()
+              new Date(s1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={services}

--- a/frontend/src/components/serviceaccount/Details.tsx
+++ b/frontend/src/components/serviceaccount/Details.tsx
@@ -13,23 +13,25 @@ export default function ServiceAccountDetails() {
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && [
-        {
-          name: 'Secrets',
-          value: <React.Fragment>
-            {
-              item.secrets.map(({name}, index) =>
-                <React.Fragment key={`${name}__${index}`}>
-                  <Link routeName={'secret'} params={{namespace, name}}>
-                    {name}
-                  </Link>
-                  {index !== item.secrets.length - 1 && ','}
-                </React.Fragment>
-              )
-            }
-          </React.Fragment>
-        }
-      ]}
+      extraInfo={
+        item && [
+          {
+            name: 'Secrets',
+            value: (
+              <React.Fragment>
+                {item.secrets.map(({ name }, index) => (
+                  <React.Fragment key={`${name}__${index}`}>
+                    <Link routeName={'secret'} params={{ namespace, name }}>
+                      {name}
+                    </Link>
+                    {index !== item.secrets.length - 1 && ','}
+                  </React.Fragment>
+                ))}
+              </React.Fragment>
+            ),
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/serviceaccount/List.tsx
+++ b/frontend/src/components/serviceaccount/List.tsx
@@ -11,13 +11,7 @@ export default function ServiceAccountList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Service Accounts"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Service Accounts" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -25,7 +19,7 @@ export default function ServiceAccountList() {
         columns={[
           {
             label: 'Name',
-            getter: (serviceAccount) => <Link kubeObject={serviceAccount} />,
+            getter: serviceAccount => <Link kubeObject={serviceAccount} />,
             sort: (s1: ServiceAccount, s2: ServiceAccount) => {
               if (s1.metadata.name < s2.metadata.name) {
                 return -1;
@@ -33,18 +27,18 @@ export default function ServiceAccountList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (serviceAccount) => serviceAccount.getNamespace()
+            getter: serviceAccount => serviceAccount.getNamespace(),
           },
           {
             label: 'Age',
-            getter: (serviceAccount) => serviceAccount.getAge(),
+            getter: serviceAccount => serviceAccount.getAge(),
             sort: (s1: ServiceAccount, s2: ServiceAccount) =>
               new Date(s2.metadata.creationTimestamp).getTime() -
-              new Date(s1.metadata.creationTimestamp).getTime()
+              new Date(s1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={serviceAccounts}

--- a/frontend/src/components/statefulset/Details.tsx
+++ b/frontend/src/components/statefulset/Details.tsx
@@ -13,16 +13,18 @@ export default function StatefulSetDetails() {
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && [
-        {
-          name: 'Update Strategy',
-          value: item.spec.updateStrategy.type,
-        },
-        {
-          name: 'Selector',
-          value: <MetadataDictGrid dict={item.spec.selector.matchLabels as StringDict} />,
-        },
-      ]}
+      extraInfo={
+        item && [
+          {
+            name: 'Update Strategy',
+            value: item.spec.updateStrategy.type,
+          },
+          {
+            name: 'Selector',
+            value: <MetadataDictGrid dict={item.spec.selector.matchLabels as StringDict} />,
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/statefulset/List.tsx
+++ b/frontend/src/components/statefulset/List.tsx
@@ -17,13 +17,7 @@ export default function StatefulSetList() {
   }
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Stateful Sets"
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Stateful Sets" />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -31,7 +25,7 @@ export default function StatefulSetList() {
         columns={[
           {
             label: 'Name',
-            getter: (statefulSet) => <Link kubeObject={statefulSet} />,
+            getter: statefulSet => <Link kubeObject={statefulSet} />,
             sort: (s1: StatefulSet, s2: StatefulSet) => {
               if (s1.metadata.name < s2.metadata.name) {
                 return -1;
@@ -39,26 +33,26 @@ export default function StatefulSetList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (statefulSet) => statefulSet.getNamespace()
+            getter: statefulSet => statefulSet.getNamespace(),
           },
           {
             label: 'Pods',
-            getter: (statefulSet) => renderPods(statefulSet)
+            getter: statefulSet => renderPods(statefulSet),
           },
           {
             label: 'Replicas',
-            getter: (statefulSet) => statefulSet.spec.replicas
+            getter: statefulSet => statefulSet.spec.replicas,
           },
           {
             label: 'Age',
-            getter: (statefulSet) => statefulSet.getAge(),
+            getter: statefulSet => statefulSet.getAge(),
             sort: (s1: StatefulSet, s2: StatefulSet) =>
               new Date(s2.metadata.creationTimestamp).getTime() -
-              new Date(s1.metadata.creationTimestamp).getTime()
+              new Date(s1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={statefulSets}

--- a/frontend/src/components/storage/ClaimDetails.tsx
+++ b/frontend/src/components/storage/ClaimDetails.tsx
@@ -12,38 +12,36 @@ export default function VolumeClaimDetails() {
 
   function makeStatusLabel(item: PersistentVolumeClaim) {
     const status = item.status!.phase;
-    return (
-      <StatusLabel status={status === 'Bound' ? 'success' : 'error'}>
-        {status}
-      </StatusLabel>
-    );
+    return <StatusLabel status={status === 'Bound' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && [
-        {
-          name: 'Status',
-          value: makeStatusLabel(item),
-        },
-        {
-          name: 'Capacity',
-          value: item.spec!.resources.requests.storage
-        },
-        {
-          name: 'Access Modes',
-          value: item.spec!.accessModes.join(', '),
-        },
-        {
-          name: 'Volume Mode',
-          value: item.spec!.volumeMode,
-        },
-        {
-          name: 'Storage Class',
-          value: item.spec!.storageClassName,
-        },
-      ]}
+      extraInfo={
+        item && [
+          {
+            name: 'Status',
+            value: makeStatusLabel(item),
+          },
+          {
+            name: 'Capacity',
+            value: item.spec!.resources.requests.storage,
+          },
+          {
+            name: 'Access Modes',
+            value: item.spec!.accessModes.join(', '),
+          },
+          {
+            name: 'Volume Mode',
+            value: item.spec!.volumeMode,
+          },
+          {
+            name: 'Storage Class',
+            value: item.spec!.storageClassName,
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -23,7 +23,7 @@ export default function VolumeClaimList() {
         columns={[
           {
             label: 'Name',
-            getter: (volumeClaim) => <Link kubeObject={volumeClaim} />,
+            getter: volumeClaim => <Link kubeObject={volumeClaim} />,
             sort: (v1: PersistentVolumeClaim, v2: PersistentVolumeClaim) => {
               if (v1.metadata.name < v2.metadata.name) {
                 return -1;
@@ -31,34 +31,34 @@ export default function VolumeClaimList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Namespace',
-            getter: (volumeClaim) => volumeClaim.getNamespace()
+            getter: volumeClaim => volumeClaim.getNamespace(),
           },
           {
             label: 'Status',
-            getter: (volumeClaim) => volumeClaim.status.phase
+            getter: volumeClaim => volumeClaim.status.phase,
           },
           {
             label: 'Class Name',
-            getter: (volumeClaim) => volumeClaim.spec.storageClassName
+            getter: volumeClaim => volumeClaim.spec.storageClassName,
           },
           {
             label: 'Volume',
-            getter: (volumeClaim) => volumeClaim.spec.volumeName
+            getter: volumeClaim => volumeClaim.spec.volumeName,
           },
           {
             label: 'Capacity',
-            getter: (volumeClaim) => volumeClaim.status.capacity?.storage
+            getter: volumeClaim => volumeClaim.status.capacity?.storage,
           },
           {
             label: 'Age',
-            getter: (volumeClaim) => volumeClaim.getAge(),
+            getter: volumeClaim => volumeClaim.getAge(),
             sort: (v1: PersistentVolumeClaim, v2: PersistentVolumeClaim) =>
               new Date(v2.metadata.creationTimestamp).getTime() -
-              new Date(v1.metadata.creationTimestamp).getTime()
+              new Date(v1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={volumeClaim}

--- a/frontend/src/components/storage/ClassDetails.tsx
+++ b/frontend/src/components/storage/ClassDetails.tsx
@@ -12,20 +12,22 @@ export default function StorageClassDetails() {
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && [
-        {
-          name: 'Reclaim Policy',
-          value: item.reclaimPolicy,
-        },
-        {
-          name: 'Binding Mode',
-          value: item.volumeBindingMode,
-        },
-        {
-          name: 'Provisioner',
-          value: item.provisioner,
-        },
-      ]}
+      extraInfo={
+        item && [
+          {
+            name: 'Reclaim Policy',
+            value: item.reclaimPolicy,
+          },
+          {
+            name: 'Binding Mode',
+            value: item.volumeBindingMode,
+          },
+          {
+            name: 'Provisioner',
+            value: item.provisioner,
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/storage/ClassList.tsx
+++ b/frontend/src/components/storage/ClassList.tsx
@@ -11,14 +11,7 @@ export default function ClassList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Storage Classes"
-          noNamespaceFilter
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Storage Classes" noNamespaceFilter />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -26,7 +19,7 @@ export default function ClassList() {
         columns={[
           {
             label: 'Name',
-            getter: (storageClass) => <Link kubeObject={storageClass} />,
+            getter: storageClass => <Link kubeObject={storageClass} />,
             sort: (sc1: StorageClass, sc2: StorageClass) => {
               if (sc1.metadata.name < sc2.metadata.name) {
                 return -1;
@@ -34,22 +27,22 @@ export default function ClassList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Reclaim Policy',
-            getter: (storageClass) => storageClass.reclaimPolicy
+            getter: storageClass => storageClass.reclaimPolicy,
           },
           {
             label: 'Volume Binding Mode',
-            getter: (storageClass) => storageClass.volumeBindingMode,
+            getter: storageClass => storageClass.volumeBindingMode,
           },
           {
             label: 'Age',
-            getter: (storageClass) => storageClass.getAge(),
+            getter: storageClass => storageClass.getAge(),
             sort: (sc1: StorageClass, sc2: StorageClass) =>
               new Date(sc2.metadata.creationTimestamp).getTime() -
-              new Date(sc1.metadata.creationTimestamp).getTime()
+              new Date(sc1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={storageClasses}

--- a/frontend/src/components/storage/VolumeDetails.tsx
+++ b/frontend/src/components/storage/VolumeDetails.tsx
@@ -12,38 +12,36 @@ export default function VolumeDetails() {
 
   function makeStatusLabel(item: PersistentVolume) {
     const status = item.status!.phase;
-    return (
-      <StatusLabel status={status === 'Bound' ? 'success' : 'error'}>
-        {status}
-      </StatusLabel>
-    );
+    return <StatusLabel status={status === 'Bound' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
   return (
     <MainInfoSection
       resource={item}
-      extraInfo={item && [
-        {
-          name: 'Status',
-          value: makeStatusLabel(item),
-        },
-        {
-          name: 'Capacity',
-          value: item.spec!.capacity.storage,
-        },
-        {
-          name: 'Access Modes',
-          value: item.spec!.accessModes.join(', '),
-        },
-        {
-          name: 'Reclaim Policy',
-          value: item.spec!.persistentVolumeReclaimPolicy,
-        },
-        {
-          name: 'Storage Class',
-          value: item.spec!.storageClassName,
-        },
-      ]}
+      extraInfo={
+        item && [
+          {
+            name: 'Status',
+            value: makeStatusLabel(item),
+          },
+          {
+            name: 'Capacity',
+            value: item.spec!.capacity.storage,
+          },
+          {
+            name: 'Access Modes',
+            value: item.spec!.accessModes.join(', '),
+          },
+          {
+            name: 'Reclaim Policy',
+            value: item.spec!.persistentVolumeReclaimPolicy,
+          },
+          {
+            name: 'Storage Class',
+            value: item.spec!.storageClassName,
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -11,14 +11,7 @@ export default function VolumeList() {
   const filterFunc = useFilterFunc();
 
   return (
-    <SectionBox
-      title={
-        <SectionFilterHeader
-          title="Persistent Volumes"
-          noNamespaceFilter
-        />
-      }
-    >
+    <SectionBox title={<SectionFilterHeader title="Persistent Volumes" noNamespaceFilter />}>
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
@@ -26,7 +19,7 @@ export default function VolumeList() {
         columns={[
           {
             label: 'Name',
-            getter: (volume) => <Link kubeObject={volume} />,
+            getter: volume => <Link kubeObject={volume} />,
             sort: (pv1: PersistentVolume, pv2: PersistentVolume) => {
               if (pv1.metadata.name < pv2.metadata.name) {
                 return -1;
@@ -34,22 +27,22 @@ export default function VolumeList() {
                 return 1;
               }
               return 0;
-            }
+            },
           },
           {
             label: 'Status',
-            getter: (volume) => volume.status.phase
+            getter: volume => volume.status.phase,
           },
           {
             label: 'Capacity',
-            getter: (volume) => volume.spec.capacity.storage
+            getter: volume => volume.spec.capacity.storage,
           },
           {
             label: 'Age',
-            getter: (volume) => volume.getAge(),
+            getter: volume => volume.getAge(),
             sort: (pv1: PersistentVolume, pv2: PersistentVolume) =>
               new Date(pv2.metadata.creationTimestamp).getTime() -
-              new Date(pv1.metadata.creationTimestamp).getTime()
+              new Date(pv1.metadata.creationTimestamp).getTime(),
           },
         ]}
         data={volumes}

--- a/frontend/src/components/workload/Charts.tsx
+++ b/frontend/src/components/workload/Charts.tsx
@@ -13,16 +13,11 @@ interface WorkloadCircleChartProps extends Omit<PercentageCircleProps, 'data'> {
 export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
   const theme = useTheme();
 
-  const {
-    workloadData,
-    partialLabel = '',
-    totalLabel = '',
-    ...other
-  } = props;
+  const { workloadData, partialLabel = '', totalLabel = '', ...other } = props;
 
   const total = workloadData.length;
-  const partial = workloadData.filter(item =>
-    getReadyReplicas(item) !== getTotalReplicas(item)).length;
+  const partial = workloadData.filter(item => getReadyReplicas(item) !== getTotalReplicas(item))
+    .length;
 
   function makeData() {
     return [
@@ -35,7 +30,7 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
   }
 
   function getLabel() {
-    return getPercentStr((total - partial), total);
+    return getPercentStr(total - partial, total);
   }
 
   function getLegend() {
@@ -54,7 +49,7 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
       data={makeData()}
       total={workloadData.length}
       totalProps={{
-        fill: theme.palette.chartStyles.fillColor || theme.palette.common.black
+        fill: theme.palette.chartStyles.fillColor || theme.palette.common.black,
       }}
       label={getLabel()}
       legend={getLegend()}

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { NavLinkProps, useLocation, useParams } from 'react-router-dom';
 import { KubeObject, Workload } from '../../lib/k8s/cluster';
-import { ContainersSection, MainInfoSection, MetadataDictGrid, PageGrid, ReplicasSection } from '../common/Resource';
+import {
+  ContainersSection,
+  MainInfoSection,
+  MetadataDictGrid,
+  PageGrid,
+  ReplicasSection,
+} from '../common/Resource';
 
 interface WorkloadDetailsProps {
   workloadKind: KubeObject;
@@ -9,7 +15,7 @@ interface WorkloadDetailsProps {
 
 export default function WorkloadDetails(props: WorkloadDetailsProps) {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
-  const location = useLocation<{backLink: NavLinkProps['location']}>();
+  const location = useLocation<{ backLink: NavLinkProps['location'] }>();
   const { workloadKind } = props;
   const [item, setItem] = React.useState<Workload | null>(null);
 
@@ -20,20 +26,23 @@ export default function WorkloadDetails(props: WorkloadDetailsProps) {
       <MainInfoSection
         backLink={location.state?.backLink}
         resource={item}
-        extraInfo={item && [
-          {
-            name: 'Strategy Type',
-            value: item.spec.strategy && item.spec.strategy.type,
-            hide: !item.spec.strategy
-          },
-          {
-            name: 'Selector',
-            value: item.spec.selector &&
-              <MetadataDictGrid
-                dict={item.spec.selector.matchLabels as {[key: string]: string}}
-              />,
-          },
-        ]}
+        extraInfo={
+          item && [
+            {
+              name: 'Strategy Type',
+              value: item.spec.strategy && item.spec.strategy.type,
+              hide: !item.spec.strategy,
+            },
+            {
+              name: 'Selector',
+              value: item.spec.selector && (
+                <MetadataDictGrid
+                  dict={item.spec.selector.matchLabels as { [key: string]: string }}
+                />
+              ),
+            },
+          ]
+        }
       />
       <ReplicasSection resource={item?.jsonData} />
       <ContainersSection resource={item?.jsonData} />

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -24,9 +24,11 @@ export default function Overview() {
   const location = useLocation();
   const filterFunc = useFilterFunc();
 
-  function setWorkloads(workloads: WorkloadDict,
-                        {items, kind}: {items: Workload[]; kind: string}) {
-    const data = {...workloads};
+  function setWorkloads(
+    workloads: WorkloadDict,
+    { items, kind }: { items: Workload[]; kind: string }
+  ) {
+    const data = { ...workloads };
     data[kind] = items;
 
     return data;
@@ -46,28 +48,17 @@ export default function Overview() {
 
   const workloads = [DaemonSet, Deployment, Job, CronJob, ReplicaSet, StatefulSet];
   workloads.forEach(workloadClass => {
-    workloadClass.useApiList((items: InstanceType<(typeof workloadClass)>[]) =>
-      dispatch({items, kind: workloadClass.className})
+    workloadClass.useApiList((items: InstanceType<typeof workloadClass>[]) =>
+      dispatch({ items, kind: workloadClass.className })
     );
   });
 
   return (
     <PageGrid>
       <SectionBox py={2}>
-        <Grid
-          container
-          justify="space-around"
-          alignItems="flex-start"
-          spacing={1}
-        >
-          {workloads.map(({className: name}) =>
-            <Grid
-              item
-              lg={2}
-              md={4}
-              xs={6}
-              key={name}
-            >
+        <Grid container justify="space-around" alignItems="flex-start" spacing={1}>
+          {workloads.map(({ className: name }) => (
+            <Grid item lg={2} md={4} xs={6} key={name}>
               <WorkloadCircleChart
                 workloadData={workloadsData[name] || []}
                 // @todo: Use a plural from from the class itself when we have it
@@ -76,24 +67,23 @@ export default function Overview() {
                 totalLabel="Running"
               />
             </Grid>
-          )}
+          ))}
         </Grid>
       </SectionBox>
-      <SectionBox
-        title={<SectionFilterHeader title="Workloads" />}
-      >
+      <SectionBox title={<SectionFilterHeader title="Workloads" />}>
         <SimpleTable
           rowsPerPage={[15, 25, 50]}
           filterFunction={filterFunc}
           columns={[
             {
               label: 'Type',
-              getter: (item) => item.kind
+              getter: item => item.kind,
             },
             {
               label: 'Name',
-              getter: (item) =>
-                <ResourceLink resource={item} state={{backLink: {...location}}} />,
+              getter: item => (
+                <ResourceLink resource={item} state={{ backLink: { ...location } }} />
+              ),
               sort: (w1: Workload, w2: Workload) => {
                 if (w1.metadata.name < w2.metadata.name) {
                   return -1;
@@ -101,22 +91,22 @@ export default function Overview() {
                   return 1;
                 }
                 return 0;
-              }
+              },
             },
             {
               label: 'Namespace',
-              getter: (item) => item.metadata.namespace
+              getter: item => item.metadata.namespace,
             },
             {
               label: 'Pods',
-              getter: (item) => item && getPods(item)
+              getter: item => item && getPods(item),
             },
             {
               label: 'Age',
-              getter: (item) => timeAgo(item.metadata.creationTimestamp),
+              getter: item => timeAgo(item.metadata.creationTimestamp),
               sort: (w1: Workload, w2: Workload) =>
                 new Date(w2.metadata.creationTimestamp).getTime() -
-                new Date(w1.metadata.creationTimestamp).getTime()
+                new Date(w1.metadata.creationTimestamp).getTime(),
             },
           ]}
           data={getJointItems()}

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -4,17 +4,29 @@
 // helper method to determine whether app is running in electron environment
 export function isElectron(): boolean {
   // Renderer process
-  if (typeof window !== 'undefined' && typeof window.process === 'object' && (window.process as any).type === 'renderer') {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.process === 'object' &&
+    (window.process as any).type === 'renderer'
+  ) {
     return true;
   }
 
   // Main process
-  if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!(process.versions as any).electron) {
+  if (
+    typeof process !== 'undefined' &&
+    typeof process.versions === 'object' &&
+    !!(process.versions as any).electron
+  ) {
     return true;
   }
 
   // Detect the user agent when the `nodeIntegration` option is set to true
-  if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+  if (
+    typeof navigator === 'object' &&
+    typeof navigator.userAgent === 'string' &&
+    navigator.userAgent.indexOf('Electron') >= 0
+  ) {
     return true;
   }
 

--- a/frontend/src/lib/docs.ts
+++ b/frontend/src/lib/docs.ts
@@ -18,7 +18,7 @@ export default async function getDocDefinitions(apiVersion: string, kind: string
     docsPromise = getDocs(); // Don't wait here. Just kick off the request
   }
 
-  const {definitions = {}} = (await docsPromise) as OpenAPIV2.Document;
+  const { definitions = {} } = (await docsPromise) as OpenAPIV2.Document;
 
   let [group, version] = apiVersion.split('/');
   if (!version) {
@@ -31,8 +31,6 @@ export default async function getDocDefinitions(apiVersion: string, kind: string
     .find(x => x['x-kubernetes-group-version-kind'].some(comparer));
 
   function comparer(info: OpenAPIV2.SchemaObject) {
-    return info.group === group
-            && info.version === version
-            && info.kind === kind;
+    return info.group === group && info.version === version && info.kind === kind;
   }
 }

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -14,11 +14,12 @@ import { ResourceClasses } from '.';
 import { KubeMetrics, KubeObjectClass, KubeObjectInterface } from './cluster';
 
 const isDev = process.env.NODE_ENV !== 'production';
-const backendServicesURL = isElectron() || isDev ? 'http://localhost:4466/' : window.location.origin;
+const backendServicesURL =
+  isElectron() || isDev ? 'http://localhost:4466/' : window.location.origin;
 const BASE_HTTP_URL = backendServicesURL;
 const BASE_WS_URL = BASE_HTTP_URL.replace('http', 'ws');
 const CLUSTERS_PREFIX = 'clusters';
-const JSON_HEADERS = {Accept: 'application/json', 'Content-Type': 'application/json'};
+const JSON_HEADERS = { Accept: 'application/json', 'Content-Type': 'application/json' };
 const DEFAULT_TIMEOUT = 2 * 60 * 1000; // ms
 
 interface RequestParams {
@@ -26,15 +27,19 @@ interface RequestParams {
   [prop: string]: any;
 }
 
-export async function request(path: string, params: RequestParams = {},
-                              autoLogoutOnAuthError: boolean = true, useCluster: boolean = true) {
+export async function request(
+  path: string,
+  params: RequestParams = {},
+  autoLogoutOnAuthError: boolean = true,
+  useCluster: boolean = true
+) {
   interface RequestHeaders {
     Authorization?: string;
     [otherHeader: string]: any;
-  };
+  }
 
-  const {timeout = DEFAULT_TIMEOUT, ...otherParams} = params;
-  const opts: {headers: RequestHeaders} = Object.assign({headers: {}}, otherParams);
+  const { timeout = DEFAULT_TIMEOUT, ...otherParams } = params;
+  const opts: { headers: RequestHeaders } = Object.assign({ headers: {} }, otherParams);
 
   // @todo: This is a temporary way of getting the current cluster. We should improve it later.
   const cluster = getCluster();
@@ -53,24 +58,23 @@ export async function request(path: string, params: RequestParams = {},
   const id = setTimeout(() => controller.abort(), timeout);
 
   const url = combinePath(BASE_HTTP_URL, fullPath);
-  let response: Response = new Response(undefined,
-                                        {status: 502, statusText: 'Unreachable'});
+  let response: Response = new Response(undefined, { status: 502, statusText: 'Unreachable' });
 
   try {
-    response = await fetch(url, {signal: controller.signal, ...opts});
+    response = await fetch(url, { signal: controller.signal, ...opts });
   } catch (err) {
     // AbortController sets the error code as 20
     if (err.code === 20) {
-      response = new Response(undefined, {status: 408, statusText: 'Request timed-out'});
+      response = new Response(undefined, { status: 408, statusText: 'Request timed-out' });
     }
   } finally {
     clearTimeout(id);
-  };
+  }
 
   if (!response.ok) {
-    const {status, statusText} = response;
+    const { status, statusText } = response;
     if (autoLogoutOnAuthError && status === 401 && opts.headers.Authorization) {
-      console.error('Logging out due to auth error', {status, statusText, path});
+      console.error('Logging out due to auth error', { status, statusText, path });
       logout();
     }
 
@@ -79,10 +83,10 @@ export async function request(path: string, params: RequestParams = {},
       const json = await response.json();
       message += ` - ${json.message}`;
     } catch (err) {
-      console.error('Unable to parse error json', {err});
+      console.error('Unable to parse error json', { err });
     }
 
-    const error: Error & {status?: number} = new Error(message);
+    const error: Error & { status?: number } = new Error(message);
     error.status = status;
     throw error;
   }
@@ -97,10 +101,10 @@ export function apiFactory(group: string, version: string, resource: string) {
   const apiRoot = getApiRoot(group, version);
   const url = `${apiRoot}/${resource}`;
   return {
-    resource: {group, resource},
+    resource: { group, resource },
     list: (cb: StreamResultsCb, errCb: StreamErrCb) => streamResults(url, cb, errCb),
-    get: (name: string, cb: StreamResultsCb,
-          errCb: StreamErrCb) => streamResult(url, name, cb, errCb),
+    get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
+      streamResult(url, name, cb, errCb),
     post: (body: KubeObjectInterface) => post(url, body),
     put: (body: KubeObjectInterface) => put(`${url}/${body.metadata.name}`, body),
     delete: (name: string) => remove(`${url}/${name}`),
@@ -108,8 +112,12 @@ export function apiFactory(group: string, version: string, resource: string) {
   };
 }
 
-export function apiFactoryWithNamespace(group: string, version: string, resource: string,
-                                        includeScale: boolean = false) {
+export function apiFactoryWithNamespace(
+  group: string,
+  version: string,
+  resource: string,
+  includeScale: boolean = false
+) {
   const apiRoot = getApiRoot(group, version);
   const results: {
     resource: {
@@ -118,13 +126,14 @@ export function apiFactoryWithNamespace(group: string, version: string, resource
     };
     [other: string]: any;
   } = {
-    resource: {group, resource},
-    list: (namespace: string, cb: StreamResultsCb,
-           errCb: StreamErrCb) => streamResults(url(namespace), cb, errCb),
-    get: (namespace: string, name: string, cb: StreamResultsCb,
-          errCb: StreamErrCb) => streamResult(url(namespace), name, cb, errCb),
+    resource: { group, resource },
+    list: (namespace: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
+      streamResults(url(namespace), cb, errCb),
+    get: (namespace: string, name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
+      streamResult(url(namespace), name, cb, errCb),
     post: (body: KubeObjectInterface) => post(url(body.metadata.namespace as string), body),
-    put: (body: KubeObjectInterface) => put(`${url(body.metadata.namespace as string)}/${body.metadata.name}`, body),
+    put: (body: KubeObjectInterface) =>
+      put(`${url(body.metadata.namespace as string)}/${body.metadata.name}`, body),
     delete: (namespace: string, name: string) => remove(`${url(namespace)}/${name}`),
     isNamespaced: true,
   };
@@ -156,27 +165,39 @@ function apiScaleFactory(apiRoot: string, resource: string) {
   }
 }
 
-export function post(url: string, json: JSON | object | KubeObjectInterface,
-                     autoLogoutOnAuthError = true, requestOptions = {}) {
+export function post(
+  url: string,
+  json: JSON | object | KubeObjectInterface,
+  autoLogoutOnAuthError = true,
+  requestOptions = {}
+) {
   const body = JSON.stringify(json);
-  const opts = {method: 'POST', body, headers: JSON_HEADERS, ...requestOptions};
+  const opts = { method: 'POST', body, headers: JSON_HEADERS, ...requestOptions };
   return request(url, opts, autoLogoutOnAuthError);
 }
 
-export function put(url: string, json: KubeObjectInterface, autoLogoutOnAuthError = true,
-                    requestOptions = {}) {
+export function put(
+  url: string,
+  json: KubeObjectInterface,
+  autoLogoutOnAuthError = true,
+  requestOptions = {}
+) {
   const body = JSON.stringify(json);
-  const opts = {method: 'PUT', body, headers: JSON_HEADERS, ...requestOptions};
+  const opts = { method: 'PUT', body, headers: JSON_HEADERS, ...requestOptions };
   return request(url, opts, autoLogoutOnAuthError);
 }
 
 export function remove(url: string, requestOptions = {}) {
-  const opts = {method: 'DELETE', headers: JSON_HEADERS, ...requestOptions};
+  const opts = { method: 'DELETE', headers: JSON_HEADERS, ...requestOptions };
   return request(url, opts);
 }
 
-export async function streamResult(url: string, name: string, cb: StreamResultsCb,
-                                   errCb: StreamErrCb) {
+export async function streamResult(
+  url: string,
+  name: string,
+  cb: StreamResultsCb,
+  errCb: StreamErrCb
+) {
   let isCancelled = false;
   let socket: ReturnType<typeof stream>;
   run();
@@ -193,9 +214,9 @@ export async function streamResult(url: string, name: string, cb: StreamResultsC
       const fieldSelector = encodeURIComponent(`metadata.name=${name}`);
       const watchUrl = `${url}?watch=1&fieldSelector=${fieldSelector}`;
 
-      socket = stream(watchUrl, x => cb(x.object), {isJson: true});
+      socket = stream(watchUrl, x => cb(x.object), { isJson: true });
     } catch (err) {
-      console.error('Error in api request', {err, url});
+      console.error('Error in api request', { err, url });
       if (errCb) errCb(err);
     }
   }
@@ -220,16 +241,16 @@ export async function streamResults(url: string, cb: StreamResultsCb, errCb: Str
 
   async function run() {
     try {
-      const {kind, items, metadata} = await request(url);
+      const { kind, items, metadata } = await request(url);
 
       if (isCancelled) return;
 
       add(items, kind);
 
       const watchUrl = `${url}?watch=1&resourceVersion=${metadata.resourceVersion}`;
-      socket = stream(watchUrl, update, {isJson: true});
+      socket = stream(watchUrl, update, { isJson: true });
     } catch (err) {
-      console.error('Error in api request', {err, url});
+      console.error('Error in api request', { err, url });
       if (errCb) errCb(err);
     }
   }
@@ -251,7 +272,13 @@ export async function streamResults(url: string, cb: StreamResultsCb, errCb: Str
     push();
   }
 
-  function update({type, object}: {type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'ERROR'; object: KubeObjectInterface}) {
+  function update({
+    type,
+    object,
+  }: {
+    type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'ERROR';
+    object: KubeObjectInterface;
+  }) {
     object.actionType = type; // eslint-disable-line no-param-reassign
 
     switch (type) {
@@ -277,7 +304,7 @@ export async function streamResults(url: string, cb: StreamResultsCb, errCb: Str
         delete results[object.metadata.uid];
         break;
       case 'ERROR':
-        console.error('Error in update', {type, object});
+        console.error('Error in update', { type, object });
         break;
       default:
         console.error('Unknown update type', type);
@@ -302,11 +329,11 @@ interface StreamArgs {
 export function stream(url: string, cb: StreamResultsCb, args: StreamArgs) {
   let connection: ReturnType<typeof connectStream>;
   let isCancelled = false;
-  const {isJson = false, additionalProtocols, connectCb, reconnectOnFailure = true} = args;
+  const { isJson = false, additionalProtocols, connectCb, reconnectOnFailure = true } = args;
 
   connect();
 
-  return {cancel, getSocket};
+  return { cancel, getSocket };
 
   function getSocket() {
     return connection.socket;
@@ -326,14 +353,19 @@ export function stream(url: string, cb: StreamResultsCb, args: StreamArgs) {
     if (isCancelled) return;
 
     if (reconnectOnFailure) {
-      console.log('Reconnecting in 3 seconds', {url});
+      console.log('Reconnecting in 3 seconds', { url });
       setTimeout(connect, 3000);
     }
   }
 }
 
-function connectStream(path: string, cb: StreamResultsCb, onFail: () => void, isJson: boolean,
-                       additionalProtocols: string[] = []) {
+function connectStream(
+  path: string,
+  cb: StreamResultsCb,
+  onFail: () => void,
+  isJson: boolean,
+  additionalProtocols: string[] = []
+) {
   let isClosing = false;
 
   // @todo: This is a temporary way of getting the current cluster. We should improve it later.
@@ -345,10 +377,7 @@ function connectStream(path: string, cb: StreamResultsCb, onFail: () => void, is
     additionalProtocols.push(`base64url.bearer.authorization.k8s.io.${encodedToken}`);
   }
 
-  const protocols = [
-    'base64.binary.k8s.io',
-    ...additionalProtocols,
-  ];
+  const protocols = ['base64.binary.k8s.io', ...additionalProtocols];
 
   let fullPath = path;
   if (cluster) {
@@ -367,7 +396,7 @@ function connectStream(path: string, cb: StreamResultsCb, onFail: () => void, is
     console.error(error);
   }
 
-  return {close, socket};
+  return { close, socket };
 
   function close() {
     isClosing = true;
@@ -395,12 +424,12 @@ function connectStream(path: string, cb: StreamResultsCb, onFail: () => void, is
     socket.removeEventListener('close', onClose);
     socket.removeEventListener('error', onError);
 
-    console.warn('Socket closed unexpectedly', {path, args});
+    console.warn('Socket closed unexpectedly', { path, args });
     onFail();
   }
 
   function onError(err: any) {
-    console.error('Error in api stream', {err, path});
+    console.error('Error in api stream', { err, path });
   }
 }
 
@@ -438,8 +467,11 @@ export interface ApiError extends Error {
   status: number;
 }
 
-export async function metrics(url: string, onMetrics: (arg: KubeMetrics[]) => void,
-                              onError?: (err: ApiError) => void) {
+export async function metrics(
+  url: string,
+  onMetrics: (arg: KubeMetrics[]) => void,
+  onError?: (err: ApiError) => void
+) {
   const handel = setInterval(getMetrics, 10000);
 
   async function getMetrics() {
@@ -447,7 +479,7 @@ export async function metrics(url: string, onMetrics: (arg: KubeMetrics[]) => vo
       const metric = await request(url);
       onMetrics(metric.items || metric);
     } catch (err) {
-      console.debug('No metrics', {err, url});
+      console.debug('No metrics', { err, url });
 
       if (onError) {
         onError(err);
@@ -465,6 +497,8 @@ export async function metrics(url: string, onMetrics: (arg: KubeMetrics[]) => vo
 }
 
 export async function testAuth() {
-  const spec = {namespace: 'default'};
-  return post('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews', {spec}, false, {timeout: 5 * 1000});
+  const spec = { namespace: 'default' };
+  return post('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews', { spec }, false, {
+    timeout: 5 * 1000,
+  });
 }

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -95,11 +95,14 @@ export function useClustersConf(): ConfigState['clusters'] {
 
           const configToStore = {
             ...config,
-            clusters: clustersToConfig
+            clusters: clustersToConfig,
           };
 
-          if (!clusters || Object.keys(clusters).length !== 0 ||
-              Object.keys(clustersToConfig).length !== 0) {
+          if (
+            !clusters ||
+            Object.keys(clusters).length !== 0 ||
+            Object.keys(clustersToConfig).length !== 0
+          ) {
             dispatch(setConfig(configToStore));
           }
         })
@@ -115,8 +118,7 @@ export function useClustersConf(): ConfigState['clusters'] {
         }
       };
     }
-  },
-  [clusters, dispatch, retry]);
+  }, [clusters, dispatch, retry]);
 
   return clusters;
 }
@@ -133,8 +135,7 @@ export function useCluster() {
     if (cluster !== currentCluster) {
       setCluster(getCluster());
     }
-  },
-  [clusters, cluster, location]);
+  }, [clusters, cluster, location]);
 
   return cluster;
 }
@@ -151,17 +152,19 @@ export function useConnectApi(...apiCalls: (() => CancellablePromise)[]) {
   // @todo: Update this if the active cluster management is changed.
   const location = useLocation();
 
-  React.useEffect(() => {
-    const cancellables = apiCalls.map(func => func());
+  React.useEffect(
+    () => {
+      const cancellables = apiCalls.map(func => func());
 
-    return function cleanup() {
-      for (const cancellablePromise of cancellables) {
-        cancellablePromise.then(cancellable => cancellable());
-      }
-    };
-  },
+      return function cleanup() {
+        for (const cancellablePromise of cancellables) {
+          cancellablePromise.then(cancellable => cancellable());
+        }
+      };
+    },
     // If we add the apiCalls to the dependency list, then it actually
     // results in undesired reloads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [location]);
+    [location]
+  );
 }

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -26,7 +26,7 @@ class Ingress extends makeKubeObject<KubeIngress>('ingress') {
   }
 
   getHosts() {
-    return this.spec!.rules.map(({host}) => host).join(' | ');
+    return this.spec!.rules.map(({ host }) => host).join(' | ');
   }
 
   get listRoute() {

--- a/frontend/src/lib/k8s/persistentVolumeClaim.ts
+++ b/frontend/src/lib/k8s/persistentVolumeClaim.ts
@@ -24,7 +24,9 @@ export interface KubePersistentVolumeClaim extends KubeObjectInterface {
   };
 }
 
-class PersistentVolumeClaim extends makeKubeObject<KubePersistentVolumeClaim>('persistentVolumeClaim') {
+class PersistentVolumeClaim extends makeKubeObject<KubePersistentVolumeClaim>(
+  'persistentVolumeClaim'
+) {
   static apiEndpoint = apiFactoryWithNamespace('', 'v1', 'persistentvolumeclaims');
 
   get spec() {

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -1,6 +1,12 @@
 import { Base64 } from 'js-base64';
 import { apiFactoryWithNamespace, stream, StreamResultsCb } from './apiProxy';
-import { KubeCondition, KubeContainer, KubeContainerStatus, KubeObjectInterface, makeKubeObject } from './cluster';
+import {
+  KubeCondition,
+  KubeContainer,
+  KubeContainerStatus,
+  KubeObjectInterface,
+  makeKubeObject,
+} from './cluster';
 
 export interface KubePod extends KubeObjectInterface {
   spec: {
@@ -35,8 +41,7 @@ class Pod extends makeKubeObject<KubePod>('Pod') {
     return this.jsonData!.status;
   }
 
-  getLogs(container: string, tailLines: number, showPrevious: boolean,
-          onLogs: StreamResultsCb) {
+  getLogs(container: string, tailLines: number, showPrevious: boolean, onLogs: StreamResultsCb) {
     let logs: string[] = [];
     const url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/log?container=${container}&previous=${showPrevious}&tailLines=${tailLines}&follow=true`;
 
@@ -49,21 +54,28 @@ class Pod extends makeKubeObject<KubePod>('Pod') {
       onLogs(logs);
     }
 
-    const { cancel } = stream(url, onResults,
-                              { isJson: false,
-                                connectCb: () => { logs = []; },
-                              });
+    const { cancel } = stream(url, onResults, {
+      isJson: false,
+      connectCb: () => {
+        logs = [];
+      },
+    });
 
     return cancel;
   }
 
   exec(container: string, onExec: StreamResultsCb, options: ExecOptions = {}) {
-    const {command = ['sh'], reconnectOnFailure = undefined} = options;
+    const { command = ['sh'], reconnectOnFailure = undefined } = options;
     const commandStr = command.map(item => '&command=' + encodeURIComponent(item)).join('');
     const url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/exec?container=${container}${commandStr}&stdin=1&stderr=1&stdout=1&tty=1`;
-    const additionalProtocols = ['v4.channel.k8s.io', 'v3.channel.k8s.io', 'v2.channel.k8s.io', 'channel.k8s.io'];
+    const additionalProtocols = [
+      'v4.channel.k8s.io',
+      'v3.channel.k8s.io',
+      'v2.channel.k8s.io',
+      'channel.k8s.io',
+    ];
 
-    return stream(url, onExec, {additionalProtocols, isJson: false, reconnectOnFailure});
+    return stream(url, onExec, { additionalProtocols, isJson: false, reconnectOnFailure });
   }
 }
 

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -70,7 +70,7 @@ export const ROUTES: {
     exact: true,
     name: 'Cluster',
     sidebar: 'cluster',
-    component: () => <Overview />
+    component: () => <Overview />,
   },
   chooser: {
     path: '/',
@@ -78,286 +78,286 @@ export const ROUTES: {
     sidebar: null,
     noCluster: true,
     noAuthRequired: true,
-    component: () => <Chooser useCover open />
+    component: () => <Chooser useCover open />,
   },
   namespaces: {
     path: '/namespaces',
     name: 'Namespaces',
     exact: true,
     sidebar: 'namespaces',
-    component: () => <NamespacesList />
+    component: () => <NamespacesList />,
   },
   namespace: {
     path: '/namespaces/:name',
     sidebar: 'namespaces',
-    component: () => <NamespaceDetails />
+    component: () => <NamespaceDetails />,
   },
   nodes: {
     path: '/nodes',
     name: 'Nodes',
     exact: true,
     sidebar: 'nodes',
-    component: () => <NodeList />
+    component: () => <NodeList />,
   },
   node: {
     path: '/nodes/:name',
     sidebar: 'nodes',
-    component: () => <NodeDetails />
+    component: () => <NodeDetails />,
   },
   storageClasses: {
     path: '/storage/classes',
     exact: true,
     sidebar: 'storageClasses',
     name: 'Storage Classes',
-    component: () => <StorageClassList />
+    component: () => <StorageClassList />,
   },
   storageClass: {
     path: '/storage/classes/:name',
     name: 'Storage Classes',
     sidebar: 'storageClasses',
-    component: () => <StorageClassDetails />
+    component: () => <StorageClassDetails />,
   },
   persistentVolumes: {
     path: '/storage/persistentvolumes',
     exact: true,
     sidebar: 'persistentVolumes',
     name: 'Storage Volumes',
-    component: () => <PersistentVolumeList />
+    component: () => <PersistentVolumeList />,
   },
   persistentVolume: {
     path: '/storage/persistentvolumes/:name',
     exact: true,
     sidebar: 'persistentVolumes',
     name: 'Storage Volume',
-    component: () => <PersistentVolumeDetails />
+    component: () => <PersistentVolumeDetails />,
   },
   persistentVolumeClaims: {
     path: '/storage/persistentvolumeclaims',
     exact: true,
     sidebar: 'persistentVolumeClaims',
     name: 'Persistent Volume Claims',
-    component: () => <PersistentVolumeClaimList />
+    component: () => <PersistentVolumeClaimList />,
   },
   persistentVolumeClaim: {
     path: '/storage/persistentvolumeclaims/:namespace/:name',
     sidebar: 'persistentVolumeClaims',
     exact: true,
-    component: () => <PersistentVolumeClaimDetails />
+    component: () => <PersistentVolumeClaimDetails />,
   },
   workloads: {
     path: '/workloads',
     exact: true,
     name: 'Workloads',
     sidebar: 'workloads',
-    component: () => <WorkloadOverview />
+    component: () => <WorkloadOverview />,
   },
   DaemonSet: {
     path: '/daemonsets/:namespace/:name',
     exact: true,
     sidebar: 'DaemonSets',
-    component: () => <DaemonSetDetails />
+    component: () => <DaemonSetDetails />,
   },
   StatefulSet: {
     path: '/statefulsets/:namespace/:name',
     exact: true,
     sidebar: 'StatefulSets',
-    component: () => <StatefulSetDetails />
+    component: () => <StatefulSetDetails />,
   },
   Deployment: {
     path: '/deployments/:namespace/:name',
     exact: true,
     sidebar: 'Deployments',
-    component: () => <WorkloadDetails workloadKind={Deployment} />
+    component: () => <WorkloadDetails workloadKind={Deployment} />,
   },
   Job: {
     path: '/jobs/:namespace/:name',
     exact: true,
     sidebar: 'Jobs',
-    component: () => <WorkloadDetails workloadKind={Job} />
+    component: () => <WorkloadDetails workloadKind={Job} />,
   },
   CronJob: {
     path: '/cronjobs/:namespace/:name',
     exact: true,
     sidebar: 'CronJobs',
-    component: () => <WorkloadDetails workloadKind={CronJob} />
+    component: () => <WorkloadDetails workloadKind={CronJob} />,
   },
   Pods: {
     path: '/pods',
     exact: true,
     name: 'Pods',
     sidebar: 'Pods',
-    component: () => <PodList />
+    component: () => <PodList />,
   },
   Pod: {
     path: '/pods/:namespace/:name',
     exact: true,
     sidebar: 'Pods',
-    component: () => <PodDetails />
+    component: () => <PodDetails />,
   },
   services: {
     path: '/services',
     exact: true,
     name: 'Services',
     sidebar: 'services',
-    component: () => <ServiceList />
+    component: () => <ServiceList />,
   },
   service: {
     path: '/services/:namespace/:name',
     exact: true,
     sidebar: 'services',
-    component: () => <ServiceDetails />
+    component: () => <ServiceDetails />,
   },
   ingresses: {
     path: '/ingresses',
     exact: true,
     name: 'Ingresses',
     sidebar: 'ingresses',
-    component: () => <IngressList />
+    component: () => <IngressList />,
   },
   ingress: {
     path: '/ingresses/:namespace/:name',
     exact: true,
     sidebar: 'ingresses',
-    component: () => <IngressDetails />
+    component: () => <IngressDetails />,
   },
   DaemonSets: {
     path: '/daemonsets',
     exact: true,
     sidebar: 'DaemonSets',
     name: 'DaemonSets',
-    component: () => <DaemonSetList/>
+    component: () => <DaemonSetList />,
   },
   Jobs: {
     path: '/jobs',
     exact: true,
     sidebar: 'Jobs',
     name: 'Jobs',
-    component: () => <JobsList/>
+    component: () => <JobsList />,
   },
   CronJobs: {
     path: '/cronjobs',
     exact: true,
     sidebar: 'CronJobs',
     name: 'CronJobs',
-    component: () => <CronJobList/>
+    component: () => <CronJobList />,
   },
   Deployments: {
     path: '/deployments',
     exact: true,
     sidebar: 'Deployments',
     name: 'Deployments',
-    component: () => <DeploymentsList/>
+    component: () => <DeploymentsList />,
   },
   StatefulSets: {
     path: '/statefulsets',
     exact: true,
     sidebar: 'StatefulSets',
     name: 'StatefulSets',
-    component: () => <StatefulSetList/>
+    component: () => <StatefulSetList />,
   },
   ReplicaSets: {
     path: '/replicasets',
     exact: true,
     name: 'ReplicaSets',
     sidebar: 'ReplicaSets',
-    component: () => <ReplicaSetList />
+    component: () => <ReplicaSetList />,
   },
   ReplicaSet: {
     path: '/replicasets/:namespace/:name',
     exact: true,
     sidebar: 'ReplicaSets',
-    component: () => <WorkloadDetails workloadKind={ReplicaSet} />
+    component: () => <WorkloadDetails workloadKind={ReplicaSet} />,
   },
   configMaps: {
     path: '/configmaps',
     exact: true,
     name: 'Config Maps',
     sidebar: 'configMaps',
-    component: () => <ConfigMapList />
+    component: () => <ConfigMapList />,
   },
   configMap: {
     path: '/configmaps/:namespace/:name',
     exact: true,
     sidebar: 'configMaps',
-    component: () => <ConfigDetails />
+    component: () => <ConfigDetails />,
   },
   serviceAccounts: {
     path: '/serviceaccounts',
     exact: true,
     name: 'Service Accounts',
     sidebar: 'serviceAccounts',
-    component: () => <ServiceAccountList />
+    component: () => <ServiceAccountList />,
   },
   serviceAccount: {
     path: '/serviceaccounts/:namespace/:name',
     exact: true,
     sidebar: 'serviceAccounts',
-    component: () => <ServiceAccountDetails />
+    component: () => <ServiceAccountDetails />,
   },
   roles: {
     path: '/roles',
     exact: true,
     name: 'Roles',
     sidebar: 'roles',
-    component: () => <RoleList />
+    component: () => <RoleList />,
   },
   role: {
     path: '/roles/:namespace/:name',
     exact: true,
     sidebar: 'roles',
-    component: () => <RoleDetails />
+    component: () => <RoleDetails />,
   },
   clusterrole: {
     path: '/clusterroles/:name',
     exact: true,
     sidebar: 'roles',
-    component: () => <RoleDetails />
+    component: () => <RoleDetails />,
   },
   clusterRoles: {
     path: '/roles',
     exact: true,
     sidebar: 'roles',
-    component: () => <RoleList />
+    component: () => <RoleList />,
   },
   roleBindings: {
     path: '/rolebindings',
     exact: true,
     name: 'Role Bindings',
     sidebar: 'roleBindings',
-    component: () => <RoleBindingList />
+    component: () => <RoleBindingList />,
   },
   roleBinding: {
     path: '/rolebinding/:namespace/:name',
     exact: true,
     name: 'Role Binding',
     sidebar: 'roleBindings',
-    component: () => <RoleBindingDetails />
+    component: () => <RoleBindingDetails />,
   },
   clusterRoleBinding: {
     path: '/clusterrolebinding/:name',
     exact: true,
     name: 'Role Binding',
     sidebar: 'roleBindings',
-    component: () => <RoleBindingDetails />
+    component: () => <RoleBindingDetails />,
   },
   clusterRoleBindings: {
     path: '/rolebindings',
     exact: true,
     sidebar: 'roleBindings',
-    component: () => <RoleBindingDetails />
+    component: () => <RoleBindingDetails />,
   },
   secrets: {
     path: '/secrets',
     exact: true,
     name: 'Secrets',
     sidebar: 'secrets',
-    component: () => <SecretList />
+    component: () => <SecretList />,
   },
   secret: {
     path: '/secrets/:namespace/:name',
     exact: true,
     sidebar: 'secrets',
-    component: () => <SecretDetails />
+    component: () => <SecretDetails />,
   },
   token: {
     path: '/token',
@@ -365,14 +365,14 @@ export const ROUTES: {
     name: 'Token',
     sidebar: null,
     noAuthRequired: true,
-    component: () => <AuthToken/>
+    component: () => <AuthToken />,
   },
   oidcAuth: {
     path: '/auth',
     name: 'OidcAuth',
     sidebar: null,
     noAuthRequired: true,
-    component: () => <OIDCAuth/>
+    component: () => <OIDCAuth />,
   },
   login: {
     path: '/login',
@@ -380,21 +380,21 @@ export const ROUTES: {
     name: 'Login',
     sidebar: null,
     noAuthRequired: true,
-    component: () => <AuthChooser />
+    component: () => <AuthChooser />,
   },
   crds: {
     path: '/crds',
     exact: true,
     name: 'CRDs',
     sidebar: 'crds',
-    component: () => <CustomResourceDefinitionList />
+    component: () => <CustomResourceDefinitionList />,
   },
   crd: {
     path: '/crds/:name',
     exact: true,
     name: 'CRD',
     sidebar: 'crds',
-    component: () => <CustomResourceDefinitionDetails />
+    component: () => <CustomResourceDefinitionDetails />,
   },
 };
 
@@ -430,7 +430,7 @@ export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
     }
   }
   const fullParams = {
-    ...params
+    ...params,
   };
   if (cluster) {
     fullParams.cluster = cluster;

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -32,12 +32,12 @@ const commonRules = {
     success: {
       light: green['50'],
       main: green['500'],
-      ...green
+      ...green,
     },
     warning: {
       main: orange['500'],
       light: orange['50'],
-      ...orange
+      ...orange,
     },
     sidebarLink: {
       main: grey['500'],
@@ -48,13 +48,13 @@ const commonRules = {
       light: red['50'],
     },
     resourceToolTip: {
-      color: 'rgba(0, 0, 0, 0.87)'
+      color: 'rgba(0, 0, 0, 0.87)',
     },
     sidebarBg: '#000',
     normalEventBg: '#F0F0F0',
     chartStyles: {
       defaultFillColor: grey['300'],
-      labelColor: '#000'
+      labelColor: '#000',
     },
     metadataBgColor: grey['300'],
     headerStyle: {
@@ -78,7 +78,7 @@ const commonRules = {
     },
   },
   typography: {
-    fontFamily: ['Overpass', 'sans-serif'].join(', ')
+    fontFamily: ['Overpass', 'sans-serif'].join(', '),
   },
   shape: {
     borderRadius: 0,
@@ -97,17 +97,17 @@ const darkTheme = createMuiTheme({
     chartStyles: {
       defaultFillColor: 'rgba(20, 20, 20, 0.1)',
       fillColor: '#3DA3F5',
-      labelColor: '#fff'
+      labelColor: '#fff',
     },
     success: {
       light: green['500'],
       main: green['50'],
-      ...green
+      ...green,
     },
     warning: {
       main: orange['500'],
       light: 'rgba(255, 152, 0, 0.15)',
-      ...orange
+      ...orange,
     },
     error: {
       main: red['500'],
@@ -116,7 +116,7 @@ const darkTheme = createMuiTheme({
     normalEventBg: '#333333',
     metadataBgColor: '#333',
     resourceToolTip: {
-      color: 'rgba(255, 255, 255, 0.87)'
+      color: 'rgba(255, 255, 255, 0.87)',
     },
     type: 'dark',
   },
@@ -127,8 +127,8 @@ export interface ThemesConf {
 }
 
 const themesConf: ThemesConf = {
-  'light': lightTheme,
-  'dark': darkTheme,
+  light: lightTheme,
+  dark: darkTheme,
 };
 
 export default themesConf;

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -32,18 +32,18 @@ function parseUnitsOfBytes(value: string): number {
 
   // number with exponent ex. 1e3
   if (groups[4] !== undefined) {
-    return number * (10 ** parseInt(groups[4], 10));
+    return number * 10 ** parseInt(groups[4], 10);
   }
 
   const unitIndex = _.indexOf(UNITS, groups[2]);
 
   // Unit + i ex. 1Ki
   if (groups[3] !== undefined) {
-    return number * (1024 ** unitIndex);
+    return number * 1024 ** unitIndex;
   }
 
   // Unit ex. 1K
-  return number * (1000 ** unitIndex);
+  return number * 1000 ** unitIndex;
 }
 
 export function unparseRam(value: number) {

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -28,18 +28,17 @@ export function getPercentStr(value: number, total: number) {
   if (total === 0) {
     return null;
   }
-  const percentage = value / total * 100;
+  const percentage = (value / total) * 100;
   const decimals = percentage % 10 > 0 ? 1 : 0;
   return `${percentage.toFixed(decimals)} %`;
-
 }
 
 export function getReadyReplicas(item: Workload) {
-  return (item.status.readyReplicas || item.status.numberReady || 0);
+  return item.status.readyReplicas || item.status.numberReady || 0;
 }
 
 export function getTotalReplicas(item: Workload) {
-  return (item.spec.replicas || item.status.currentNumberScheduled || 0);
+  return item.spec.replicas || item.status.currentNumberScheduled || 0;
 }
 
 export function getResourceStr(value: number, resourceType: 'cpu' | 'memory') {
@@ -52,7 +51,11 @@ export function getResourceStr(value: number, resourceType: 'cpu' | 'memory') {
   return `${valueInfo.value}${valueInfo.unit}`;
 }
 
-export function getResourceMetrics(item: Node, metrics: KubeMetrics[], resourceType: 'cpu' | 'memory') {
+export function getResourceMetrics(
+  item: Node,
+  metrics: KubeMetrics[],
+  resourceType: 'cpu' | 'memory'
+) {
   const resourceParsers: any = {
     cpu: parseCpu,
     memory: parseRam,
@@ -109,21 +112,24 @@ export function getClusterPrefixedPath(path?: string | null) {
 
 export function getCluster(): string | null {
   const urlPath = isElectron() ? window.location.hash.substr(1) : window.location.pathname;
-  const clusterURLMatch =
-    matchPath<{cluster?: string}>(urlPath, {path: getClusterPrefixedPath()});
+  const clusterURLMatch = matchPath<{ cluster?: string }>(urlPath, {
+    path: getClusterPrefixedPath(),
+  });
   return (!!clusterURLMatch && clusterURLMatch.params.cluster) || null;
 }
 
 export function useErrorState(dependentSetter?: (...args: any) => void) {
   const [error, setError] = React.useState<ApiError | null>(null);
 
-  React.useEffect(() => {
-    if (!!error && !!dependentSetter) {
-      dependentSetter(null);
-    }
-  },
-  // eslint-disable-next-line
-  [error]);
+  React.useEffect(
+    () => {
+      if (!!error && !!dependentSetter) {
+        dependentSetter(null);
+      }
+    },
+    // eslint-disable-next-line
+    [error]
+  );
 
   // Adding "as any" here because it was getting difficult to validate the setter type.
   return [error, setError as any];

--- a/frontend/src/plugin/index.tsx
+++ b/frontend/src/plugin/index.tsx
@@ -1,7 +1,7 @@
 import Registry from './registry';
 
 export abstract class Plugin {
-    abstract initialize(register: Registry): boolean;
+  abstract initialize(register: Registry): boolean;
 }
 
 declare global {
@@ -25,7 +25,7 @@ window.pluginLib = {
   ReactRedux: require('react-redux'),
   Utils: require('../lib/util'),
   Iconify: require('@iconify/react'),
-  Lodash: require('lodash')
+  Lodash: require('lodash'),
 };
 
 window.plugins = {};
@@ -37,10 +37,10 @@ function registerPlugin(pluginId: string, pluginObj: Plugin) {
 window.registerPlugin = registerPlugin;
 
 function loadScripts(array: string[], onLoadFinished: (value?: any) => void) {
-  var loader = function(src: string, handler: () => void) {
+  var loader = function (src: string, handler: () => void) {
     const script: HTMLScriptElement = document.createElement('script');
     script.src = src;
-    script.onload = (script as any).onreadystatechange = function() {
+    script.onload = (script as any).onreadystatechange = function () {
       (script as any).onreadystatechange = script.onload = null;
       handler();
     };
@@ -59,8 +59,8 @@ function loadScripts(array: string[], onLoadFinished: (value?: any) => void) {
 function loadExternalPlugins() {
   return new Promise(resolve => {
     fetch('/plugins/list')
-      .then((response) => response.json())
-      .then((pluginsScriptURLS) => {
+      .then(response => response.json())
+      .then(pluginsScriptURLS => {
         loadScripts(pluginsScriptURLS || [], resolve);
       });
   });

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1,26 +1,39 @@
 import { Route } from '../lib/router';
-import { setAppBarAction, setDetailsViewHeaderAction, setRoute, setSidebarItem } from '../redux/actions/actions';
+import {
+  setAppBarAction,
+  setDetailsViewHeaderAction,
+  setRoute,
+  setSidebarItem,
+} from '../redux/actions/actions';
 import store from '../redux/stores/store';
 
 export default class Registry {
-  registerSidebarItem(parentName: string, itemName: string,
-                      itemLabel: string, url: string,
-                      opts = {useClusterURL: true}) {
-    store.dispatch(setSidebarItem({
-      name: itemName,
-      label: itemLabel,
-      url,
-      useClusterURL: !!opts.useClusterURL,
-      parent: parentName
-    }));
+  registerSidebarItem(
+    parentName: string,
+    itemName: string,
+    itemLabel: string,
+    url: string,
+    opts = { useClusterURL: true }
+  ) {
+    store.dispatch(
+      setSidebarItem({
+        name: itemName,
+        label: itemLabel,
+        url,
+        useClusterURL: !!opts.useClusterURL,
+        parent: parentName,
+      })
+    );
   }
 
   registerRoute(routeSpec: Route) {
     store.dispatch(setRoute(routeSpec));
   }
 
-  registerDetailsViewHeaderAction(actionName: string,
-                                  actionFunc: (...args: any[]) => JSX.Element | null) {
+  registerDetailsViewHeaderAction(
+    actionName: string,
+    actionFunc: (...args: any[]) => JSX.Element | null
+  ) {
     store.dispatch(setDetailsViewHeaderAction(actionName, actionFunc));
   }
 

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -71,12 +71,15 @@ export function resetFilter() {
   return { type: FILTER_RESET };
 }
 
-export function clusterAction(callback: CallbackAction['callback'], actionOptions: CallbackActionOptions = {}) {
-  return { type: CLUSTER_ACTION, callback, ...actionOptions};
+export function clusterAction(
+  callback: CallbackAction['callback'],
+  actionOptions: CallbackActionOptions = {}
+) {
+  return { type: CLUSTER_ACTION, callback, ...actionOptions };
 }
 
 export function updateClusterAction(actionOptions: ClusterAction) {
-  return { type: CLUSTER_ACTION_UPDATE, ...actionOptions};
+  return { type: CLUSTER_ACTION_UPDATE, ...actionOptions };
 }
 
 export function setSidebarSelected(selected: SidebarType['selected']) {
@@ -84,7 +87,7 @@ export function setSidebarSelected(selected: SidebarType['selected']) {
 }
 
 export function setWhetherSidebarOpen(isSidebarOpen: boolean) {
-  return { type: UI_SIDEBAR_SET_EXPANDED, isSidebarOpen};
+  return { type: UI_SIDEBAR_SET_EXPANDED, isSidebarOpen };
 }
 
 export function setSidebarVisible(isVisible: SidebarType['isVisible']) {
@@ -96,22 +99,22 @@ export function setSidebarItem(item: SidebarEntry) {
   if (item.parent === undefined) {
     item['parent'] = null;
   }
-  return { type: UI_SIDEBAR_SET_ITEM, item};
+  return { type: UI_SIDEBAR_SET_ITEM, item };
 }
 
 export function setRoute(routeSpec: any) {
   // @todo: Define routeSpec later.
-  return { type: UI_ROUTER_SET_ROUTE, route: routeSpec};
+  return { type: UI_ROUTER_SET_ROUTE, route: routeSpec };
 }
 
 export function setDetailsViewHeaderAction(actionName: string, actionFunc: HeaderActionFunc) {
-  return { type: UI_DETAILS_VIEW_SET_HEADER_ACTION, name: actionName, action: actionFunc};
+  return { type: UI_DETAILS_VIEW_SET_HEADER_ACTION, name: actionName, action: actionFunc };
 }
 
 export function setAppBarAction(actionName: string, actionFunc: HeaderActionFunc) {
-  return { type: UI_APP_BAR_SET_ACTION, name: actionName, action: actionFunc};
+  return { type: UI_APP_BAR_SET_ACTION, name: actionName, action: actionFunc };
 }
 
 export function setConfig(config: object) {
-  return { type: CONFIG_NEW, config};
+  return { type: CONFIG_NEW, config };
 }

--- a/frontend/src/redux/reducers/clusterAction.tsx
+++ b/frontend/src/redux/reducers/clusterAction.tsx
@@ -10,20 +10,20 @@ export const INITIAL_STATE: ClusterState = {
 };
 
 function cluster(clusterActions = INITIAL_STATE, action: ClusterAction & Action) {
-  const {type, id, ...actionOptions} = action;
-  const newState = {...clusterActions};
+  const { type, id, ...actionOptions } = action;
+  const newState = { ...clusterActions };
   switch (type) {
     case CLUSTER_ACTION_UPDATE:
       if (_.isEmpty(actionOptions)) {
         delete newState[id];
       } else {
-        newState[id] = {...(action as ClusterAction)};
+        newState[id] = { ...(action as ClusterAction) };
       }
       break;
 
     default:
       break;
-  };
+  }
 
   return newState;
 }

--- a/frontend/src/redux/reducers/config.tsx
+++ b/frontend/src/redux/reducers/config.tsx
@@ -12,14 +12,14 @@ export const INITIAL_STATE: ConfigState = {
 };
 
 function reducer(state = INITIAL_STATE, action: Action) {
-  const newState = {...state};
+  const newState = { ...state };
   switch (action.type) {
     case CONFIG_NEW:
-      newState.clusters = {...action.config.clusters};
+      newState.clusters = { ...action.config.clusters };
       break;
     default:
       break;
-  };
+  }
 
   return newState;
 }

--- a/frontend/src/redux/reducers/filter.tsx
+++ b/frontend/src/redux/reducers/filter.tsx
@@ -3,11 +3,11 @@ import { Action, FILTER_RESET, FILTER_SET_NAMESPACE, FILTER_SET_SEARCH } from '.
 
 export const INITIAL_STATE: FilterState = {
   namespaces: new Set(),
-  search: ''
+  search: '',
 };
 
 function filter(filters = INITIAL_STATE, action: Action) {
-  let newFilters = {...filters};
+  let newFilters = { ...filters };
   switch (action.type) {
     case FILTER_SET_NAMESPACE:
       newFilters.namespaces = new Set(action.namespaces);
@@ -16,12 +16,12 @@ function filter(filters = INITIAL_STATE, action: Action) {
       newFilters.search = action.search;
       break;
     case FILTER_RESET:
-      newFilters = {...INITIAL_STATE};
+      newFilters = { ...INITIAL_STATE };
       break;
 
     default:
       break;
-  };
+  }
 
   return newFilters;
 }

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,4 +1,14 @@
-import { Action, HeaderActionFunc, UI_APP_BAR_SET_ACTION, UI_DETAILS_VIEW_SET_HEADER_ACTION, UI_ROUTER_SET_ROUTE, UI_SIDEBAR_SET_EXPANDED, UI_SIDEBAR_SET_ITEM, UI_SIDEBAR_SET_SELECTED, UI_SIDEBAR_SET_VISIBLE } from '../actions/actions';
+import {
+  Action,
+  HeaderActionFunc,
+  UI_APP_BAR_SET_ACTION,
+  UI_DETAILS_VIEW_SET_HEADER_ACTION,
+  UI_ROUTER_SET_ROUTE,
+  UI_SIDEBAR_SET_EXPANDED,
+  UI_SIDEBAR_SET_ITEM,
+  UI_SIDEBAR_SET_SELECTED,
+  UI_SIDEBAR_SET_VISIBLE,
+} from '../actions/actions';
 
 export interface SidebarEntry {
   name: string;
@@ -50,7 +60,7 @@ export const INITIAL_STATE: UIState = {
     selected: null,
     isVisible: false,
     isSidebarOpen: getSidebarOpenStatus(),
-    entries: {}
+    entries: {},
   },
   routes: {
     // path -> component
@@ -59,18 +69,18 @@ export const INITIAL_STATE: UIState = {
     details: {
       headerActions: {
         // action-name -> action-callback
-      }
+      },
     },
     appBar: {
       actions: {
         // action-name -> action-callback
       },
     },
-  }
+  },
 };
 
 function reducer(state = INITIAL_STATE, action: Action) {
-  const newFilters = {...state};
+  const newFilters = { ...state };
   switch (action.type) {
     case UI_SIDEBAR_SET_SELECTED: {
       newFilters.sidebar = {
@@ -83,48 +93,48 @@ function reducer(state = INITIAL_STATE, action: Action) {
     case UI_SIDEBAR_SET_VISIBLE: {
       newFilters.sidebar = {
         ...newFilters.sidebar,
-        isVisible: action.isVisible
+        isVisible: action.isVisible,
       };
       break;
     }
     case UI_SIDEBAR_SET_ITEM: {
-      const entries = {...newFilters.sidebar.entries};
+      const entries = { ...newFilters.sidebar.entries };
       entries[action.item.name] = action.item;
 
       newFilters.sidebar = {
         ...newFilters.sidebar,
-        entries
+        entries,
       };
       break;
     }
     case UI_SIDEBAR_SET_EXPANDED: {
       newFilters.sidebar = {
         ...newFilters.sidebar,
-        isSidebarOpen: action.isSidebarOpen
+        isSidebarOpen: action.isSidebarOpen,
       };
       break;
     }
     case UI_ROUTER_SET_ROUTE: {
-      const routes = {...newFilters.routes};
+      const routes = { ...newFilters.routes };
       routes[action.route.path] = action.route;
       newFilters.routes = routes;
       break;
     }
     case UI_DETAILS_VIEW_SET_HEADER_ACTION: {
-      const headerActions = {...newFilters.views.details.headerActions};
+      const headerActions = { ...newFilters.views.details.headerActions };
       headerActions[action.action as string] = action.action;
       newFilters.views.details.headerActions = headerActions;
       break;
     }
     case UI_APP_BAR_SET_ACTION: {
-      const appBarActions = {...newFilters.views.appBar.actions};
+      const appBarActions = { ...newFilters.views.appBar.actions };
       appBarActions[action.name as string] = action.action;
       newFilters.views.appBar.actions = appBarActions;
       break;
     }
     default:
       return state;
-  };
+  }
 
   return newFilters;
 }

--- a/frontend/src/redux/sagas/sagas.tsx
+++ b/frontend/src/redux/sagas/sagas.tsx
@@ -1,6 +1,13 @@
 import { all, call, cancelled, delay, put, race, take, takeEvery } from 'redux-saga/effects';
 import { CLUSTER_ACTION_GRACE_PERIOD } from '../../lib/util';
-import { Action, CallbackAction, CLUSTER_ACTION, CLUSTER_ACTION_CANCEL, ClusterAction, updateClusterAction } from '../actions/actions';
+import {
+  Action,
+  CallbackAction,
+  CLUSTER_ACTION,
+  CLUSTER_ACTION_CANCEL,
+  ClusterAction,
+  updateClusterAction,
+} from '../actions/actions';
 
 function newActionKey() {
   return (new Date().getTime() + Math.random()).toString();
@@ -34,36 +41,40 @@ function* doClusterAction(action: CallbackAction, actionKey: string, uniqueCance
     successMessage,
     startOptions = {},
     cancelledOptions = {},
-    successOptions = {variant: 'success'},
-    errorOptions = {variant: 'error'},
+    successOptions = { variant: 'success' },
+    errorOptions = { variant: 'error' },
   } = action;
 
   try {
-    yield put(updateClusterAction({
-      key: actionKey,
-      id: actionKey,
-      message: startMessage,
-      url: startUrl,
-      buttons: [
-        {
-          label: 'Cancel',
-          actionToDispatch: uniqueCancelAction,
-        },
-      ],
-      snackbarProps: startOptions,
-    }));
+    yield put(
+      updateClusterAction({
+        key: actionKey,
+        id: actionKey,
+        message: startMessage,
+        url: startUrl,
+        buttons: [
+          {
+            label: 'Cancel',
+            actionToDispatch: uniqueCancelAction,
+          },
+        ],
+        snackbarProps: startOptions,
+      })
+    );
 
     yield delay(CLUSTER_ACTION_GRACE_PERIOD);
   } finally {
     // Check if it's been cancelled.
     if (yield cancelled()) {
-      yield put(updateClusterAction({
-        id: actionKey,
-        message: cancelledMessage,
-        dismissSnackbar: actionKey,
-        url: cancelUrl,
-        snackbarProps: cancelledOptions,
-      }));
+      yield put(
+        updateClusterAction({
+          id: actionKey,
+          message: cancelledMessage,
+          dismissSnackbar: actionKey,
+          url: cancelUrl,
+          snackbarProps: cancelledOptions,
+        })
+      );
     } else {
       // Actually perform the action. This part is no longer cancellable,
       // so it's here instead of within the try block.
@@ -100,22 +111,22 @@ function* doClusterAction(action: CallbackAction, actionKey: string, uniqueCance
     }
 
     // Reset state if no other deletion happens
-    const {timeout} = yield race({
+    const { timeout } = yield race({
       newAction: take(CLUSTER_ACTION),
-      timeout: delay(3000)
+      timeout: delay(3000),
     });
 
     // Reset the cluster action
     if (timeout) {
-      yield put(updateClusterAction({
-        id: actionKey
-      }));
+      yield put(
+        updateClusterAction({
+          id: actionKey,
+        })
+      );
     }
   }
 }
 
 export default function* rootSaga() {
-  yield all([
-    watchClusterAction(),
-  ]);
+  yield all([watchClusterAction()]);
 }

--- a/frontend/src/redux/stores/store.tsx
+++ b/frontend/src/redux/stores/store.tsx
@@ -14,11 +14,7 @@ const initialState = {
 
 const sagaMiddleware = createSagaMiddleware();
 
-const store = createStore(
-  reducers,
-  initialState,
-  applyMiddleware(sagaMiddleware),
-);
+const store = createStore(reducers, initialState, applyMiddleware(sagaMiddleware));
 
 export default store;
 

--- a/frontend/src/serviceWorker.ts
+++ b/frontend/src/serviceWorker.ts
@@ -15,12 +15,10 @@ const isLocalhost = Boolean(
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
     // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
-export function register(config: {[prop: string]: any}) {
+export function register(config: { [prop: string]: any }) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
@@ -54,7 +52,7 @@ export function register(config: {[prop: string]: any}) {
   }
 }
 
-function registerValidSW(swUrl: string, config: {[prop: string]: any}) {
+function registerValidSW(swUrl: string, config: { [prop: string]: any }) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
@@ -98,7 +96,7 @@ function registerValidSW(swUrl: string, config: {[prop: string]: any}) {
     });
 }
 
-function checkValidServiceWorker(swUrl: string, config: {[prop: string]: any}) {
+function checkValidServiceWorker(swUrl: string, config: { [prop: string]: any }) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
@@ -120,9 +118,7 @@ function checkValidServiceWorker(swUrl: string, config: {[prop: string]: any}) {
       }
     })
     .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
+      console.log('No internet connection found. App is running in offline mode.');
     });
 }
 

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,5 +1,5 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
-module.exports = function(app) {
+module.exports = function (app) {
   app.use(
     '/plugins',
     createProxyMiddleware({


### PR DESCRIPTION
Based on config from create react app prettier docs.
https://create-react-app.dev/docs/setting-up-your-editor/#formatting-code-automatically

Files that are git staged get eslint and prettier run on them.
This is done via lint-staged, and husky with git hooks.

`npm run format` formats code with prettier.

We use eslint-config-prettier to smooth integration with eslint.

Both eslint, and prettier:

- use @kinvolk/eslint-config 0.3.0
- are configured by package.json.

# How to use

Files that are git staged get prettier run on them.

See [Editor integration](https://prettier.io/docs/en/editors.html) section of prettier docs.

# Testing done

- `npm run format`
- `npm run lint`
- `vi src/App.tsx && git commit .` # should show eslint and prettier being run with git pre-commit hook.

See the new `@kinvolk/eslint-config` shared config PR here: https://github.com/kinvolk/eslint-config/pull/3 (which has instructions on how to test).

fixes #185 