### PR TITLE
Use Browser or OS light/dark theme preference

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ import ThemeProviderNexti18n from './i18n/ThemeProviderNexti18n';
 import { getToken, setToken } from './lib/auth';
 import { useCluster, useClustersConf } from './lib/k8s';
 import { createRouteURL, getRoutePath, ROUTES } from './lib/router';
-import themes, { getTheme, ThemesConf } from './lib/themes';
+import themes, { getThemeName, ThemesConf, usePrefersColorScheme } from './lib/themes';
 import { getCluster } from './lib/util';
 import { initializePlugins } from './plugin';
 import { setTheme as setThemeRedux } from './redux/actions/actions';
@@ -196,6 +196,8 @@ function TopBar() {
 }
 
 function ThemeChangeButton() {
+  const themeName = getThemeName();
+
   const dispatch = useDispatch();
   type iconType = typeof darkIcon;
 
@@ -206,12 +208,12 @@ function ThemeChangeButton() {
     dark: lightIcon,
   };
 
-  const [icon, setIcon] = React.useState<iconType>(counterIcons[getTheme()]);
+  const [icon, setIcon] = React.useState<iconType>(counterIcons[themeName]);
 
   const themeNames = Object.keys(counterIcons);
 
   function changeTheme() {
-    const idx = themeNames.indexOf(getTheme());
+    const idx = themeNames.indexOf(themeName);
     const newTheme = themeNames[(idx + 1) % themeNames.length];
     dispatch(setThemeRedux(newTheme));
     setIcon(counterIcons[newTheme]);
@@ -283,7 +285,13 @@ function AppContainer() {
 }
 
 function AppWithRedux(props: React.PropsWithChildren<{}>) {
-  const themeName = useTypedSelector(state => state.ui.theme.name);
+  let themeName = useTypedSelector(state => state.ui.theme.name);
+  usePrefersColorScheme();
+
+  if (!themeName) {
+    themeName = getThemeName();
+  }
+
   React.useEffect(() => {
     initializePlugins();
   }, [themeName]);

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import getDocDefinitions from '../../../lib/docs';
 import { KubeObjectInterface } from '../../../lib/k8s/cluster';
+import { getThemeName } from '../../../lib/themes';
 import ConfirmButton from '../ConfirmButton';
 import Empty from '../EmptyContent';
 import Loader from '../Loader';
@@ -184,6 +185,8 @@ export default function EditorDialog(props: EditorDialogProps) {
     const { i18n } = useTranslation();
     const [lang, setLang] = React.useState(i18n.language);
 
+    const themeName = getThemeName();
+
     React.useEffect(() => {
       i18n.on('languageChanged', setLang);
       return () => {
@@ -205,7 +208,7 @@ export default function EditorDialog(props: EditorDialogProps) {
       <Box paddingTop={2} height="100%">
         <Editor
           language="yaml"
-          theme="vs-dark"
+          theme={themeName === 'dark' ? 'vs-dark' : 'light'}
           value={code}
           options={editorOptions}
           onChange={onChange}

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -4,6 +4,7 @@ import orange from '@material-ui/core/colors/orange';
 import red from '@material-ui/core/colors/red';
 import { createMuiTheme, Theme } from '@material-ui/core/styles';
 import { PaletteColor, PaletteColorOptions } from '@material-ui/core/styles/createPalette';
+import React from 'react';
 
 declare module '@material-ui/core/styles/createPalette.d' {
   interface Palette {
@@ -142,17 +143,52 @@ const themesConf: ThemesConf = {
 
 export default themesConf;
 
-export function getTheme(): string {
-  let theme: string = localStorage.theme;
-
-  if (!theme) {
-    theme = 'light';
-    setTheme(theme);
+export function usePrefersColorScheme() {
+  if (typeof window.matchMedia !== 'function') {
+    return 'light';
   }
 
-  return theme;
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const [value, setValue] = React.useState(mql.matches);
+
+  React.useEffect(() => {
+    const handler = (x: MediaQueryListEvent | MediaQueryList) => setValue(x.matches);
+    mql.addListener(handler);
+    return () => mql.removeListener(handler);
+  }, []);
+
+  return value;
+}
+
+/**
+ * Hook gets theme based on user preference, and also OS/Browser preference.
+ * @returns 'light' | 'dark' theme name
+ */
+export function getThemeName(user = false): string {
+  const themePreference: string = localStorage.headlampThemePreference;
+
+  if (typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+
+  let themeName = 'light';
+  if (themePreference) {
+    // A selected theme preference takes precedence.
+    themeName = themePreference;
+  } else {
+    if (prefersLight) {
+      themeName = 'light';
+    } else if (prefersDark) {
+      themeName = 'dark';
+    }
+  }
+
+  return themeName;
 }
 
 export function setTheme(themeName: string) {
-  localStorage.theme = themeName;
+  const selectedTheme: string = localStorage.headlampSelectedTheme;
+  localStorage.headlampThemePreference = themeName;
 }

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,4 +1,4 @@
-import { getTheme, setTheme } from '../../lib/themes';
+import { getThemeName, setTheme } from '../../lib/themes';
 import {
   Action,
   HeaderActionFunc,
@@ -83,7 +83,7 @@ export const INITIAL_STATE: UIState = {
     },
   },
   theme: {
-    name: getTheme(),
+    name: '',
   },
 };
 


### PR DESCRIPTION
If the user makes a preference by selecting the theme from the UI, then it uses that preference instead. Once the user preference is selected it always uses that preference from then on.
    
The localStorage key was prefixed with headlamp to try and avoid nameclashes. The older key was ignored, since it was set without a user selecting a preference. This way the browser/OS preference is used until they change it manually.
    
Also make the theme preference change reactive. So it changes when the os/browser preference changes.

https://user-images.githubusercontent.com/9541/122554287-13de9680-d039-11eb-905d-08b9e5b6bdd7.mov

To test, use the browser/OS to set a darkmode/lightmode theme preference. There is no way to clear the user preference except to delete the local storage "themePreference" key.

For the [Accessibility improvements](https://github.com/kinvolk/headlamp/issues/245) issue.