### PR TITLE
deploy: Add Helm chart

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "{{ .Name }}-helm-{{ .Version }}"

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,1 @@
+target-branch: main

--- a/.github/workflows/helm-chart-lint-test.yml
+++ b/.github/workflows/helm-chart-lint-test.yml
@@ -1,0 +1,47 @@
+name: Lint and Test Charts
+
+on:
+  pull_request:
+    paths:
+      - charts/**
+      - '!charts/**/README.md'
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config .github/ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config .github/ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config .github/ct.yaml
+

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,0 +1,36 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - charts/**
+      - '!charts/**/README.md'
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+          
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .github/cr.yaml
+

--- a/charts/headlamp/.helmignore
+++ b/charts/headlamp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: headlamp
+description: Headlamp is an easy-to-use and extensible Kubernetes web UI.
+icon: https://raw.githubusercontent.com/kinvolk/headlamp/main/docs/headlamp_light.svg
+home: https://github.com/kinvolk/headlamp/tree/main/deploy/helm
+type: application
+keywords:
+  - kubernetes
+  - plugins
+  - kinvolk
+  - headlamp
+sources:
+  - https://github.com/kinvolk/headlamp
+  - https://kinvolk.io/
+maintainers:
+  - name: kinvolk
+    url: https://kinvolk.io/
+version: 0.1.0
+appVersion: 0.4.0

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -1,0 +1,66 @@
+# headlamp
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+
+Headlamp is an easy-to-use and extensible Kubernetes web UI.
+
+**Homepage:** <https://github.com/kinvolk/headlamp/tree/main/charts/headlamp>
+
+## TL;DR
+
+```console
+$ helm repo add headlamp https://kinvolk.github.io/headlamp/
+$ helm install my-headlamp headlamp/headlamp --namespace kube-system
+```
+
+## Maintainers
+
+| Name | Url |
+| ---- | --- |
+| kinvolk | https://kinvolk.io/ |
+
+## Source Code
+
+* <https://github.com/kinvolk/headlamp>
+* <https://kinvolk.io/>
+
+### Headlamp parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity settings for pod assignment	 |
+| clusterRoleBinding.annotations | object | `{}` | Annotations to add to the cluster role binding |
+| clusterRoleBinding.create | bool | `true` | Specified whether a cluster role binding should be created |
+| fullnameOverride | string | `""` | Overrides the full name of the chart	 |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent	 |
+| image.registry | string | `"ghcr.io"` | Container image registry	 |
+| image.repository | string | `"kinvolk/headlamp"` | Container image name	 |
+| image.tag | string | `""` | Container image tag, If ""	uses appVersion in Chart.yaml |
+| imagePullSecrets | list | `[]` | An optional list of references to secrets in the same namespace to use for pulling any of the images used	 |
+| ingress.annotations | object | `{}` | Annotations for Ingress resource	 |
+| ingress.enabled | bool | `false` | Enable ingress controller resource	 |
+| ingress.hosts | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` | Overrides the name of the chart	 |
+| nodeSelector | object | `{}` | Node labels for pod assignment	 |
+| podAnnotations | object | `{}` | Annotations to add to the pod |
+| podSecurityContext | object | `{}` | Headlamp pods' Security Context	 |
+| replicaCount | int | `1` | Number of desired pods |
+| resources | object | `{}` | CPU/Memory resource requests/limits	 |
+| securityContext | object | `{}` | Headlamp containers Security Context |
+| service.port | int | `80` | Kubernetes Service port	 |
+| service.type | string | `"ClusterIP"` | Kubernetes Service type	 |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use.(If not set and create is true, a name is generated using the fullname template) |
+| tolerations | list | `[]` | Toleration labels for pod assignment	 |
+
+### Headlamp Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| config.baseURL | string | `""` | base url path at which headlamp should run |
+| config.oidc.clientID | string | `""` | OIDC client ID |
+| config.oidc.clientSecret | string | `""` | OIDC client secret |
+| config.oidc.issuerURL | string | `""` | OIDC issuer URL |
+| config.oidc.scopes | string | `""` | OIDC scopes to be used |

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -1,0 +1,27 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "headlamp.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "headlamp.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "headlamp.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "headlamp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- if .Values.clusterRoleBinding.create }}
+2. Get the clusterrolebinding token using
+  export SECRET=$(kubectl get secrets --namespace {{ .Release.Namespace }} -o custom-columns=":metadata.name" | grep "{{ include "headlamp.fullname" . }}-token")
+  kubectl get secret $SECRET --namespace {{ .Release.Namespace }} --template=\{\{.data.token\}\} | base64 --decode
+{{- end }}

--- a/charts/headlamp/templates/_helpers.tpl
+++ b/charts/headlamp/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "headlamp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "headlamp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "headlamp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "headlamp.labels" -}}
+helm.sh/chart: {{ include "headlamp.chart" . }}
+{{ include "headlamp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "headlamp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "headlamp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "headlamp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "headlamp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/headlamp/templates/clusterrolebinding.yaml
+++ b/charts/headlamp/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.clusterRoleBinding.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "headlamp.fullname" . }}-admin
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+  {{- with .Values.clusterRoleBinding.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: {{ include "headlamp.serviceAccountName" . }}
+  namespace: kube-system
+{{- end }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "headlamp.fullname" . }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "headlamp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "headlamp.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "headlamp.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-in-cluster"
+            - "-plugins-dir=/headlamp/plugins"
+            {{- with .Values.config.oidc.clientID }}
+            - "-oidc-client-id={{ . }}"
+            {{- end }}
+            {{- with .Values.config.oidc.clientSecret }}
+            - "-oidc-client-secret={{ . }}"
+            {{- end }}
+            {{- with .Values.config.oidc.issuerURL }}
+            - "-oidc-idp-issuer-url={{ . }}"
+            {{- end }}
+            {{- with .Values.config.oidc.scopes }}
+            - "-oidc-scopes={{ . }}"
+            {{- end }}
+            {{- with .Values.config.baseURL }}
+            - "-base-url={{ . }}"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/headlamp/templates/ingress.yaml
+++ b/charts/headlamp/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "headlamp.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .type }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/headlamp/templates/service.yaml
+++ b/charts/headlamp/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "headlamp.fullname" . }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "headlamp.selectorLabels" . | nindent 4 }}

--- a/charts/headlamp/templates/serviceaccount.yaml
+++ b/charts/headlamp/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "headlamp.serviceAccountName" . }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -1,0 +1,116 @@
+# Default values for headlamp.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of desired pods
+replicaCount: 1
+
+image:
+  # -- Container image registry
+  registry: ghcr.io
+  # -- Container image name
+  repository: kinvolk/headlamp
+  # -- Image pull policy. One of Always, Never, IfNotPresent
+  pullPolicy: IfNotPresent
+  # -- Container image tag, If "" uses appVersion in Chart.yaml
+  tag: ""
+
+# -- An optional list of references to secrets in the same namespace to use for pulling any of the images used
+imagePullSecrets: []
+# -- Overrides the name of the chart
+nameOverride: ""
+# -- Overrides the full name of the chart
+fullnameOverride: ""
+
+config:
+  # -- base url path at which headlamp should run
+  baseURL: ""
+  oidc:
+    # -- OIDC client ID
+    clientID: ""
+    # -- OIDC client secret
+    clientSecret: ""
+    # -- OIDC issuer URL
+    issuerURL: ""
+    # -- OIDC scopes to be used
+    scopes: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.(If not set and create is true, a name is generated using the fullname template)
+  name: ""
+
+clusterRoleBinding:
+  # -- Specified whether a cluster role binding should be created
+  create: true
+  # -- Annotations to add to the cluster role binding
+  annotations: {}
+
+# -- Annotations to add to the pod
+podAnnotations: {}
+
+# -- Headlamp pods' Security Context
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+# -- Headlamp containers Security Context
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # -- Kubernetes Service type
+  type: ClusterIP
+  # -- Kubernetes Service port
+  port: 80
+
+ingress:
+  # -- Enable ingress controller resource
+  enabled: false
+  # -- Annotations for Ingress resource
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # -- Hostname(s) for the Ingress resource
+  hosts:
+    []
+    # - host: chart-example.local
+    #   paths: []
+  # -- Ingress TLS configuration
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- CPU/Memory resource requests/limits
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Node labels for pod assignment
+nodeSelector: {}
+
+# -- Toleration labels for pod assignment
+tolerations: []
+
+# -- Affinity settings for pod assignment
+affinity: {}


### PR DESCRIPTION
This patch adds helm chart, thus allowing
users to easily deploy headlamp in their cluster

Signed-off-by: yolossn <nssvlr@gmail.com>