### PR TITLE
Flatpak Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ web UIs/dashboards available (i.e. to list and view resources) as well as other 
 If you want to deploy Headlamp in your cluster, check out the instructions on running it [in-cluster](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/).
 
 If you have a kube config already, you can quickly try Headlamp locally as a
-[desktop application](https://kinvolk.io/docs/headlamp/latest/installation/desktop/). **Make sure** you have a kube config
-set up with your favorite clusters and in the default path so Headlamp can use it.
+[desktop application](https://kinvolk.io/docs/headlamp/latest/installation/desktop/),
+for [Linux](https://kinvolk.io/docs/headlamp/latest/installation/desktop/linux-installation),
+[Mac]((https://kinvolk.io/docs/headlamp/latest/installation/desktop/mac-installation)),
+or [Windows]((https://kinvolk.io/docs/headlamp/latest/installation/desktop/win-installation)).
+**Make sure** you have a kubeconfig file set up with your favorite clusters and
+in the default path so Headlamp can use it.
 
 ### Accessing
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -7,8 +7,8 @@ Headlamp is an easy-to-use and extensible Kubernetes web UI.
 Headlamp was created to be a Kubernetes web UI that has the traditional functionality of other
 web UIs/dashboards available (i.e. to list and view resources) as well as other features.
 
-Headlamp can be used in-cluster, where it's accessed through a web browser,
-or as a desktop application (using the information defined in the user's
+Headlamp can be used [in-cluster](./installation/in-cluster), where it's accessed through a web browser,
+or as a [desktop application](./installation/desktop) (using the information defined in the user's
 kubeconfig).
 
 ## Get involved

--- a/docs/installation/desktop/headless.md
+++ b/docs/installation/desktop/headless.md
@@ -13,7 +13,7 @@ Assuming the have already downloaded and installed Headlamp on your desktop, you
 
 Example:
 
-  On Linux: `./Headlamp.AppImage --headless`
+  On Linux: `flatpak run io.kinvolk.Headlamp --headless` (or `./Headlamp.AppImage --headless` for AppImage)
 
   On MacOS: `./Headlamp --headless`
 

--- a/docs/installation/desktop/linux-installation.md
+++ b/docs/installation/desktop/linux-installation.md
@@ -4,8 +4,25 @@ linktitle: Linux
 weight: 15
 ---
 
-Currently we ship a Linux desktop application as an AppImage file. So you
-can just run the application using the downloaded file.
+Currently we ship a Linux desktop application in two formats: [Flatpak](#flatpak), and [AppImage](#appimage).
+
+## Flatpak
+
+[Flatpak](https://flatpak.org/) gives an isolated and bundled way of running Headlamp, with decoupled runtime updates (besides other [benefits](https://en.wikipedia.org/wiki/Flatpak#Features)).
+
+You need to make sure that Flatpak is [installed](https://flatpak.org/setup/) in your Linux distro.
+
+For installing Headlamp as a Flatpak, follow the instructions in its [Flathub page](https://flathub.org/apps/details/io.kinvolk.Headlamp).
+
+For running it, just launch it as usually in your Linux desktop, or run:
+
+```bash
+flatpak run io.kinvolk.Headlamp
+```
+
+## AppImage
+
+Headlamp can be used as an [AppImage](https://appimage.org/) by downloading and running it directly.
 
 To download, choose the latest AppImage file from the [releases page](https://github.com/kinvolk/headlamp/releases).
 You can then run it by doing:


### PR DESCRIPTION
- README: Add links to the desktop platforms installation docs directly
- docs: Mention Flatpak in the Linux installation

I would like to add badges for the different platforms, much like [Joplin](https://joplinapp.org/#desktop-applications) has. But this is enough ATM.