### PR TITLE
Add a --disable-gpu option for the app

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -12,8 +12,12 @@ const args = yargs
   .option('headless', {
     describe: 'Open Headlamp in the default web browser instead of its app window',
   })
+  .option('disable-gpu', {
+    describe: 'Disable use of GPU. For people who may have buggy graphics drivers',
+  })
   .parse();
 const isHeadlessMode = args.headless;
+const disableGPU = args['disable-gpu']
 const defaultPort = 4466;
 
 function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
@@ -208,6 +212,11 @@ function startElecron() {
   autoUpdater.on('update-downloaded', () => {
     sendStatusToWindow('Update downloaded');
   });
+
+  if (disableGPU) {
+    log.info("Disabling GPU hardware acceleration.");
+    app.disableHardwareAcceleration();
+  }
 
   app.on('ready', createWindow);
   app.on('activate', function () {


### PR DESCRIPTION
For people who have buggy graphics drivers.

# How to use

`headlamp --disable-gpu`

Then you should see this message:
```
› Disabling GPU hardware acceleration.
```

Electron docs: https://www.electronjs.org/docs/api/app#appdisablehardwareacceleration