### PR TITLE
Allow viewing resource YAML even if its read-only token

### DIFF
--- a/frontend/src/components/common/EditButton.tsx
+++ b/frontend/src/components/common/EditButton.tsx
@@ -9,6 +9,7 @@ import { KubeObject } from '../../lib/k8s/cluster';
 import { KubeServiceAccount } from '../../lib/k8s/serviceAccount';
 import { CallbackActionOptions, clusterAction } from '../../redux/actions/actions';
 import EditorDialog from './EditorDialog';
+import ViewButton from './ViewButton';
 
 interface EditButtonProps {
   item: KubeObject;
@@ -76,7 +77,7 @@ export default function EditButton(props: EditButtonProps) {
   [item]);
 
   if (!visible) {
-    return null;
+    return <ViewButton item={item}/>;
   }
 
   return (

--- a/frontend/src/components/common/ViewButton.tsx
+++ b/frontend/src/components/common/ViewButton.tsx
@@ -1,0 +1,41 @@
+import eyeIcon from '@iconify/icons-mdi/eye';
+import eyeOff from '@iconify/icons-mdi/eye-off';
+import Icon from '@iconify/react';
+import { IconButton, Tooltip } from '@material-ui/core';
+import React from 'react';
+import { KubeObject } from '../../lib/k8s/cluster';
+import EditorDialog from './EditorDialog';
+
+interface ViewButtonProps {
+    item: KubeObject;
+}
+
+function ViewButton(props: ViewButtonProps) {
+  const {item} = props;
+  const [toggle, setToggle] = React.useState(false);
+  function handleButtonClick() {
+    setToggle((toggle) => !toggle);
+  }
+  return (
+    <>
+      <Tooltip title="View YAML">
+        <IconButton
+          edge="end"
+          aria-label="show yaml viewer"
+          onClick={handleButtonClick}
+          onMouseDown={event => event.preventDefault()}
+        >
+          <Icon icon={eyeIcon} />
+        </IconButton>
+      </Tooltip>
+      <EditorDialog
+        item={item.jsonData}
+        open={toggle}
+        onClose={() => setToggle((toggle) => !toggle)}
+        onSave={null}
+      />
+    </>
+  );
+}
+
+export default ViewButton;


### PR DESCRIPTION
Users logged in via a read only token can also see resource YAML(in read-only mode)

fixes #175 