### PR TITLE
Fix Electron integration, show lang selector on front page, generate LocaleSelect options from config

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import ActionsNotifier from './components/common/ActionsNotifier';
 import AlertNotification from './components/common/AlertNotification';
 import Sidebar, { drawerWidth, NavigationTabs, useSidebarItem } from './components/Sidebar';
 import helpers from './helpers';
+import { useElectronI18n } from './i18n/electronI18n';
 import LocaleSelect from './i18n/LocaleSelect/LocaleSelect';
 import ThemeProviderNexti18n from './i18n/ThemeProviderNexti18n';
 import { getToken, setToken } from './lib/auth';
@@ -293,6 +294,7 @@ function AppContainer() {
 function AppWithRedux(props: React.PropsWithChildren<{}>) {
   let themeName = useTypedSelector(state => state.ui.theme.name);
   usePrefersColorScheme();
+  useElectronI18n();
 
   if (!themeName) {
     themeName = getThemeName();

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -202,7 +202,7 @@ export function ClusterDialog(props: ClusterDialogProps) {
 function Chooser(props: ClusterDialogProps) {
   const history = useHistory();
   const clusters = useClustersConf();
-  const { open = null, onClose, ...otherProps } = props;
+  const { open = null, onClose, children = [], ...otherProps } = props;
   // Only used if open is not provided
   const [show, setShow] = React.useState(props.open);
   const { t } = useTranslation('cluster');
@@ -283,6 +283,7 @@ function Chooser(props: ClusterDialogProps) {
       ) : (
         <ClusterList clusters={clusterList} onButtonClick={handleButtonClick} />
       )}
+      {children}
     </ClusterDialog>
   );
 }

--- a/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
+++ b/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
@@ -4,7 +4,6 @@ import Select from '@material-ui/core/Select';
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import helpers from '../../helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -14,15 +13,6 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 export interface LocaleSelectProps {}
-
-// If we're running under electron, we need to communicate any language changes.
-const ipcRenderer = helpers.isElectron() ? window.require('electron').ipcRenderer : null;
-
-function tellAppAboutLanguage(lang: string) {
-  if (ipcRenderer) {
-    ipcRenderer.send('locale', lang);
-  }
-}
 
 /**
  * A UI for selecting the locale with i18next
@@ -34,19 +24,12 @@ export default function LocaleSelect(props: LocaleSelectProps) {
   const theme = useTheme();
   document.body.dir = i18n.dir();
 
-  React.useEffect(() => {
-    // Inform the app about the current locale as soon as we set it up.
-    tellAppAboutLanguage(i18n.language);
-  }, []);
-
   const changeLng = (event: React.ChangeEvent<{ value: unknown }>) => {
     const lng = event.target.value as string;
 
     i18n.changeLanguage(lng);
     document.body.dir = i18n.dir();
     theme.direction = i18n.dir();
-
-    tellAppAboutLanguage(lng);
   };
 
   return (

--- a/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
+++ b/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
@@ -39,9 +39,10 @@ export default function LocaleSelect(props: LocaleSelectProps) {
         onChange={changeLng}
         inputProps={{ 'aria-label': t('Select locale') }}
       >
-        <MenuItem value={'en'}>en</MenuItem>
-        <MenuItem value={'pt'}>pt</MenuItem>
-        <MenuItem value={'es'}>es</MenuItem>
+        {i18n?.options?.supportedLngs &&
+          i18n.options.supportedLngs
+            .filter(lng => lng !== 'cimode')
+            .map(lng => <MenuItem value={lng}>{lng}</MenuItem>)}
       </Select>
     </FormControl>
   );

--- a/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
+++ b/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
@@ -1,4 +1,5 @@
 import FormControl from '@material-ui/core/FormControl';
+import FormLabel from '@material-ui/core/FormLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
@@ -12,7 +13,9 @@ const useStyles = makeStyles((theme: Theme) =>
     },
   })
 );
-export interface LocaleSelectProps {}
+export interface LocaleSelectProps {
+  showTitle?: boolean;
+}
 
 /**
  * A UI for selecting the locale with i18next
@@ -34,6 +37,7 @@ export default function LocaleSelect(props: LocaleSelectProps) {
 
   return (
     <FormControl className={classes.formControl}>
+      {props.showTitle && <FormLabel component="legend">{t('Select locale')}</FormLabel>}
       <Select
         value={i18n.language ? i18n.language : 'en'}
         onChange={changeLng}

--- a/frontend/src/i18n/electronI18n.tsx
+++ b/frontend/src/i18n/electronI18n.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import helpers from '../helpers';
+
+// If we're running under electron, we need to communicate any language changes.
+const ipcRenderer = helpers.isElectron() ? window.require('electron').ipcRenderer : null;
+
+function tellAppAboutLanguage(lang: string) {
+  if (ipcRenderer) {
+    ipcRenderer.send('locale', lang);
+  }
+}
+
+/** Integration with Electron app, so it can change locale information. */
+export function useElectronI18n() {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    i18n.on('languageChanged', tellAppAboutLanguage);
+    return () => {
+      i18n.off('languageChanged', tellAppAboutLanguage);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -46,6 +46,7 @@ import PersistentVolumeDetails from '../components/storage/VolumeDetails';
 import PersistentVolumeList from '../components/storage/VolumeList';
 import WorkloadDetails from '../components/workload/Details';
 import WorkloadOverview from '../components/workload/Overview';
+import LocaleSelect from '../i18n/LocaleSelect/LocaleSelect';
 import CronJob from './k8s/cronJob';
 import Deployment from './k8s/deployment';
 import Job from './k8s/job';
@@ -87,7 +88,11 @@ export const ROUTES: {
     sidebar: null,
     noCluster: true,
     noAuthRequired: true,
-    component: () => <Chooser useCover open />,
+    component: () => (
+      <Chooser useCover open>
+        <LocaleSelect />
+      </Chooser>
+    ),
   },
   namespaces: {
     path: '/namespaces',


### PR DESCRIPTION
# Fix Electron integration, show lang selector on front page, generate LocaleSelect options from config

## Testing done

- With pt selected, when starting app fresh the pt locale is used for menu items and other parts
- there is a locale selecter on the front page (under the cluster list)

<img width="988" alt="Screenshot 2021-06-22 at 09 42 59" src="https://user-images.githubusercontent.com/9541/122884298-4a205c80-d33e-11eb-91c9-bd8b004f7ea5.png">
