### PR TITLE
github: Simplify the release draft action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -3,10 +3,6 @@ name: Create Release Draft
 on:
   workflow_dispatch:
     inputs:
-      releaseBranch:
-        description: 'Headlamp ref/branch/tag'
-        required: true
-        default: 'main'
       releaseName:
         description: 'Name for this release (should be equivalent to the tag without the v prefix)'
         required: true
@@ -17,19 +13,12 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.releaseBranch }}
       - name: Create Release Draft
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.event.inputs.releaseName }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
+          name: ${{ github.event.inputs.releaseName }}
           body: |
             ## Enhancements:
             * Feature 1
@@ -57,3 +46,5 @@ jobs:
             :green_apple:  [Mac (AMD64)](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-mac-x64.dmg)
             :green_apple: [Mac (ARM/M1)](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-mac-arm64.dmg)
             :blue_square:  [Windows (AMD64)](https://github.com/kinvolk/headlamp/releases/download/v${{ github.event.inputs.releaseName }}/Headlamp-${{ github.event.inputs.releaseName }}-win-x64.exe)
+        env:
+          GITHUB_REPOSITORY: $GITHUB_REPOSITORY


### PR DESCRIPTION
Turns out the action used before is discontinued, so this one replaces it and also simplifies the logic.