### PR TITLE
backend: better way of determining the URL scheme

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -164,10 +164,15 @@ func baseURLReplace(staticDir string, baseURL string) {
 func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
 	urlScheme := r.URL.Scheme
 	if urlScheme == "" {
-		// @todo: Find a better way to get the scheme for the URL.
-		if r.Host == "localhost:"+config.port {
+		// check proxy headers first
+		fwdProto := r.Header.Get("X-Forwarded-Proto")
+
+		switch {
+		case fwdProto != "":
+			urlScheme = fwdProto
+		case r.Host == "localhost:"+config.port:
 			urlScheme = "http"
-		} else {
+		default:
 			urlScheme = "https"
 		}
 	}


### PR DESCRIPTION
# Better way of determining scheme of an URL for OIDC callback

Instead of guessing (which would return HTTP for localhost and HTTPS for every other situation – which is not always correct), check TLS property of a request object. It is `nil` for plain connection, and not `nil` if HTTPS is used.

## How to use

Not a new functionality.


