### PR TITLE
docs: Add platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ permissions, you may not be able to view your cluster resources correctly.
 
 See the documentation on [how to easily get a Service Account token](https://kinvolk.io/docs/headlamp/latest/installation#create-a-service-account-token) for your cluster.
 
+## Tested platforms
+
+We maintain a list of the [Kubernetes platforms](./docs/platforms.md) we have
+tested Headlamp with, and invite you to add any missing platform you have
+tested, or comments if there are regressions in already filed platforms that
+should be consider.
+
 ## Get involved
 
 Check out our [guidelines](https://kinvolk.io/docs/headlamp/latest/contributing/)

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,24 @@
+---
+title: Tested Kubernetes Platforms
+linkTitle: Platforms
+weight: 300
+---
+
+This section shows the different platforms where Headlamp has been tested (in-cluster) or is intended to be tested, and useful observations about it.
+If you have tested Headlamp on a different flavor or Kubernetes, please file a PR or [issue](https://github.com/kinvolk/headlamp/issues/new/choose) to add your remarks to the list.
+
+The "works" column refers to the overall Kubernetes related functionality when running in the respective platform; it may have 3 different values:
+- ✔️ : Has been tried and works fine to the extent of what has been tested
+- ❌ : Has been tried and didn't work or had issues that prevented a regular use of it
+- ❔: Hasn't been tried/reported yet
+
+Platform<div style="min-width: 300px"></div>    | Works | Comments
+----------------------------------------------|:-----:|------------------------------------------------------------------------------------------
+[Amazon EKS](https://aws.amazon.com/eks/)                     | ❔    | - Have you tried Headlamp on this platform? Please report your experience.
+[DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/)        | ❔    | - Have you tried Headlamp on this platform? Please report your experience.
+[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) | ❔    | - Have you tried Headlamp on this platform? Please report your experience.
+[K3s](https://k3s.io/)                                         | ✔️     | - Simple to install / expose with the regular [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/).
+[Kind](https://kind.sigs.k8s.io/)                              | ✔️     | - Simple to install / expose with the regular [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/).
+[Lokomotive](https://kinvolk.io/lokomotive-kubernetes/)                     | ✔️     | - Works with the regular in-cluster instructions <br> - There's also the [Lokomotive Web UI](https://kinvolk.io/docs/lokomotive/latest/configuration-reference/components/web-ui/) as a component, which is
+[Microsoft AKS](https://azure.microsoft.com/)                  | ✔️     | Testing (not suitable for production):<br/>- Deploy Headlamp from the [in-cluster instructions](https://kinvolk.io/docs/headlamp/latest/installation/in-cluster/)<br/>- [Enable the http_application_routing addon](https://docs.microsoft.com/en-us/azure/aks/http-application-routing#use-http-routing) (this creates a DNS zone)<br/>- Use the DNS zone name as the domain for Headlamp, i.e. if it is `1234567.eastus.aksapp.io`, then apply [Headlamp's ingress](https://raw.githubusercontent.com/kinvolk/headlamp/master/kubernetes-headlamp-ingress-sample.yaml) using `headlamp.1234567.eastus.aksapp.io` as the path and use ``kubernetes.io/ingress.class: addon-http-application-routing`` as the ingress class annotation.<br/><br/>For production, please follow the [intructions to deploy with an HTTPS ingress controller](https://docs.microsoft.com/en-us/azure/aks/ingress-tls).
+[Minikube](https://minikube.sigs.k8s.io/)                     | ✔️     | - For exposing with an ingress, enable ingresses with `minikube addons enable ingress` <br> - There are docs about the [development](../development/) with Minikube.|


### PR DESCRIPTION
We want to keep a list of platforms where we've tested Headlamp in order
to share not only works and what doesn't, but also any useful remarks
about the deployment.

@vbatts : We have tried it on Azure as well but need to do it again in
order to capture any gotchas (hence it showing as `?`).

I have also chosen to add it to the docs instead of the README as it looks out of place and a misleading (from a "tested" to a "supported" vibe somehow) there.

fixes #248 