### PR TITLE
Make release notes more resilient

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -10,7 +10,6 @@ import url from 'url';
 import yargs from 'yargs';
 import i18n from './i18next.config';
 
-const appVersion = app.getVersion();
 const store = new Store();
 const args = yargs
   .option('headless', {
@@ -268,6 +267,14 @@ function startElecron() {
   let mainWindow: BrowserWindow | null;
 
   const isDev = process.env.ELECTRON_DEV || false;
+
+  let appVersion: string;
+  if (isDev && process.env.HEADLAMP_APP_VERSION) {
+    appVersion = process.env.HEADLAMP_APP_VERSION;
+    console.debug(`Overridding app version to ${appVersion}`);
+  } else {
+    appVersion = app.getVersion();
+  }
 
   setMenu(i18n);
 

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -37,9 +37,7 @@ export default function ReleaseNotes() {
     this check will help us later in determining whether we are on the latest release or not
     */
           const storedAppVersion = helpers.getAppVersion();
-          if (!storedAppVersion) {
-            helpers.setAppVersion(currentBuildAppVersion);
-          } else if (semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
+          if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
             // get the release notes for the version with which the app was built with
             const githubReleaseURL = `GET /repos/{owner}/{repo}/releases/tags/v${currentBuildAppVersion}`;
             const response = await octokit.request(githubReleaseURL, {
@@ -48,10 +46,11 @@ export default function ReleaseNotes() {
             });
             const [releaseNotes] = response.data.body.split('<!-- end-release-notes -->');
             setReleaseNotes(releaseNotes);
-            // set the store version to latest so that we don't show release notes on
-            // every start of app
-            helpers.setAppVersion(currentBuildAppVersion);
           }
+
+          // set the store version to the current so that we don't show release notes on
+          // every start of app
+          helpers.setAppVersion(currentBuildAppVersion);
         }
         const isUpdateCheckingDisabled = JSON.parse(
           localStorage.getItem('disable_update_check') || 'false'

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -40,12 +40,27 @@ export default function ReleaseNotes() {
           if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
             // get the release notes for the version with which the app was built with
             const githubReleaseURL = `GET /repos/{owner}/{repo}/releases/tags/v${currentBuildAppVersion}`;
-            const response = await octokit.request(githubReleaseURL, {
-              owner: 'kinvolk',
-              repo: 'headlamp',
-            });
-            const [releaseNotes] = response.data.body.split('<!-- end-release-notes -->');
-            setReleaseNotes(releaseNotes);
+            let releaseNotes = '';
+            try {
+              const response = await octokit.request(githubReleaseURL, {
+                owner: 'kinvolk',
+                repo: 'headlamp',
+              });
+
+              const [notes] = response.data.body.split('<!-- end-release-notes -->');
+              if (!!notes) {
+                releaseNotes = notes;
+              }
+            } catch (err) {
+              console.error(
+                `Error getting release notes for version ${currentBuildAppVersion}:`,
+                err
+              );
+            }
+
+            if (!!releaseNotes) {
+              setReleaseNotes(releaseNotes);
+            }
           }
 
           // set the store version to the current so that we don't show release notes on


### PR DESCRIPTION
- app: Allow to override the app version with an env var
- frontend: Ensure the current app version is always set
- frontend: Catch any errors when getting the release information
