### PR TITLE
Add "make docs" with typedoc for docs/developer/api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ backend/server
 backend/server.exe
 backend/tools
 app/electron/src/*
+docs/development/storybook/

--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,7 @@ image:
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile \
 	.
+
+.PHONY: docs
+docs:
+	cd frontend && npm install && npm run build-typedoc

--- a/docs/development/api/_index.md
+++ b/docs/development/api/_index.md
@@ -1,0 +1,12 @@
+---
+title: "API"
+linkTitle: "API"
+slug: "_index"
+---
+
+## Table of contents
+
+### Modules
+
+- [k8s](modules/k8s.md)
+- [util](modules/util.md)

--- a/docs/development/api/interfaces/_index.md
+++ b/docs/development/api/interfaces/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Interfaces"
+---

--- a/docs/development/api/interfaces/util.filterstate.md
+++ b/docs/development/api/interfaces/util.filterstate.md
@@ -1,0 +1,23 @@
+---
+title: "Interface: FilterState"
+linkTitle: "FilterState"
+slug: "util.filterstate"
+---
+
+[util](../modules/util.md).FilterState
+
+## Properties
+
+### namespaces
+
+• **namespaces**: *Set*<string\>
+
+Defined in: [util.ts:74](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L74)
+
+___
+
+### search
+
+• **search**: *string*
+
+Defined in: [util.ts:75](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L75)

--- a/docs/development/api/modules/_index.md
+++ b/docs/development/api/modules/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Modules"
+---

--- a/docs/development/api/modules/k8s.md
+++ b/docs/development/api/modules/k8s.md
@@ -1,0 +1,61 @@
+---
+title: "Module: k8s"
+linkTitle: "k8s"
+slug: "k8s"
+---
+
+## Variables
+
+### ResourceClasses
+
+• `Const` **ResourceClasses**: *object*
+
+#### Type declaration:
+
+Defined in: [k8s/index.ts:71](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/k8s/index.ts#L71)
+
+## Functions
+
+### getVersion
+
+▸ **getVersion**(): *Promise*<StringDict\>
+
+**Returns:** *Promise*<StringDict\>
+
+Defined in: [k8s/index.ts:143](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/k8s/index.ts#L143)
+
+___
+
+### useCluster
+
+▸ **useCluster**(): *null* \| *string*
+
+**Returns:** *null* \| *string*
+
+Defined in: [k8s/index.ts:126](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/k8s/index.ts#L126)
+
+___
+
+### useClustersConf
+
+▸ **useClustersConf**(): ConfigState[*clusters*]
+
+**Returns:** ConfigState[*clusters*]
+
+Defined in: [k8s/index.ts:78](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/k8s/index.ts#L78)
+
+___
+
+### useConnectApi
+
+▸ **useConnectApi**(...`apiCalls`: () => CancellablePromise[]): *void*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`...apiCalls` | () => CancellablePromise[] |
+
+**Returns:** *void*
+
+Defined in: [k8s/index.ts:149](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/k8s/index.ts#L149)

--- a/docs/development/api/modules/util.md
+++ b/docs/development/api/modules/util.md
@@ -1,0 +1,204 @@
+---
+title: "Module: util"
+linkTitle: "util"
+slug: "util"
+---
+
+## Table of contents
+
+### Interfaces
+
+- [FilterState](../interfaces/util.filterstate.md)
+
+## Variables
+
+### CLUSTER\_ACTION\_GRACE\_PERIOD
+
+• `Const` **CLUSTER\_ACTION\_GRACE\_PERIOD**: *5000*= 5000
+
+Defined in: [util.ts:15](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L15)
+
+## Functions
+
+### filterResource
+
+▸ **filterResource**(`item`: KubeObjectInterface, `filter`: [*FilterState*](../interfaces/util.filterstate.md)): *boolean*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`item` | KubeObjectInterface |
+`filter` | [*FilterState*](../interfaces/util.filterstate.md) |
+
+**Returns:** *boolean*
+
+Defined in: [util.ts:78](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L78)
+
+___
+
+### getCluster
+
+▸ **getCluster**(): *string* \| *null*
+
+**Returns:** *string* \| *null*
+
+Defined in: [util.ts:113](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L113)
+
+___
+
+### getClusterPrefixedPath
+
+▸ **getClusterPrefixedPath**(`path?`: *string* \| *null*): *string*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`path?` | *string* \| *null* |
+
+**Returns:** *string*
+
+Defined in: [util.ts:105](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L105)
+
+___
+
+### getPercentStr
+
+▸ **getPercentStr**(`value`: *number*, `total`: *number*): *null* \| *string*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`value` | *number* |
+`total` | *number* |
+
+**Returns:** *null* \| *string*
+
+Defined in: [util.ts:27](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L27)
+
+___
+
+### getReadyReplicas
+
+▸ **getReadyReplicas**(`item`: Workload): *any*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`item` | Workload |
+
+**Returns:** *any*
+
+Defined in: [util.ts:36](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L36)
+
+___
+
+### getResourceMetrics
+
+▸ **getResourceMetrics**(`item`: Node, `metrics`: KubeMetrics[], `resourceType`: *cpu* \| *memory*): *any*[]
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`item` | Node |
+`metrics` | KubeMetrics[] |
+`resourceType` | *cpu* \| *memory* |
+
+**Returns:** *any*[]
+
+Defined in: [util.ts:54](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L54)
+
+___
+
+### getResourceStr
+
+▸ **getResourceStr**(`value`: *number*, `resourceType`: *cpu* \| *memory*): *string*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`value` | *number* |
+`resourceType` | *cpu* \| *memory* |
+
+**Returns:** *string*
+
+Defined in: [util.ts:44](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L44)
+
+___
+
+### getTotalReplicas
+
+▸ **getTotalReplicas**(`item`: Workload): *any*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`item` | Workload |
+
+**Returns:** *any*
+
+Defined in: [util.ts:40](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L40)
+
+___
+
+### localeDate
+
+▸ **localeDate**(`date`: DateParam): *string*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`date` | DateParam |
+
+**Returns:** *string*
+
+Defined in: [util.ts:23](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L23)
+
+___
+
+### timeAgo
+
+▸ **timeAgo**(`date`: DateParam): *string*
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`date` | DateParam |
+
+**Returns:** *string*
+
+Defined in: [util.ts:19](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L19)
+
+___
+
+### useErrorState
+
+▸ **useErrorState**(`dependentSetter?`: (...`args`: *any*) => *void*): *any*[]
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`dependentSetter?` | (...`args`: *any*) => *void* |
+
+**Returns:** *any*[]
+
+Defined in: [util.ts:125](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L125)
+
+___
+
+### useFilterFunc
+
+▸ **useFilterFunc**(): *function*
+
+**Returns:** (`item`: KubeObjectInterface) => *boolean*
+
+Defined in: [util.ts:100](https://github.com/kinvolk/headlamp/blob/b1d8df6/frontend/src/lib/util.ts#L100)

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -26,3 +26,16 @@ make run-frontend
 
 This command leverages the `create-react-app`'s start script that launches
 a development server for the frontend (by default at `localhost:3000`).
+
+
+## API documentation
+
+API documentation for TypeScript is done with [typedoc](https://typedoc.org/) and [typedoc-plugin-markdown](https://github.com/tgreyuk/typedoc-plugin-markdown), and is configured in tsconfig.json
+
+```bash
+make docs
+```
+
+The API output mardown is generated in docs/development/api and is not 
+committed to git, but is shown on the website at
+[headlamp/latest/development/api](https://kinvolk.io/docs/headlamp/latest/development/api/)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10780,8 +10780,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -15394,6 +15393,27 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -19712,6 +19732,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -19788,6 +19814,12 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
+    },
+    "marked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "dev": true
     },
     "material-colors": {
       "version": "1.2.6",
@@ -20893,6 +20925,32 @@
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "open": {
@@ -25749,6 +25807,16 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "optional": true
     },
+    "shiki": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
@@ -27930,6 +27998,72 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.20.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.28.tgz",
+      "integrity": "sha512-8j0T8u9FuyDkoe+M/3cyoaGJSVgXCY9KwVoo7TLUnmQuzXwqH+wkScY530ZEdK6G39UZ2LFTYPIrL5eykWjx6A==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
+        "marked": "^2.0.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.2",
+        "typedoc-default-themes": "^0.12.7"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.7.tgz",
+      "integrity": "sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==",
+      "dev": true
+    },
+    "typedoc-hugo-theme": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/typedoc-hugo-theme/-/typedoc-hugo-theme-0.2.0.tgz",
+      "integrity": "sha512-rOArPW/tDbc9envS7apYKS/iqNCKRLxGQHQWAC2pJ5ytxR8ra6aJhSdtLtO6tFbrqQqpryLYZo0OU3Sjus7g2A==",
+      "dev": true
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.6.0.tgz",
+      "integrity": "sha512-fg4xby3awJVVxB8TdhHNsZQfiTC5x1XmauVwhKXc6hGeu1bzTnqrkmDT8NCjxfUgw64si8cUX1jBfBjAHthWpQ==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.6"
+      }
+    },
     "typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
@@ -27955,6 +28089,13 @@
       "requires": {
         "typescript-compare": "^0.0.2"
       }
+    },
+    "uglify-js": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
+      "integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
+      "dev": true,
+      "optional": true
     },
     "unfetch": {
       "version": "4.2.0",
@@ -28548,6 +28689,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -29824,6 +29971,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "workbox-background-sync": {
       "version": "5.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,8 @@
     "lint": "eslint -c package.json --ext .js,.ts,.tsx src/ ../app/electron",
     "format": "prettier --config package.json --write src/ ../app/electron",
     "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-typedoc": "npx typedoc",
+    "build-storybook": "build-storybook -s public -o ../docs/development/storybook"
   },
   "browserslist": {
     "production": [
@@ -133,6 +134,9 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "http-proxy-middleware": "^1.0.6",
-    "monaco-editor-webpack-plugin": "^2.1.0"
+    "monaco-editor-webpack-plugin": "^2.1.0",
+    "typedoc": "^0.20.28",
+    "typedoc-hugo-theme": "^0.2.0",
+    "typedoc-plugin-markdown": "^3.6.0"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,5 +22,17 @@
   },
   "include": [
     "src"
-  ]
+  ],
+  "typedocOptions": {
+    "out": "../docs/development/api",
+    "entryPoints": ["src/lib/k8s/index.ts", "src/lib/util.ts"],
+    "theme": "./node_modules/typedoc-hugo-theme/dist",
+    "excludeExternals": true,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    "hideBreadcrumbs": true,
+    "readme": "none",
+    "hideInPageTOC": true,
+    "indexTitle": "API"
+  }
 }


### PR DESCRIPTION
We generate `api` under docs/development.

Using typedoc for the generated `api` files.

# How to use

`make docs`

# Testing done

`make docs` outputs static markdown, and you can view that in the following folders:

- docs/development/api

With the website using the docs branch at (https://github.com/kinvolk/docs/pull/14) inside the website repo you can do `make docs run` and have it serve the api folder with hugo.
- http://localhost:1313/docs/headlamp/0.2/development/api/
