### PR TITLE
Change html lang when switching locales

### DIFF
--- a/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
+++ b/frontend/src/i18n/LocaleSelect/LocaleSelect.tsx
@@ -25,13 +25,11 @@ export default function LocaleSelect(props: LocaleSelectProps) {
 
   const { t, i18n } = useTranslation('frequent');
   const theme = useTheme();
-  document.body.dir = i18n.dir();
 
   const changeLng = (event: React.ChangeEvent<{ value: unknown }>) => {
     const lng = event.target.value as string;
 
     i18n.changeLanguage(lng);
-    document.body.dir = i18n.dir();
     theme.direction = i18n.dir();
   };
 

--- a/frontend/src/i18n/ThemeProviderNexti18n.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.tsx
@@ -23,10 +23,18 @@ const ThemeProviderNexti18n: React.FunctionComponent<{ theme: Theme }> = props =
   const { i18n } = useTranslation();
   const [lang, setLang] = useState(i18n.language);
 
+  function changeLang(lng: string) {
+    if (lng) {
+      document.documentElement.lang = lng;
+      document.body.dir = i18n.dir();
+      setLang(lng);
+    }
+  }
+
   useEffect(() => {
-    i18n.on('languageChanged', setLang);
+    i18n.on('languageChanged', changeLang);
     return () => {
-      i18n.off('languageChanged', setLang);
+      i18n.off('languageChanged', changeLang);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
Useful for different browser functionality including a11y tools.

Also fixes an issue where the language direction was being set incorrectly at startup for a brief moment (you could see it sometimes on the first screen before the locale loaded).

## How to use

Switch language, inspect html lang attribute.
