### PR TITLE
docker: Upgrade alpine linux 3.13.5 add icu-data package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_BASE=alpine:3.11.3
+ARG IMAGE_BASE=alpine:3.13.5
 FROM $IMAGE_BASE as base-build
 
 ENV GOPATH=/go \
@@ -6,7 +6,7 @@ ENV GOPATH=/go \
 		GO111MODULE=on
 
 RUN apk update && \
-	apk add git nodejs npm go ca-certificates make musl-dev bash
+	apk add git nodejs npm go ca-certificates make musl-dev bash icu-data
 
 COPY ./ /headlamp/
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_CMD ?= docker
 DOCKER_REPO ?= quay.io/kinvolk
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)
-DOCKER_IMAGE_BASE ?= alpine:3.11.3
+DOCKER_IMAGE_BASE ?= alpine:3.13.5
 
 ifeq ($(OS), Windows_NT)
 	SERVER_EXE_EXT = .exe


### PR DESCRIPTION
icu-data package is used to support better locale formatting.

Alpine 3.13.x comes with Nodejs 14.x which has plenty of improvements,
but one area it improves greatly is locale based formatting.

https://alpinelinux.org/posts/Alpine-3.13.0-released.html
https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.13

Related to [ [RFE] Support i18n #246 ](https://github.com/kinvolk/headlamp/issues/246)