### PR TITLE
frontend: Do not change state on VersionButton after it's unmounted

### DIFF
--- a/frontend/src/components/Sidebar/VersionButton.tsx
+++ b/frontend/src/components/Sidebar/VersionButton.tsx
@@ -72,9 +72,14 @@ export default function VersionButton() {
 
   React.useEffect(
     () => {
+      let stillAlive = true;
       function fetchVersion() {
         getVersion()
           .then((results: StringDict) => {
+            if (!stillAlive) {
+              return;
+            }
+
             setClusterVersion(results);
             let versionChange = 0;
             if (clusterVersion && results && results.gitVersion) {
@@ -113,6 +118,7 @@ export default function VersionButton() {
       }, versionFetchInterval);
 
       return function cleanup() {
+        stillAlive = false;
         clearInterval(intervalHandler);
       };
     },


### PR DESCRIPTION
Due to how the VersionButton was fetching the version details, it
could end up trying to change the state after the button was no longer
mounted. This patch changes that by ensuring we have not unmounted it.
