### PR TITLE
Add app name as Headlamp, generate Headlamp.app

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "headlamp",
+  "name": "Headlamp",
   "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "headlamp",
+  "name": "Headlamp",
   "version": "0.2.1",
   "description": "",
   "main": "electron/src/main.js",
@@ -16,6 +16,7 @@
   },
   "build": {
     "appId": "com.kinvolk.headlamp",
+    "artifactName": "${name}.${ext}",
     "extraMetadata": {
       "main": "build/electron/main.js"
     },


### PR DESCRIPTION
Otherwise it would install as "io.kinvolk.headlamp.app" rather than Headlamp.app