### PR TITLE
frontend: Add links to the events list

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -7,7 +7,7 @@ import Event from '../../lib/k8s/event';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
 import { timeAgo, useFilterFunc } from '../../lib/util';
-import { StatusLabel } from '../common';
+import { Link, StatusLabel } from '../common';
 import Empty from '../common/EmptyContent';
 import { PageGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
@@ -75,6 +75,15 @@ function EventsSection() {
     );
   }
 
+  function makeObjectLink(event: Event) {
+    const obj = event.involvedObjectInstance;
+    if (!!obj) {
+      return <Link kubeObject={obj} />;
+    }
+
+    return event.involvedObject.name;
+  }
+
   return (
     <SectionBox title={<SectionFilterHeader title={t('Events')} />}>
       <SimpleTable
@@ -91,7 +100,7 @@ function EventsSection() {
                 },
                 {
                   label: t('frequent|Name'),
-                  getter: event => event.involvedObject.name,
+                  getter: event => makeObjectLink(event),
                   sort: true,
                 },
                 {

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -440,7 +440,7 @@ function LivenessProbes(props: { liveness: KubeContainer['livenessProbe'] }) {
   return (
     <Box display="flex" flexDirection="column">
       <LivenessProbeItem>
-        {`http-get, path: ${liveness?.httpGet?.path}, port: ${liveness?.httpGet?.port}, 
+        {`http-get, path: ${liveness?.httpGet?.path}, port: ${liveness?.httpGet?.port},
     scheme: ${liveness?.httpGet?.scheme}`}
       </LivenessProbeItem>
       <LivenessProbeItem>

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -1,5 +1,6 @@
+import { ResourceClasses } from '.';
 import { apiFactoryWithNamespace } from './apiProxy';
-import { KubeMetadata, makeKubeObject } from './cluster';
+import { KubeMetadata, KubeObject, makeKubeObject } from './cluster';
 
 export interface KubeEvent {
   type: string;
@@ -43,6 +44,26 @@ class Event extends makeKubeObject<KubeEvent>('Event') {
 
   get message() {
     return this.getValue('message');
+  }
+
+  get involvedObjectInstance(): KubeObject | null {
+    if (!this.involvedObject) {
+      return null;
+    }
+
+    const InvolvedObjectClass = ResourceClasses[this.involvedObject.kind];
+    let objInstance: KubeObject | null = null;
+    if (!!InvolvedObjectClass) {
+      objInstance = new InvolvedObjectClass({
+        kind: this.involvedObject.kind,
+        metadata: {
+          name: this.involvedObject.name,
+          namespace: this.involvedObject.namespace,
+        },
+      });
+    }
+
+    return objInstance;
   }
 }
 


### PR DESCRIPTION
The events list shows important occurrences in the cluster, and it's
very useful to have a way to go right to the resource in question.

So this patch adds a link to the involved object, when possible.
