### PR TITLE
Fix copying innexistent plugins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 .git
 app
 backend/tools/
+docs/
+**/*.stories

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,16 @@ RUN cd ./backend && go build -o ./server ./cmd/
 
 RUN cd ./frontend && npm install && npm run build
 
+RUN mkdir -p ./plugins
+
 # Backwards compatibility, move plugin folder to only copy matching plugins.
 RUN mv plugins plugins-old
 
-RUN mkdir -p ./plugins
-
 # Backwards compatibility, copy any matching plugins found inside "./plugins-old" into "./plugins".
 # They should match plugins-old/MyFolder/main.js, otherwise they are not copied.
-RUN find plugins-old -mindepth 2 -maxdepth 2 -type f  | grep -i main.js$ | xargs -i dirname {} | xargs -i cp -a {} ./plugins/
+RUN for i in $(find ./plugins-old/*/main.js); do plugin_name=$(echo $i|cut -d'/' -f3); mkdir -p plugins/$plugin_name; cp $i plugins/$plugin_name; done
 
-RUN find .plugins -mindepth 2 -maxdepth 2 -type f  | grep -i main.js$ | xargs -i dirname {} | xargs -i cp -a {} ./plugins/
+RUN for i in $(find ./.plugins/*/main.js); do plugin_name=$(echo $i|cut -d'/' -f3); mkdir -p plugins/$plugin_name; cp $i plugins/$plugin_name; done
 
 FROM $IMAGE_BASE
 


### PR DESCRIPTION
 Copying the plugins was failing if the plugins folder was empty, because
    in the Dockerfile we tried to copy from /headlamp/plugins but we first
    had moved any plugins folder to plugins-old and if the folder was empty,
    then the copy command wouldn't create the final plugins directory again.
    
    Fixing that just required creating the mentioned plugins folder after
    the move, but there was also the problem that the copy command was
    copying everything in each plugins folder and not just the main.js file.
