### PR TITLE
locales/es: Fix two minor typos

### DIFF
--- a/frontend/src/i18n/locales/es/cluster.json
+++ b/frontend/src/i18n/locales/es/cluster.json
@@ -2,7 +2,7 @@
   "Install the metrics-server to get usage data.": "Instale el metrics-server para obtener datos de uso.",
   "Memory Usage": "Uso de la memoria",
   "{{ available }} units": "{{ available }} unidades",
-  "CPU Usage": "Uso da la CPU",
+  "CPU Usage": "Uso de la CPU",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} requeridos",
   "Cluster: {{cluster}}": "Cluster: {{cluster}}",
   "Choose a cluster": "Elija un cluster",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -118,5 +118,5 @@
   "Provisioner": "Proveedor",
   "Volume Binding Mode": "",
   "Persistent Volumes": "",
-  "Strategy Type": "Tipo de Estratégia"
+  "Strategy Type": "Tipo de Estrategia"
 }


### PR DESCRIPTION
Fix two minor typos in Spanish locale. 
