### PR TITLE
Fix showing the version in the release notes

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -130,7 +130,7 @@ export function PureTopBar({
   isSidebarOpenUserSelected,
   onToggleOpen,
 }: PureTopBarProps) {
-  const { t } = useTranslation();
+  const { t } = useTranslation('frequent');
   const isSmall = useMediaQuery('(max-width:960px)');
   const isMedium = useMediaQuery('(max-width:960px)');
 

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -37,10 +37,11 @@ export default function ReleaseNotes() {
     this check will help us later in determining whether we are on the latest release or not
     */
           const storedAppVersion = helpers.getAppVersion();
+          let releaseNotes = '';
           if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
             // get the release notes for the version with which the app was built with
+
             const githubReleaseURL = `GET /repos/{owner}/{repo}/releases/tags/v${currentBuildAppVersion}`;
-            let releaseNotes = '';
             try {
               const response = await octokit.request(githubReleaseURL, {
                 owner: 'kinvolk',
@@ -57,15 +58,17 @@ export default function ReleaseNotes() {
                 err
               );
             }
-
-            if (!!releaseNotes) {
-              setReleaseNotes(releaseNotes);
-            }
           }
 
           // set the store version to the current so that we don't show release notes on
           // every start of app
           helpers.setAppVersion(currentBuildAppVersion);
+
+          // Calling this after setting the version above, so the release notes have the right version
+          // set when they show it.
+          if (!!releaseNotes) {
+            setReleaseNotes(releaseNotes);
+          }
         }
         const isUpdateCheckingDisabled = JSON.parse(
           localStorage.getItem('disable_update_check') || 'false'

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -30,7 +30,6 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
     minHeight: '50%',
     overflow: 'auto',
   };
-  const appVersion = helpers.getAppVersion();
 
   return (
     <Modal open={showReleaseNotes} BackdropComponent={Backdrop} style={modalStyle}>
@@ -38,7 +37,9 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
         <Box display="flex" justifyContent="center">
           <Box flexGrow={2}>
             <Typography variant="h4">
-              {t('Release Notes')}({appVersion}){' '}
+              {t('release|Release Notes ({{ appVersion }})', {
+                appVersion: helpers.getAppVersion(),
+              })}
             </Typography>
           </Box>
           <Button onClick={() => setShowReleaseNotes(false)}>

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -46,12 +46,13 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
             <Icon icon={closeIcon} width="30" height="30" />
           </Button>
         </Box>
-        <div
+        <Box
+          mt={2}
           className="markdown-body"
           style={{ color: theme.palette.text.primary, fontFamily: 'inherit' }}
         >
           <ReactMarkdown>{releaseNotes}</ReactMarkdown>
-        </div>
+        </Box>
       </Paper>
     </Modal>
   );

--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
@@ -18,7 +18,7 @@ function UpdatePopup(props: { releaseDownloadURL: string }) {
       ContentProps={{
         'aria-describedby': 'updatePopup',
       }}
-      message={t('An update is available')}
+      message={t('release|An update is available')}
       action={
         <React.Fragment>
           <Button color="secondary" onClick={() => window.open(releaseDownloadURL)}>

--- a/frontend/src/i18n/locales/en/frequent.json
+++ b/frontend/src/i18n/locales/en/frequent.json
@@ -1,5 +1,11 @@
 {
   "Cancel": "",
+  "Change theme": "",
+  "Log out": "",
+  "(No token set up)": "",
+  "Account of current user": "",
+  "Appbar Tools": "",
+  "show more": "",
   "Try Again": "",
   "Back": "",
   "Name": "",

--- a/frontend/src/i18n/locales/en/frequent.json
+++ b/frontend/src/i18n/locales/en/frequent.json
@@ -16,6 +16,8 @@
   "Download": "",
   "download": "",
   "Close": "",
+  "More": "",
+  "Do not notify again": "",
   "Create / Apply": "",
   "apply": "",
   "Apply": "",

--- a/frontend/src/i18n/locales/en/release.json
+++ b/frontend/src/i18n/locales/en/release.json
@@ -1,0 +1,4 @@
+{
+  "Release Notes ({{ appVersion }})": "",
+  "An update is available": ""
+}

--- a/frontend/src/i18n/locales/es/frequent.json
+++ b/frontend/src/i18n/locales/es/frequent.json
@@ -16,6 +16,8 @@
   "Download": "Descargar",
   "download": "descargar",
   "Close": "Cerrar",
+  "More": "Más",
+  "Do not notify again": "No notificar de nuevo",
   "Create / Apply": "Crear / Aplicar",
   "apply": "aplicar",
   "Apply": "Aplicar",

--- a/frontend/src/i18n/locales/es/frequent.json
+++ b/frontend/src/i18n/locales/es/frequent.json
@@ -1,5 +1,11 @@
 {
   "Cancel": "Cancelar",
+  "Change theme": "Cambiar tema",
+  "Log out": "Desconectar",
+  "(No token set up)": "(Ningún token asignado)",
+  "Account of current user": "Cuenta del usuario actual",
+  "Appbar Tools": "Herramientas de la barra de aplicación",
+  "show more": "mostrar más",
   "Try Again": "Intentar de nuevo",
   "Back": "Volver",
   "Name": "Nombre",

--- a/frontend/src/i18n/locales/es/release.json
+++ b/frontend/src/i18n/locales/es/release.json
@@ -1,0 +1,4 @@
+{
+  "Release Notes ({{ appVersion }})": "Notas de lanzamiento ({{ appVersion }})",
+  "An update is available": "Una actualización está disponible"
+}

--- a/frontend/src/i18n/locales/pt/frequent.json
+++ b/frontend/src/i18n/locales/pt/frequent.json
@@ -1,5 +1,11 @@
 {
   "Cancel": "Cancelar",
+  "Change theme": "Mudar tema",
+  "Log out": "Terminar sessão",
+  "(No token set up)": "(Nenhum token establecido)",
+  "Account of current user": "Conta do utilizador actual",
+  "Appbar Tools": "Ferramentas da barra de aplicação",
+  "show more": "mostrar mais",
   "Try Again": "Tentar de Novo",
   "Back": "Atrás",
   "Name": "Nome",

--- a/frontend/src/i18n/locales/pt/frequent.json
+++ b/frontend/src/i18n/locales/pt/frequent.json
@@ -16,6 +16,8 @@
   "Download": "Descarregar",
   "download": "descarregar",
   "Close": "Fechar",
+  "More": "Mais",
+  "Do not notify again": "Não notificar mais",
   "Create / Apply": "Criar / Aplicar",
   "apply": "aplicar",
   "Apply": "Aplicar",

--- a/frontend/src/i18n/locales/pt/release.json
+++ b/frontend/src/i18n/locales/pt/release.json
@@ -1,0 +1,4 @@
+{
+  "Release Notes ({{ appVersion }})": "Notas de lançamento ({{ appVersion }})",
+  "An update is available": "Uma actualização está disponível"
+}


### PR DESCRIPTION
- frontend: Set the release notes' version string as translatable
- frontend: Add a margin between the release notes title and body
- frontend: Use frequent namespace on TopBar translations
- i18n: Use release namespace for an update release string
- i18n: Add missing translations
