### PR TITLE
Fix plugin related issues

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.stories.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { EditorDialog, EditorDialogProps } from '..';
+
+export default {
+  title: 'Resource/EditorDialog',
+  component: EditorDialog,
+  argTypes: {},
+} as Meta;
+
+const Template: Story<EditorDialogProps> = args => {
+  return (
+    <EditorDialog
+      {...args}
+      item={{
+        metadata: {
+          name: 'Dummy_Name',
+          uid: 'UNIQUE_ID',
+          resourceVersion: '0.0.0',
+          selfLink: 'https://',
+          creationTimestamp: '10/12/2021',
+        },
+        kind: 'DUMMY_KUBE_KIND',
+      }}
+    />
+  );
+};
+
+export const EditorDialogWithResource = Template.bind({});

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -52,7 +52,7 @@ const useStyle = makeStyles(theme => ({
 
 type KubeObjectIsh = Partial<KubeObjectInterface>;
 
-interface EditorDialogProps extends DialogProps {
+export interface EditorDialogProps extends DialogProps {
   item: KubeObjectIsh | null;
   onClose: () => void;
   onSave: ((...args: any[]) => void) | null;

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.stories.storyshot
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Resource/EditorDialog Editor Dialog With Resource 1`] = `
+<div
+  id="root"
+/>
+`;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -19,3 +19,5 @@ export { default as Tabs } from './Tabs';
 export * from './Terminal';
 export { default as Terminal } from './Terminal';
 export * from './Tooltip';
+export * from './Resource/EditorDialog';
+export { default as EditorDialog } from './Resource/EditorDialog';

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -45,6 +45,7 @@ import PersistentVolumeList from '../components/storage/VolumeList';
 import WorkloadDetails from '../components/workload/Details';
 import WorkloadOverview from '../components/workload/Overview';
 import LocaleSelect from '../i18n/LocaleSelect/LocaleSelect';
+import store from '../redux/stores/store';
 import CronJob from './k8s/cronJob';
 import Deployment from './k8s/deployment';
 import Job from './k8s/job';
@@ -432,7 +433,8 @@ export interface RouteURLProps {
 }
 
 export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
-  const route = getRoute(routeName);
+  const storeRoutes = store.getState().ui.routes;
+  const route = getRoute(routeName) || (storeRoutes && storeRoutes[routeName]);
 
   if (!route) {
     return '';

--- a/frontend/src/plugin/index.tsx
+++ b/frontend/src/plugin/index.tsx
@@ -106,6 +106,7 @@ window.pluginLib = {
   MuiStyles: require('@material-ui/styles'),
   React: require('react'),
   Recharts: require('recharts'),
+  ReactRouter: require('react-router-dom'),
   ReactRedux: require('react-redux'),
   Utils: require('../lib/util'),
   Iconify: require('@iconify/react'),


### PR DESCRIPTION
This PR fixes and adds a few things that are required for the plugins to work correctly.

1. The ```createRouteURL``` method in ```frontend/src/lib/router.tsx``` doesn't considers routes from redux store which could be a problem when a plugin wants to render a link and the only way the plugin can communicate it's route params is through the store so we have to make the createRouteURL method aware of the store routes.
2. We need the Editor component exported because it will come in useful when we want to modify a kube object.
3. We need  APIs such as ```useLocation``` or ```useHistory``` etc. from react-router package so it makes sense to export it as well