### PR TITLE
Fix static resource paths when the URL is not /

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -16,7 +16,6 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	oidc "github.com/coreos/go-oidc"
@@ -117,36 +116,17 @@ func copyReplace(src string, dst string,
 	}
 }
 
-func strInFile(str, filepath string) bool {
-	contents, err := ioutil.ReadFile(filepath)
-	if err != nil {
-		panic(err)
-	}
-
-	isThere, err := regexp.Match(str, contents)
-	if err != nil {
-		panic(err)
-	}
-
-	return isThere
-}
-
 // make sure the base-url is updated in the index.html file.
 func baseURLReplace(staticDir string, baseURL string) {
 	indexBaseURL := path.Join(staticDir, "index.baseUrl.html")
 	index := path.Join(staticDir, "index.html")
-
-	if baseURL == "" && (!fileExists(indexBaseURL) || strInFile("headlampBaseUrl=\".\"", index)) {
-		// The index.html does not need resetting from a different baseURL.
-		return
-	}
 
 	replaceURL := baseURL
 	if baseURL == "" {
 		// We have to do the replace when baseURL == "" because of the case when
 		//   someone first does a different baseURL. If we didn't it would stay stuck
 		//   on that previous baseURL.
-		replaceURL = "."
+		replaceURL = "/"
 	}
 
 	if !fileExists(indexBaseURL) {

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -124,7 +124,7 @@ function getBaseUrl(): string {
     baseUrl = process.env.PUBLIC_URL ? process.env.PUBLIC_URL : '';
   }
 
-  if (baseUrl === './' || baseUrl === '.') {
+  if (baseUrl === './' || baseUrl === '.' || baseUrl === '/') {
     baseUrl = '';
   }
   return baseUrl;


### PR DESCRIPTION
If coming in from a URL like /c/main then the static file
paths will be "./c/main/static/nnn.css" rather than "/static/nnn.css"

This results in a white empty page where the app does not load without any error shown, as seen in: https://github.com/kinvolk/headlamp/issues/345

## How to use

```
eval $(minikube docker-env)
docker build . -t me/headlamp 

Change in ./kubernetes-headlamp.yaml 
  image: me/headlamp:latest
  imagePullPolicy: Never

kubectl apply -f ./kubernetes-headlamp.yaml 

kubectl -n kube-system create serviceaccount headlamp-admin
kubectl create clusterrolebinding headlamp-admin --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
kubectl -n kube-system get secrets | grep headlamp-admin
# get the token to login to headlamp from here
kubectl -n kube-system describe secret headlamp-admin-token-XXXXX

kubectl port-forward -n kube-system service/headlamp 8080:80
```

### Without building an image

```
make frontend backend -j2
./backend/server -html-static-dir frontend/build/
```

Then go to: http://localhost:4466/



## Testing done

- Going to "/" works
- Going to "/c/main" works
- Refreshing the page on other URLs work

