### PR TITLE
App using plugins, and live reload of plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ backend/server.exe
 backend/tools
 app/electron/src/*
 docs/development/storybook/
+.plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,16 @@ RUN cd ./backend && go build -o ./server ./cmd/
 
 RUN cd ./frontend && npm install && npm run build
 
-# Create a plugins folder if none exists so we copy whatever exists to the
-# image.
+# Backwards compatibility, move plugin folder to only copy matching plugins.
+RUN mv plugins plugins-old
+
 RUN mkdir -p ./plugins
+
+# Backwards compatibility, copy any matching plugins found inside "./plugins-old" into "./plugins".
+# They should match plugins-old/MyFolder/main.js, otherwise they are not copied.
+RUN find plugins-old -mindepth 2 -maxdepth 2 -type f  | grep -i main.js$ | xargs -i dirname {} | xargs -i cp -a {} ./plugins/
+
+RUN find .plugins -mindepth 2 -maxdepth 2 -type f  | grep -i main.js$ | xargs -i dirname {} | xargs -i cp -a {} ./plugins/
 
 FROM $IMAGE_BASE
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -167,6 +167,9 @@ func StartHeadlampServer(config *HeadlampConfig) {
 		kubeConfigPath = GetDefaultKubeConfigPath()
 	}
 
+	config.pluginDir = defaultPluginDir(config.pluginDir)
+	log.Printf("plugins-dir: %s\n", config.pluginDir)
+
 	var contexts []Context
 
 	// In-cluster

--- a/backend/cmd/plugins.go
+++ b/backend/cmd/plugins.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path"
+)
+
+// folderExists(path) returns true if the folder exists.
+func folderExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return info.IsDir()
+}
+
+func defaultPluginDir(pluginDir string) string {
+	if pluginDir != "" {
+		return pluginDir
+	}
+
+	// These are the folders we use for the default plugin-dir.
+	//  - the passed in pluginDir if it's not empty.
+	//  - "./.plugins" if it exists.
+	//  - ~/.config/Headlamp/plugins exists or it can be made
+	//  - "./.plugins" if the ~/.config/Headlamp/plugins can't be made.
+	pluginDirDefault := "./.plugins"
+
+	if folderExists(pluginDirDefault) {
+		return pluginDirDefault
+	}
+
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		log.Printf("error getting user config dir: %s\n", err)
+
+		return pluginDirDefault
+	}
+
+	pluginsConfigDir := path.Join(userConfigDir, "Headlamp", "plugins")
+
+	err = os.MkdirAll(pluginsConfigDir, 0755)
+
+	if err != nil {
+		log.Printf("error creating plugins directory: %s\n", err)
+
+		return pluginDirDefault
+	}
+
+	return pluginsConfigDir
+}

--- a/backend/cmd/plugins.go
+++ b/backend/cmd/plugins.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 // folderExists(path) returns true if the folder exists.
@@ -16,11 +22,8 @@ func folderExists(path string) bool {
 	return info.IsDir()
 }
 
-func defaultPluginDir(pluginDir string) string {
-	if pluginDir != "" {
-		return pluginDir
-	}
-
+// Gets the default plugins-dir depending on platform.
+func defaultPluginDir() string {
 	// These are the folders we use for the default plugin-dir.
 	//  - the passed in pluginDir if it's not empty.
 	//  - "./.plugins" if it exists.
@@ -50,4 +53,107 @@ func defaultPluginDir(pluginDir string) string {
 	}
 
 	return pluginsConfigDir
+}
+
+// Handles if the frontend should reload because of plugin changes.
+func pluginReloadResponse(writer http.ResponseWriter) {
+	if shouldReload() {
+		// We signal back to the frontend through a header.
+		// See apiProxy.ts in the frontend for how it handles this.
+		log.Println("Sending reload plugins signal to frontend")
+
+		// We have reloaded, and we only do this once per set of changes.
+		// Because many files could change at once.
+		doneReload()
+		// Allow JavaScript access to X-Reload header. Because denied by default.
+		writer.Header().Set("Access-Control-Expose-Headers", "X-Reload")
+		writer.Header().Set("X-Reload", "reload")
+	}
+}
+
+var watcher *fsnotify.Watcher
+
+var changeHappened = false
+
+// shouldReload asks if we should reload.
+func shouldReload() bool {
+	return changeHappened
+}
+
+// doneReload tells us that we will do a reload. Next call to shouldReload will be false.
+func doneReload() {
+	changeHappened = false
+}
+
+// watchForChanges(path) looks for changes in the path, and signals that a change has happened.
+func watchForChanges(path string) {
+	watcher, _ = fsnotify.NewWatcher()
+	defer watcher.Close()
+
+	go watchSubfolders(path)
+
+	done := make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				fmt.Printf("Plugin event! %#v\n", event)
+
+				changeHappened = true
+
+				// If there is an event, we rewatch the path.
+				// Probably only need to do this on subfolder create events.
+				if err := filepath.Walk(path, watchDir); err != nil {
+					fmt.Println(err)
+				}
+			case err := <-watcher.Errors:
+				fmt.Println("Plugin watcher Error", err)
+			}
+		}
+	}()
+
+	<-done
+}
+
+// watchDir searches for directories to add watchers to.
+func watchDir(path string, fi os.FileInfo, err error) error {
+	if fi == nil {
+		return nil
+	}
+
+	// Only need to watch folders, because files are already handled.
+	if fi.Mode().IsDir() {
+		return watcher.Add(path)
+	}
+
+	return nil
+}
+
+// watchSubfolders watches the path for sub folder changes.
+// Even if the path does not exist when first calls it eventually notices it.
+// Also handles subfolders, which fsnotify doesn't do by default.
+func watchSubfolders(path string) {
+	done := make(chan struct{})
+
+	go func() {
+		done <- struct{}{}
+	}()
+
+	tickSeconds := 5
+	ticker := time.NewTicker(time.Duration(tickSeconds) * time.Second)
+
+	defer ticker.Stop()
+
+	for ; ; <-ticker.C {
+		<-done
+
+		if err := filepath.Walk(path, watchDir); err != nil {
+			fmt.Println(err)
+		}
+
+		go func() {
+			done <- struct{}{}
+		}()
+	}
 }

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -14,7 +14,7 @@ func main() {
 	insecure := flag.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	// @todo: Make this a uint and validate the values
 	port := flag.String("port", "4466", "Port to listen from")
-	pluginDir := flag.String("plugins-dir", "./plugins", "Specify the plugins directory to build the backend with")
+	pluginDir := flag.String("plugins-dir", "", "Specify the plugins directory to build the backend with")
 	// For inCluster config we need to get the oidc properties from the flags
 	oidcClientID := flag.String("oidc-client-id", "", "ClientID for OIDC")
 	oidcClientSecret := flag.String("oidc-client-secret", "", "ClientSecret for OIDC")

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -14,7 +14,7 @@ func main() {
 	insecure := flag.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	// @todo: Make this a uint and validate the values
 	port := flag.String("port", "4466", "Port to listen from")
-	pluginDir := flag.String("plugins-dir", "", "Specify the plugins directory to build the backend with")
+	pluginDir := flag.String("plugins-dir", defaultPluginDir(), "Specify the plugins directory to build the backend with")
 	// For inCluster config we need to get the oidc properties from the flags
 	oidcClientID := flag.String("oidc-client-id", "", "ClientID for OIDC")
 	oidcClientSecret := flag.String("oidc-client-secret", "", "ClientSecret for OIDC")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golangci/golangci-lint v1.31.0 // indirect
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4

--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -208,5 +208,5 @@ a deployment of Headlamp using the Docker image can mount a plugins folder
 and point to it by using the mentioned option.
 
 An alternative is to build an image that ships some plugins in it. For that,
-just create a plugins folder in the Headlamp project directory as the Dockerfile
+just create a ".plugins" folder in the Headlamp project directory as the Dockerfile
 will include it and point to it by default.

--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -6,7 +6,7 @@ linktitle: Building & Shipping
 ## Active development / In-tree build
 
 During development however, the workflow of 1. building the plugins outside
-of the project; 2. copying to a plugins folder; 3. running Headlamp pointing
+of the project; 2. copying to a ".plugins" folder; 3. running Headlamp pointing
 to that folder, is not a great development user-experience.
 
 While we are planning a smarter way to develop plugins outside of the project's tree
@@ -65,7 +65,7 @@ For example, if we have compiled 3 plugins called MyPlugin1, MyPlugin2, and
 MyPlugin3, they should be added to a directory in the following structure:
 
   ```
-  plugins/
+  .plugins/
     MyPlugin1/
       main.js
     MyPlugin2/
@@ -78,5 +78,5 @@ Then, when running Headlamp's server, the `-plugin-dir` option should point
 to the directory:
 
 ```bash
-./server -plugins-dir=/path/to/plugins/
+./server -plugins-dir=/path/to/.plugins/
 ```

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -68,6 +68,13 @@ export async function request(
     clearTimeout(id);
   }
 
+  // The backend signals through this header that it wants a reload.
+  // See plugins.go
+  const headerVal = response.headers.get('X-Reload');
+  if (headerVal && headerVal.indexOf('reload') !== -1) {
+    window.location.reload();
+  }
+
   if (!response.ok) {
     const { status, statusText } = response;
     if (autoLogoutOnAuthError && status === 401 && opts.headers.Authorization) {

--- a/frontend/src/plugin/index.tsx
+++ b/frontend/src/plugin/index.tsx
@@ -50,7 +50,8 @@ function loadScripts(array: string[], onLoadFinished: (value?: any) => void) {
   };
   (function run() {
     if (array.length !== 0) {
-      loader(array.shift() as string, run);
+      const src = `${helpers.getAppUrl()}${array.shift()}`;
+      loader(src, run);
     } else {
       onLoadFinished && onLoadFinished();
     }


### PR DESCRIPTION
- [x] the app can load plugins as well
- [x] we can use a user config plugins folder (eg. `~/.config/Headlamp/plugins`)
- [x] live reload happens when the plugins folder changes


# How to use

```bash
make backend run-backend
make run-frontend
# copy a plugin into ~/.config/Headlamp/plugins
```

# Testing done

- [x] app can load plugins from the user config plugins folder
- [x] live reload happens when creating/updating/deleting plugins
