### PR TITLE
Consider dynamic routes first

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -8,13 +8,14 @@ import { useTypedSelector } from '../../redux/reducers/reducers';
 import { useSidebarItem } from '../Sidebar';
 
 export default function RouteSwitcher() {
+  // The NotFoundRoute always has to be evaluated in the last place.
+  const defaultRoutes = Object.values(ROUTES).concat(NotFoundRoute);
   const routes = useTypedSelector(state => state.ui.routes);
 
   return (
     <Switch>
-      {Object.values(ROUTES)
-        .concat(Object.values(routes))
-        .concat(NotFoundRoute)
+      {Object.values(routes)
+        .concat(defaultRoutes)
         .map((route, index) =>
           route.name === 'OidcAuth' ? (
             <Route

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -449,7 +449,7 @@ export interface RouteURLProps {
 
 export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
   const storeRoutes = store.getState().ui.routes;
-  const route = getRoute(routeName) || (storeRoutes && storeRoutes[routeName]);
+  const route = (storeRoutes && storeRoutes[routeName]) || getRoute(routeName);
 
   if (!route) {
     return '';


### PR DESCRIPTION
We have default routes and dynamic ones (set in redux, by plugins), and
so far we've been considering the default ones first. This meant that
routes couldn't be overridden by plugins and this makes things less
flexible for them.

This patch considers default routes last, so it opens a lot of
flexibility for plugins to replace a route completely.