### PR TITLE
desktop: Use a different kubeconfig

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -310,10 +310,17 @@ function startElecron() {
   setMenu(i18n);
 
   function createWindow() {
+    let frontendPath = '';
+    if (isDev) {
+      frontendPath = path.resolve('..', 'frontend', 'build', 'index.html');
+    } else {
+      frontendPath = path.join(process.resourcesPath, 'frontend', 'index.html');
+    }
+
     const startUrl =
       process.env.ELECTRON_START_URL ||
       url.format({
-        pathname: path.join(process.resourcesPath, 'frontend', 'index.html'),
+        pathname: frontendPath,
         protocol: 'file:',
         slashes: true,
       });

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -31,11 +31,16 @@ const isHeadlessMode = args.headless;
 const disableGPU = args['disable-gpu'];
 const defaultPort = 4466;
 
+const isDev = process.env.ELECTRON_DEV || false;
+const useExternalServer = process.env.EXTERNAL_SERVER || false;
+
 function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
-  const serverFilePath = path.join(process.resourcesPath, './server');
+  const serverFilePath = isDev
+    ? path.resolve('../backend/server')
+    : path.join(process.resourcesPath, './server');
 
   const options = { shell: true, detached: false };
-  if (process.platform !== 'win32') {
+  if (process.platform !== 'win32' && !isDev) {
     // This makes the child processes a separate group, for easier killing.
     options.detached = true;
   }
@@ -294,8 +299,6 @@ function startElecron() {
 
   let mainWindow: BrowserWindow | null;
 
-  const isDev = process.env.ELECTRON_DEV || false;
-
   let appVersion: string;
   if (isDev && process.env.HEADLAMP_APP_VERSION) {
     appVersion = process.env.HEADLAMP_APP_VERSION;
@@ -354,7 +357,7 @@ function startElecron() {
       }
     });
 
-    if (!isDev) {
+    if (!useExternalServer) {
       serverProcess = startServer();
       attachServerEventHandlers(serverProcess);
     }

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "copy-icons": "mkdir -p build/icons && cp ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "build": "npm run copy-icons && npm run compile-electron && npm run prod-deps && electron-builder --dir --publish never",
     "package": "npm run copy-icons && npm run compile-electron && electron-builder build --publish never",
-    "dev": "npm run compile-electron && export ELECTRON_DEV=1 && export ELECTRON_START_URL=http://localhost:3000 && electron .",
+    "dev": "npm run compile-electron && export ELECTRON_DEV=1 && electron .",
     "dev-only-app": "npm run compile-electron && export ELECTRON_DEV=1 && export ELECTRON_START_URL=http://localhost:3000 && export EXTERNAL_SERVER=true && electron .",
     "i18n": "npx --no-install i18next ./electron/main.ts -c ./electron/i18next-parser.config.js"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,8 @@
     "copy-icons": "mkdir -p build/icons && cp ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "build": "npm run copy-icons && npm run compile-electron && npm run prod-deps && electron-builder --dir --publish never",
     "package": "npm run copy-icons && npm run compile-electron && electron-builder build --publish never",
-    "serve-dev": "npm run compile-electron && export ELECTRON_DEV=1 && export ELECTRON_START_URL=http://localhost:3000 && electron .",
+    "dev": "npm run compile-electron && export ELECTRON_DEV=1 && export ELECTRON_START_URL=http://localhost:3000 && electron .",
+    "dev-only-app": "npm run compile-electron && export ELECTRON_DEV=1 && export ELECTRON_START_URL=http://localhost:3000 && export EXTERNAL_SERVER=true && electron .",
     "i18n": "npx --no-install i18next ./electron/main.ts -c ./electron/i18next-parser.config.js"
   },
   "build": {

--- a/docs/installation/desktop/_index.md
+++ b/docs/installation/desktop/_index.md
@@ -10,6 +10,31 @@ Currently there are desktop apps for [Linux](./linux-installation.md), [Mac](./m
 
 Please check the following guides for the installation in your desired platform.
 
+## Use a non-default kube config file
+
+If you wish to use a non-default kube config file, then you can do it by
+providing it as an argument to Headlamp, e.g.:
+
+```bash
+/path/to/headlamp /my/different/kubeconfig
+```
+
+or by using an environment variable:
+
+```bash
+KUBECONFIG=/my/different/kubeconfig /path/to/headlamp
+```
+
+### Use several kube config files
+
+If you need to use more than one kube config file, please merge them into
+one and use the resulting one as indicated above.
+
+You can easily merge kubee config files the following way:
+```bash
+KUBECONFIG=kubeconfig1:kubeconfig2:kubeconfig3 kubectl config view --raw > mynewconfig
+```
+
 ## Access using OIDC
 
 OIDC has a feature makes more sense when

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -18,6 +18,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { Trans, useTranslation } from 'react-i18next';
 import { generatePath } from 'react-router';
 import { useHistory } from 'react-router-dom';
+import helpers from '../../helpers';
 import { useCluster, useClustersConf } from '../../lib/k8s';
 import { Cluster } from '../../lib/k8s/cluster';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
@@ -286,6 +287,11 @@ function Chooser(props: ClusterDialogProps) {
               <DialogContentText>
                 {t('Please make sure you have at least one cluster configured.')}
               </DialogContentText>
+              {helpers.isElectron() && (
+                <DialogContentText>
+                  {t('Or try running Headlamp with a different kube config.')}
+                </DialogContentText>
+              )}
             </>
           )}
         </React.Fragment>


### PR DESCRIPTION
This PR adds the possibility of running Headlamp with a different kube config, by using either a `KUBECONFIG` env var, or the new positional argument: `headlamp /path/to/my/different/kubeconfig`.

fixes #370 
fixes #357 

cc/ @sgandon , it's not loading an entire dir by default, but I hope this makes sense.