### PR TITLE
frontend: Simplify and fix advanced search

### DIFF
--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -13,11 +13,8 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
-import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { KubeObjectInterface } from '../../lib/k8s/cluster';
-import { useTypedSelector } from '../../redux/reducers/reducers';
 import Empty from './EmptyContent';
 import { ValueLabel } from './Label';
 import Loader from './Loader';
@@ -80,7 +77,6 @@ export interface SimpleTableProps {
   emptyMessage?: string;
   errorMessage?: string | null;
   defaultSortingColumn?: number;
-  advancedFilters?: [string];
 }
 
 interface ColumnSortButtonProps {
@@ -115,7 +111,6 @@ export default function SimpleTable(props: SimpleTableProps) {
     emptyMessage = null,
     errorMessage = null,
     defaultSortingColumn,
-    advancedFilters,
   } = props;
   const [page, setPage] = React.useState(0);
   const [currentData, setCurrentData] = React.useState(data);
@@ -123,7 +118,6 @@ export default function SimpleTable(props: SimpleTableProps) {
   const rowsPerPageOptions = props.rowsPerPage || [5, 10, 50];
   const [rowsPerPage, setRowsPerPage] = React.useState(rowsPerPageOptions[0]);
   const classes = useTableStyle();
-  const filter = useTypedSelector(state => state.filter);
   const [isIncreasingOrder, setIsIncreasingOrder] = React.useState(
     !defaultSortingColumn || defaultSortingColumn > 0
   );
@@ -243,22 +237,8 @@ export default function SimpleTable(props: SimpleTableProps) {
   let filteredData = displayData;
   if (filterFunction) {
     filteredData = displayData.filter(filterFunction);
-    if (advancedFilters) {
-      for (let i = 0; i < advancedFilters.length; i++) {
-        // attach all data from previous filter so that we don't lose data from any filter
-        filteredData = filteredData.concat(
-          displayData.filter((item: KubeObjectInterface) =>
-            _.get(item, advancedFilters[i]).toLowerCase().includes(filter.search.toLowerCase())
-          )
-        );
-      }
-      //remove duplicate entries
-      filteredData = _.uniqBy(
-        filteredData as KubeObjectInterface[],
-        (val: KubeObjectInterface) => val.metadata.uid
-      );
-    }
   }
+
   function sortClickHandler(isIncreasingOrder: boolean, index: number) {
     setIsIncreasingOrder(isIncreasingOrder);
     setSortColIndex(index);

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -18,7 +18,7 @@ export default function RoleBindingList() {
   const [clusterRoleBindingError, onClusterRoleBindingError] =
     useErrorState(setupClusterRoleBindings);
   const { t } = useTranslation('glossary');
-  const filterFunc = useFilterFunc();
+  const filterFunc = useFilterFunc(['.kind']);
 
   function setRoleBindings(newBindings: RoleBinding[] | null, kind: string) {
     const currentBindings: RoleBindingDict = bindings || {};
@@ -70,7 +70,6 @@ export default function RoleBindingList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
-        advancedFilters={['kind']}
         errorMessage={getErrorMessage()}
         columns={[
           {

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -17,7 +17,7 @@ export default function RoleList() {
   const [roleError, setRolesError] = useErrorState(setupRoles);
   const [clusterRoleError, setClusterRolesError] = useErrorState(setupClusterRoles);
   const { t } = useTranslation('glossary');
-  const filterFunc = useFilterFunc();
+  const filterFunc = useFilterFunc(['.jsonData.kind']);
 
   function setupRolesWithKind(newRoles: Role[] | null, kind: string) {
     setRoles(oldRoles => ({ ...(oldRoles || {}), [kind]: newRoles }));
@@ -65,7 +65,6 @@ export default function RoleList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
-        advancedFilters={['kind']}
         errorMessage={getErrorMessage()}
         columns={[
           {

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -9,7 +9,7 @@ import SimpleTable from '../common/SimpleTable';
 
 export default function SecretList() {
   const [secrets, error] = Secret.useList();
-  const filterFunc = useFilterFunc();
+  const filterFunc = useFilterFunc(['.jsonData.type']);
   const { t } = useTranslation('glossary');
 
   return (
@@ -18,7 +18,6 @@ export default function SecretList() {
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
         errorMessage={Secret.getErrorMessage(error)}
-        advancedFilters={['type']}
         columns={[
           {
             label: t('frequent|Name'),

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -9,7 +9,7 @@ import SimpleTable from '../common/SimpleTable';
 
 export default function ServiceList() {
   const [services, error] = Service.useList();
-  const filterFunc = useFilterFunc();
+  const filterFunc = useFilterFunc(['.jsonData.spec.type']);
   const { t } = useTranslation('glossary');
 
   return (
@@ -17,7 +17,6 @@ export default function ServiceList() {
       <SimpleTable
         rowsPerPage={[15, 25, 50]}
         filterFunction={filterFunc}
-        advancedFilters={['spec.type']}
         errorMessage={Service.getErrorMessage(error)}
         columns={[
           {

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -23,7 +23,7 @@ interface WorkloadDict {
 export default function Overview() {
   const [workloadsData, dispatch] = React.useReducer(setWorkloads, {});
   const location = useLocation();
-  const filterFunc = useFilterFunc();
+  const filterFunc = useFilterFunc(['.jsonData.kind']);
   const { t } = useTranslation('glossary');
 
   function setWorkloads(
@@ -85,7 +85,6 @@ export default function Overview() {
         <SimpleTable
           rowsPerPage={[15, 25, 50]}
           filterFunction={filterFunc}
-          advancedFilters={['kind']}
           columns={[
             {
               label: t('Type'),


### PR DESCRIPTION
The advanced filter search (searching by non-default criteria) was
not working correctly because it was mixing non-filtered matches with
the matched ones, e.g. if we selected a namespace and then used the
advance filter matching (by matching the "kind" in the workload
overview), it was showing the correctly matched kind, but with data
from all namespaces.

This patch not only fixes that issue, but also simplifies how the
advanced filter is implemented (in the filter function rather than
in the SimpleTable component) and uses JSONPath to make it a bit more
powerful as well.
