### PR TITLE
Sort almost everything

### DIFF
--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -44,13 +44,14 @@ const useTableStyle = makeStyles(theme => ({
 }));
 
 type sortFunction = (arg1: any, arg2: any) => number;
+type getterFunction = (arg: any) => any;
 
 interface SimpleTableColumn {
   label: string;
   cellProps?: {
     [propName: string]: any;
   };
-  sort?: sortFunction | boolean;
+  sort?: sortFunction | getterFunction | boolean;
 }
 
 interface SimpleTableDatumColumn extends SimpleTableColumn {
@@ -154,9 +155,14 @@ export default function SimpleTable(props: SimpleTableProps) {
   );
 
   function defaultSortingFunction(column: SimpleTableGetterColumn) {
+    const sort = column?.sort;
     function defaultSortingReal(item1: any, item2: any) {
-      const value1 = column.getter(item1);
-      const value2 = column.getter(item2);
+      let getterFunc = column.getter;
+      if (!!sort && typeof sort === 'function') {
+        getterFunc = sort;
+      }
+      const value1 = getterFunc(item1);
+      const value2 = getterFunc(item2);
 
       let compareValue = 0;
       if (value1 < value2) {
@@ -179,7 +185,10 @@ export default function SimpleTable(props: SimpleTableProps) {
     const columnAskingForSort = columns[sortColIndex];
     const sortFunction = columnAskingForSort?.sort;
 
-    if (typeof sortFunction === 'boolean' && sortFunction) {
+    if (
+      (typeof sortFunction === 'boolean' && sortFunction) ||
+      (typeof sortFunction === 'function' && sortFunction.length === 1)
+    ) {
       setDisplayData(
         data.slice().sort(defaultSortingFunction(columnAskingForSort as SimpleTableGetterColumn))
       );

--- a/frontend/src/components/configmap/List.tsx
+++ b/frontend/src/components/configmap/List.tsx
@@ -34,6 +34,7 @@ export default function ConfigMapList() {
           {
             label: t('glossary|Namespace'),
             getter: configMap => configMap.getNamespace(),
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -37,10 +37,12 @@ export default function CustomResourceDefinitionList() {
           {
             label: t('frequent|Group'),
             getter: crd => crd.spec.group,
+            sort: true,
           },
           {
             label: t('Scope'),
             getter: crd => crd.spec.scope,
+            sort: true,
           },
           {
             label: t('frequent|Full name'),

--- a/frontend/src/components/cronjob/List.tsx
+++ b/frontend/src/components/cronjob/List.tsx
@@ -53,6 +53,7 @@ export default function CronJobList() {
           {
             label: t('glossary|Namespace'),
             getter: cronJob => cronJob.getNamespace(),
+            sort: true,
           },
           {
             label: t('Schedule'),

--- a/frontend/src/components/daemonset/List.tsx
+++ b/frontend/src/components/daemonset/List.tsx
@@ -34,10 +34,12 @@ export default function DaemonSetList() {
           {
             label: t('glossary|Namespace'),
             getter: daemonSet => daemonSet.getNamespace(),
+            sort: true,
           },
           {
             label: t('Pods'),
             getter: daemonSet => daemonSet.status.currentNumberScheduled,
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -19,6 +19,18 @@ export default function DeploymentsList() {
     return `${availableReplicas || 0}/${replicas || 0}`;
   }
 
+  function sortByPods(d1: Deployment, d2: Deployment) {
+    const { replicas: r1, availableReplicas: avail1 } = d1.status;
+    const { replicas: r2, availableReplicas: avail2 } = d2.status;
+
+    const availSorted = avail1 - avail2;
+    if (availSorted === 0) {
+      return r1 - r2;
+    }
+
+    return availSorted;
+  }
+
   function renderConditions(deployment: Deployment) {
     const { conditions } = deployment.status;
     if (!conditions) {
@@ -71,14 +83,17 @@ export default function DeploymentsList() {
           {
             label: t('glossary|Namespace'),
             getter: deployment => deployment.getNamespace(),
+            sort: true,
           },
           {
             label: t('Pods'),
             getter: deployment => renderPods(deployment),
+            sort: sortByPods,
           },
           {
             label: t('Replicas'),
             getter: deployment => deployment.spec.replicas || 0,
+            sort: true,
           },
           {
             label: t('Conditions'),

--- a/frontend/src/components/job/List.tsx
+++ b/frontend/src/components/job/List.tsx
@@ -16,6 +16,14 @@ export default function JobsList() {
     return `${job.spec.completions}/${job.spec.parallelism}`;
   }
 
+  function sortByCompletions(job1: Job, job2: Job) {
+    const parallelismSorted = job1.spec.parallelism - job2.spec.parallelism;
+    if (parallelismSorted === 0) {
+      return job1.spec.completions - job2.spec.completions;
+    }
+    return parallelismSorted;
+  }
+
   function getCondition(job: Job) {
     const { conditions } = job.status;
     if (!conditions) {
@@ -47,10 +55,12 @@ export default function JobsList() {
           {
             label: t('glossary|Namespace'),
             getter: job => job.getNamespace(),
+            sort: true,
           },
           {
             label: t('Completions'),
             getter: job => getCompletions(job),
+            sort: sortByCompletions,
           },
           {
             label: t('Conditions'),

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -42,6 +42,7 @@ export default function NamespacesList() {
           {
             label: t('Status'),
             getter: makeStatusLabel,
+            sort: (namespace: Namespace) => namespace.status.phase,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -28,6 +28,9 @@ export default function PodList() {
   const { t } = useTranslation('glossary');
 
   function getRestartCount(pod: Pod) {
+    if (!pod) {
+      return 0;
+    }
     return _.sumBy(pod.status.containerStatuses, container => container.restartCount);
   }
 
@@ -53,14 +56,17 @@ export default function PodList() {
           {
             label: t('glossary|Namespace'),
             getter: (pod: Pod) => pod.getNamespace(),
+            sort: true,
           },
           {
             label: t('Restarts'),
             getter: (pod: Pod) => getRestartCount(pod),
+            sort: true,
           },
           {
             label: t('Status'),
             getter: makePodStatusLabel,
+            sort: (pod: Pod) => pod?.status.phase,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/replicaset/List.tsx
+++ b/frontend/src/components/replicaset/List.tsx
@@ -16,6 +16,15 @@ export default function ReplicaSetList() {
     return `${replicaSet.spec.replicas} / ${replicaSet.status.replicas}`;
   }
 
+  function sortByReplicas(r1: ReplicaSet, r2: ReplicaSet) {
+    const totalReplicasDiff = r1.status.replicas - r2.status.replicas;
+    if (totalReplicasDiff === 0) {
+      return r1.spec.replicas - r2.spec.replicas;
+    }
+
+    return totalReplicasDiff;
+  }
+
   return (
     <SectionBox title={<SectionFilterHeader title={t('Replica Sets')} />}>
       <SimpleTable
@@ -38,14 +47,17 @@ export default function ReplicaSetList() {
           {
             label: t('glossary|Namespace'),
             getter: replicaSet => replicaSet.getNamespace(),
+            sort: true,
           },
           {
             label: t('Generation'),
             getter: replicaSet => replicaSet.status.observedGeneration,
+            sort: true,
           },
           {
             label: t('Replicas'),
             getter: replicaSet => getReplicas(replicaSet),
+            sort: sortByReplicas,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -75,6 +75,7 @@ export default function RoleBindingList() {
           {
             label: t('Type'),
             getter: item => item.kind,
+            sort: true,
           },
           {
             label: t('frequent|Name'),
@@ -91,6 +92,7 @@ export default function RoleBindingList() {
           {
             label: t('glossary|Namespace'),
             getter: item => item.getNamespace() || 'All namespaces',
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -74,6 +74,7 @@ export default function RoleList() {
           {
             label: t('Type'),
             getter: item => item.kind,
+            sort: true,
           },
           {
             label: t('frequent|Name'),
@@ -100,6 +101,7 @@ export default function RoleList() {
           {
             label: t('glossary|Namespace'),
             getter: item => item.metadata.namespace,
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -34,10 +34,12 @@ export default function SecretList() {
           {
             label: t('glossary|Namespace'),
             getter: secret => secret.getNamespace(),
+            sort: true,
           },
           {
             label: t('Type'),
             getter: secret => secret.type,
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -34,14 +34,17 @@ export default function ServiceList() {
           {
             label: t('glossary|Namespace'),
             getter: service => service.getNamespace(),
+            sort: true,
           },
           {
             label: t('Type'),
             getter: service => service.spec.type,
+            sort: true,
           },
           {
             label: t('Cluster IP'),
             getter: service => service.spec.clusterIP,
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/serviceaccount/List.tsx
+++ b/frontend/src/components/serviceaccount/List.tsx
@@ -34,6 +34,7 @@ export default function ServiceAccountList() {
           {
             label: t('glossary|Namespace'),
             getter: serviceAccount => serviceAccount.getNamespace(),
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/statefulset/List.tsx
+++ b/frontend/src/components/statefulset/List.tsx
@@ -40,14 +40,17 @@ export default function StatefulSetList() {
           {
             label: t('glossary|Namespace'),
             getter: statefulSet => statefulSet.getNamespace(),
+            sort: true,
           },
           {
             label: t('Pods'),
             getter: statefulSet => renderPods(statefulSet),
+            sort: true,
           },
           {
             label: t('Replicas'),
             getter: statefulSet => statefulSet.spec.replicas,
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -38,18 +38,22 @@ export default function VolumeClaimList() {
           {
             label: t('glossary|Namespace'),
             getter: volumeClaim => volumeClaim.getNamespace(),
+            sort: true,
           },
           {
             label: t('Status'),
             getter: volumeClaim => volumeClaim.status.phase,
+            sort: true,
           },
           {
             label: t('Class Name'),
             getter: volumeClaim => volumeClaim.spec.storageClassName,
+            sort: true,
           },
           {
             label: t('Volume'),
             getter: volumeClaim => volumeClaim.spec.volumeName,
+            sort: true,
           },
           {
             label: t('Capacity'),

--- a/frontend/src/components/storage/ClassList.tsx
+++ b/frontend/src/components/storage/ClassList.tsx
@@ -34,10 +34,12 @@ export default function ClassList() {
           {
             label: t('Reclaim Policy'),
             getter: storageClass => storageClass.reclaimPolicy,
+            sort: true,
           },
           {
             label: t('Volume Binding Mode'),
             getter: storageClass => storageClass.volumeBindingMode,
+            sort: true,
           },
           {
             label: t('frequent|Age'),

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -34,6 +34,7 @@ export default function VolumeList() {
           {
             label: t('Status'),
             getter: volume => volume.status.phase,
+            sort: true,
           },
           {
             label: t('Capacity'),

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -40,6 +40,15 @@ export default function Overview() {
     return `${getReadyReplicas(item)}/${getTotalReplicas(item)}`;
   }
 
+  function sortByReplicas(w1: Workload, w2: Workload) {
+    const totalReplicasDiff = getTotalReplicas(w1) - getTotalReplicas(w2);
+    if (totalReplicasDiff === 0) {
+      return getReadyReplicas(w1) - getReadyReplicas(w2);
+    }
+
+    return totalReplicasDiff;
+  }
+
   function getJointItems() {
     let joint: Workload[] = [];
     for (const items of Object.values(workloadsData)) {
@@ -80,6 +89,7 @@ export default function Overview() {
             {
               label: t('Type'),
               getter: item => item.kind,
+              sort: true,
             },
             {
               label: t('frequent|Name'),
@@ -98,10 +108,12 @@ export default function Overview() {
             {
               label: t('glossary|Namespace'),
               getter: item => item.metadata.namespace,
+              sort: true,
             },
             {
               label: t('Pods'),
               getter: item => item && getPods(item),
+              sort: sortByReplicas,
             },
             {
               label: t('frequent|Age'),


### PR DESCRIPTION
- frontend: Allow to set the SimpleTable's sort function as a getter
- frontend: Enable sorting in (almost) every column
