### PR TITLE
Add optional folder support to headlamp-plugin build command

### DIFF
--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -39,7 +39,7 @@ npm run build
 This will create a file with the bundled plugin in
 `headlamp-myfancy/dist/main.js`.
 
-### building a folder of packages at once
+### Building a folder of packages at once
 
 For convienience the `headlamp-plugin build` command can build a 
 package or folder of packages.

--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -39,6 +39,16 @@ npm run build
 This will create a file with the bundled plugin in
 `headlamp-myfancy/dist/main.js`.
 
+### building a folder of packages at once
+
+For convienience the `headlamp-plugin build` command can build a 
+package or folder of packages.
+
+```bash
+npx @kinvolk/headlamp-plugin build myplugins
+npx @kinvolk/headlamp-plugin build myplugins/headlamp-myfancy
+```
+
 ## Shipping / Deploying Plugins
 
 Once a plugin is ready to be shipped (built for production) it needs to

--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -45,8 +45,8 @@ For convienience the `headlamp-plugin build` command can build a
 package or folder of packages.
 
 ```bash
-npx @kinvolk/headlamp-plugin build myplugins
 npx @kinvolk/headlamp-plugin build myplugins/headlamp-myfancy
+npx @kinvolk/headlamp-plugin build myplugins
 ```
 
 ## Shipping / Deploying Plugins

--- a/plugins/examples/pod-counter/package.json
+++ b/plugins/examples/pod-counter/package.json
@@ -20,6 +20,6 @@
     "directory": "plugins/headlamp-plugin-counter"
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.2.0"
+    "@kinvolk/headlamp-plugin": "^0.3.0"
   }
 }

--- a/plugins/headlamp-plugin/README.md
+++ b/plugins/headlamp-plugin/README.md
@@ -12,7 +12,9 @@ This package is published to the npm package index separately from Headlamp.
 
 ```
 headlamp-plugin --help
-headlamp-plugin build             Build the plugin
+headlamp-plugin build <package>   Build the plugin, or folder of
+                                  plugins. <package> defaults to
+                                  current working directory.
 headlamp-plugin start             Watch for changes and build the plugin
 headlamp-plugin create <name>     Create a new plugin folder with base code
 headlamp-plugin extract           Copies folders of packages from plug

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "bin": "bin/headlamp-plugin.js",
   "dependencies": {

--- a/plugins/headlamp-plugin/template/package.json
+++ b/plugins/headlamp-plugin/template/package.json
@@ -13,6 +13,6 @@
     "plugins"
   ],
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.2.0"
+    "@kinvolk/headlamp-plugin": "^0.3.0"
   }
 }


### PR DESCRIPTION
`headlamp-plugin build` changes:

- So that the build command can build a package or folder of packages given (defaults to cwd as before).
- Stop printing the watch message for building production packages.
- Stop copying the built plugins to the config/plugins folder for production builds.


# How to use

```bash
node plugins/headlamp-plugin/bin/headlamp-plugin build plugins/examples/pod-counter
ls -la plugins/examples/pod-counter/dist
rm plugins/examples/pod-counter/dist/main.js

# also works on a folder of plugins
node plugins/headlamp-plugin/bin/headlamp-plugin build plugins/examples/
ls -la plugins/examples/pod-counter/dist
rm plugins/examples/pod-counter/dist/main.js

cd plugins/examples/pod-counter
node plugins/headlamp-plugin/bin/headlamp-plugin build # works as before
ls dist/
cd ../../../

# prints an error message about /tmp not being a package
node plugins/headlamp-plugin/bin/headlamp-plugin build /tmp/ 
```


