### PR TITLE
frontend: Add a basic storybook theme

### DIFF
--- a/frontend/.storybook/HeadlampTheme.js
+++ b/frontend/.storybook/HeadlampTheme.js
@@ -1,0 +1,12 @@
+// https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart
+//  To workaround a bug at time of writing, where theme is not refreshed,
+//  you may need to `npm run storybook --no-manager-cache`
+import { create } from '@storybook/theming';
+import logoUrl from '../../docs/headlamp_light.svg';
+
+export default create({
+  base: 'light',
+  brandTitle: 'Headlamp Kubernetes Web UI dashboard',
+  brandUrl: 'https://kinvolk.io/docs/headlamp/latest/development/',
+  brandImage: logoUrl,
+});

--- a/frontend/.storybook/manager.js
+++ b/frontend/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import theme from './HeadlampTheme';
+
+addons.setConfig({
+  theme: theme,
+});


### PR DESCRIPTION
With logo, link, and description.

`npm run storybook --no-manager-cache`

(The extra --no-manager-cache argument is needed to work around a bug where storybook doesn't refresh the theme always. It's not needed the first time people run it, only when making a storybook theme.)
Related: https://github.com/kinvolk/headlamp/issues/205