### PR TITLE
Use redux for theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,10 +14,10 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import { makeStyles } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider as MuiThemeProvider } from '@material-ui/styles';
 import { SnackbarProvider } from 'notistack';
 import React from 'react';
-import { Provider } from 'react-redux';
+import { Provider, useDispatch } from 'react-redux';
 import {
   BrowserRouter,
   HashRouter,
@@ -35,9 +35,10 @@ import helpers from './helpers';
 import { getToken, setToken } from './lib/auth';
 import { useCluster, useClustersConf } from './lib/k8s';
 import { createRouteURL, getRoutePath, ROUTES } from './lib/router';
-import themes, { getTheme, setTheme, ThemesConf } from './lib/themes';
+import themes, { getTheme, ThemesConf } from './lib/themes';
 import { getCluster } from './lib/util';
 import { initializePlugins } from './plugin';
+import { setTheme as setThemeRedux } from './redux/actions/actions';
 import { useTypedSelector } from './redux/reducers/reducers';
 import store from './redux/stores/store';
 
@@ -151,12 +152,8 @@ function TopBar() {
   );
 }
 
-interface ThemeChangeButtonProps {
-  onChange: (theme: string) => void;
-}
-
-function ThemeChangeButton(props: ThemeChangeButtonProps) {
-  const { onChange } = props;
+function ThemeChangeButton() {
+  const dispatch = useDispatch();
   type iconType = typeof darkIcon;
 
   const counterIcons: {
@@ -173,11 +170,8 @@ function ThemeChangeButton(props: ThemeChangeButtonProps) {
   function changeTheme() {
     const idx = themeNames.indexOf(getTheme());
     const newTheme = themeNames[(idx + 1) % themeNames.length];
-
-    setTheme(newTheme);
+    dispatch(setThemeRedux(newTheme));
     setIcon(counterIcons[newTheme]);
-
-    onChange(newTheme);
   }
 
   return (
@@ -187,14 +181,9 @@ function ThemeChangeButton(props: ThemeChangeButtonProps) {
   );
 }
 
-interface AppContainerProps {
-  setThemeName: React.Dispatch<React.SetStateAction<string>>;
-}
-
-function AppContainer(props: AppContainerProps) {
+function AppContainer() {
   const isSidebarOpen = useTypedSelector(state => state.ui.sidebar.isSidebarOpen);
   const classes = useStyle({ isSidebarOpen });
-  const { setThemeName } = props;
   const Router = ({ children }: React.PropsWithChildren<{}>) =>
     helpers.isElectron() ? (
       <HashRouter>{children}</HashRouter>
@@ -220,7 +209,7 @@ function AppContainer(props: AppContainerProps) {
               <div style={{ flex: '1 0 0' }} />
               <ClusterTitle />
               <div style={{ flex: '1 0 0' }} />
-              <ThemeChangeButton onChange={(theme: string) => setThemeName(theme)} />
+              <ThemeChangeButton />
               <TopBar />
             </Toolbar>
           </AppBar>
@@ -242,18 +231,21 @@ function AppContainer(props: AppContainerProps) {
   );
 }
 
-function App() {
-  const [themeName, setThemeName] = React.useState(getTheme());
-
+function AppWithRedux(props: React.PropsWithChildren<{}>) {
+  const themeName = useTypedSelector(state => state.ui.theme.name);
   React.useEffect(() => {
     initializePlugins();
   }, [themeName]);
 
+  return <MuiThemeProvider theme={themes[themeName]}>{props.children}</MuiThemeProvider>;
+}
+
+function App() {
   return (
     <Provider store={store}>
-      <ThemeProvider theme={themes[themeName]}>
-        <AppContainer setThemeName={setThemeName} />
-      </ThemeProvider>
+      <AppWithRedux>
+        <AppContainer />
+      </AppWithRedux>
     </Provider>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -118,6 +118,7 @@ function TopBar() {
           <React.Fragment key={i}>{action()}</React.Fragment>
         ))
       }
+      <ThemeChangeButton />
       <IconButton
         aria-label="User menu"
         aria-controls="menu-appbar"
@@ -209,7 +210,6 @@ function AppContainer() {
               <div style={{ flex: '1 0 0' }} />
               <ClusterTitle />
               <div style={{ flex: '1 0 0' }} />
-              <ThemeChangeButton />
               <TopBar />
             </Toolbar>
           </AppBar>

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -15,6 +15,7 @@ export const UI_SIDEBAR_SET_EXPANDED = 'UI_SIDEBAR_SET_EXPANDED';
 export const UI_ROUTER_SET_ROUTE = 'UI_ROUTER_SET_ROUTE';
 export const UI_DETAILS_VIEW_SET_HEADER_ACTION = 'UI_DETAILS_VIEW_SET_HEADER_ACTION';
 export const UI_APP_BAR_SET_ACTION = 'UI_APP_BAR_SET_ACTION';
+export const UI_THEME_SET = 'UI_THEME_SET';
 
 export interface ClusterActionButton {
   label: string;
@@ -117,4 +118,8 @@ export function setAppBarAction(actionName: string, actionFunc: HeaderActionFunc
 
 export function setConfig(config: object) {
   return { type: CONFIG_NEW, config };
+}
+
+export function setTheme(name?: string) {
+  return { type: UI_THEME_SET, theme: { name } };
 }

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,3 +1,4 @@
+import { getTheme, setTheme } from '../../lib/themes';
 import {
   Action,
   HeaderActionFunc,
@@ -8,6 +9,7 @@ import {
   UI_SIDEBAR_SET_ITEM,
   UI_SIDEBAR_SET_SELECTED,
   UI_SIDEBAR_SET_VISIBLE,
+  UI_THEME_SET,
 } from '../actions/actions';
 
 export interface SidebarEntry {
@@ -45,6 +47,9 @@ export interface UIState {
       };
     };
   };
+  theme: {
+    name: string;
+  };
 }
 
 function getSidebarOpenStatus() {
@@ -76,6 +81,9 @@ export const INITIAL_STATE: UIState = {
         // action-name -> action-callback
       },
     },
+  },
+  theme: {
+    name: getTheme(),
   },
 };
 
@@ -130,6 +138,11 @@ function reducer(state = INITIAL_STATE, action: Action) {
       const appBarActions = { ...newFilters.views.appBar.actions };
       appBarActions[action.name as string] = action.action;
       newFilters.views.appBar.actions = appBarActions;
+      break;
+    }
+    case UI_THEME_SET: {
+      newFilters.theme = action.theme;
+      setTheme(newFilters.theme.name);
       break;
     }
     default:


### PR DESCRIPTION
The main motivation for this change is to not having plugins' components in the top bar being placed between the theme change and the account buttons.

On the other hand, we should in any case have the theme being set through redux as we may need it later.