### PR TITLE
Add type search

### DIFF
--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
+import { Provider } from 'react-redux';
+import store from '../../redux/stores/store';
 import SimpleTable from './SimpleTable';
 import { SimpleTableProps } from './SimpleTable';
 
@@ -9,7 +11,11 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<SimpleTableProps> = args => <SimpleTable {...args} />;
+const Template: Story<SimpleTableProps> = args => (
+  <Provider store={store}>
+    <SimpleTable {...args} />
+  </Provider>
+);
 
 const fixtureData = {
   rowsPerPage: [15, 25, 50],

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -13,8 +13,11 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
+import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { KubeObjectInterface } from '../../lib/k8s/cluster';
+import { useTypedSelector } from '../../redux/reducers/reducers';
 import Empty from './EmptyContent';
 import { ValueLabel } from './Label';
 import Loader from './Loader';
@@ -73,6 +76,7 @@ export interface SimpleTableProps {
   emptyMessage?: string;
   errorMessage?: string | null;
   defaultSortingColumn?: number;
+  advancedFilters?: [string];
 }
 
 interface ColumnSortButtonProps {
@@ -107,6 +111,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     emptyMessage = null,
     errorMessage = null,
     defaultSortingColumn,
+    advancedFilters,
   } = props;
   const [page, setPage] = React.useState(0);
   const [currentData, setCurrentData] = React.useState(data);
@@ -114,6 +119,7 @@ export default function SimpleTable(props: SimpleTableProps) {
   const rowsPerPageOptions = props.rowsPerPage || [5, 10, 50];
   const [rowsPerPage, setRowsPerPage] = React.useState(rowsPerPageOptions[0]);
   const classes = useTableStyle();
+  const filter = useTypedSelector(state => state.filter);
   const [isIncreasingOrder, setIsIncreasingOrder] = React.useState(
     !defaultSortingColumn || defaultSortingColumn > 0
   );
@@ -231,11 +237,24 @@ export default function SimpleTable(props: SimpleTableProps) {
   }
 
   let filteredData = displayData;
-
   if (filterFunction) {
     filteredData = displayData.filter(filterFunction);
+    if (advancedFilters) {
+      for (let i = 0; i < advancedFilters.length; i++) {
+        // attach all data from previous filter so that we don't lose data from any filter
+        filteredData = filteredData.concat(
+          displayData.filter((item: KubeObjectInterface) =>
+            _.get(item, advancedFilters[i]).toLowerCase().includes(filter.search.toLowerCase())
+          )
+        );
+      }
+      //remove duplicate entries
+      filteredData = _.uniqBy(
+        filteredData as KubeObjectInterface[],
+        (val: KubeObjectInterface) => val.metadata.uid
+      );
+    }
   }
-
   function sortClickHandler(isIncreasingOrder: boolean, index: number) {
     setIsIncreasingOrder(isIncreasingOrder);
     setSortColIndex(index);

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -70,6 +70,7 @@ export default function RoleBindingList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        advancedFilters={['kind']}
         errorMessage={getErrorMessage()}
         columns={[
           {

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -69,6 +69,7 @@ export default function RoleList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        advancedFilters={['kind']}
         errorMessage={getErrorMessage()}
         columns={[
           {

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -18,6 +18,7 @@ export default function SecretList() {
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
         errorMessage={Secret.getErrorMessage(error)}
+        advancedFilters={['type']}
         columns={[
           {
             label: t('frequent|Name'),

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -17,6 +17,7 @@ export default function ServiceList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
+        advancedFilters={['spec.type']}
         errorMessage={Service.getErrorMessage(error)}
         columns={[
           {

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -85,6 +85,7 @@ export default function Overview() {
         <SimpleTable
           rowsPerPage={[15, 25, 50]}
           filterFunction={filterFunc}
+          advancedFilters={['kind']}
           columns={[
             {
               label: t('Type'),


### PR DESCRIPTION
# [Title: describe the change in one sentence]
Allow to search by type and add facility of searching by other properties as well

## How to use
Go to any view which has a type column try using the search filter and you now should be able to search by type as well
## Testing done
Try using the search filter on a view that has a type column and you will see you are now able to search by type and namespace both
