### PR TITLE
charts: Bump chart version so we get it released

### DIFF
--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -15,5 +15,5 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.4.0


### PR DESCRIPTION
We want to release again because now we do have the gh-page
published.
