### PR TITLE
cronjob: fix TypeError in getSchedule()

### DIFF
--- a/frontend/src/components/cronjob/List.tsx
+++ b/frontend/src/components/cronjob/List.tsx
@@ -11,7 +11,7 @@ export default function CronJobList() {
   const filterFunc = useFilterFunc();
 
   function getSchedule(cronJob: CronJob) {
-    const { schedule } = cronJob.spec.schedule;
+    const { schedule } = cronJob.spec;
     if (!schedule.startsWith('@')) {
       return 'never';
     }


### PR DESCRIPTION
# Fix an white screen at pressing "workloads->cronjobs" button

I found a bug in Headlamp app v0.2.1 & 0.3.0-beta: when you click on "workloads->cronjobs" button in a cluster that do have an cronjobs, you got an empty white screen. I investigated into this problem and found that frontend got TypeError after pressing the button. This patch should fix it.

# Testing done
 I test it by hands with the same cluster, where the bug occurs, now it should work fine
