### PR TITLE
frontend: Fix make docs, add building docs to CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -50,3 +50,7 @@ jobs:
     - name: Test plugins
       run: |
         make plugins-test
+
+    - name: Build docs
+      run: |
+        make docs

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16661,9 +16661,9 @@
       "dev": true
     },
     "marked": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-      "integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
       "dev": true
     },
     "matcher-collection": {
@@ -17671,32 +17671,6 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
       }
     },
     "open": {
@@ -21932,13 +21906,13 @@
       "optional": true
     },
     "shiki": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.11.tgz",
-      "integrity": "sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==",
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
+        "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
     },
@@ -23524,37 +23498,44 @@
       }
     },
     "typedoc": {
-      "version": "0.21.9",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
-      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.7",
-        "handlebars": "^4.7.7",
+        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.2",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shiki": "^0.9.8",
-        "typedoc-default-themes": "^0.12.10"
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
-    "typedoc-default-themes": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
-      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
-      "dev": true
-    },
     "typedoc-hugo-theme": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/typedoc-hugo-theme/-/typedoc-hugo-theme-0.2.1.tgz",
-      "integrity": "sha512-Bx+/tMeHHTYsx2RMOhsSGUkgNK+sFRznouoolNhTrAXAXL2fN6jhbHycuJ3y2IST/2z/vx4nRpWySp021q+Wjw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-hugo-theme/-/typedoc-hugo-theme-1.0.0.tgz",
+      "integrity": "sha512-FkH7Y0469W6QN26F4N+3vSVy7PcZDJhXEc68XNBLR36gsOfRSdxC6PeBxoIyaLZ2TJHVWtwSllvqrNaUI9DiUw==",
       "dev": true
     },
     "typedoc-plugin-markdown": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.3.tgz",
-      "integrity": "sha512-rWiHbEIe0oZetDIsBR24XJVxGOJ91kDcHoj2KhFKxCLoJGX659EKBQkHne9QJ4W2stGhu1fRgFyQaouSBnxukA==",
+      "version": "3.11.11",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.11.tgz",
+      "integrity": "sha512-LyephgG2yHiSqJppuDVKy3dPLSbzP+ke/VBxGvH4I/+31NXzuEhLFhxx/X4UMqzh2XbUB44ttABtGd11biKr4Q==",
       "dev": true,
       "requires": {
         "handlebars": "^4.7.7"
@@ -23587,9 +23568,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
-      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.5.tgz",
+      "integrity": "sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==",
       "dev": true,
       "optional": true
     },
@@ -24182,6 +24163,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
     },
     "vscode-textmate": {
       "version": "5.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -152,8 +152,8 @@
     "lint-staged": "^10.5.4",
     "monaco-editor-webpack-plugin": "^4.2.0",
     "prettier": "^2.4.1",
-    "typedoc": "^0.21.9",
-    "typedoc-hugo-theme": "^0.2.1",
-    "typedoc-plugin-markdown": "^3.11.3"
+    "typedoc": "^0.22.10",
+    "typedoc-hugo-theme": "^1.0.0",
+    "typedoc-plugin-markdown": "^3.11.11"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,7 +26,7 @@
   "typedocOptions": {
     "out": "../docs/development/api",
     "entryPoints": ["src/lib/k8s/index.ts", "src/lib/util.ts", "src/plugin/index.tsx", "src/plugin/registry.tsx"],
-    "theme": "./node_modules/typedoc-hugo-theme/dist",
+    "theme": "hugo",
     "excludeExternals": true,
     "excludePrivate": true,
     "excludeProtected": true,


### PR DESCRIPTION
# docs fix

- `make docs` works again, 
- and is now run in CI (to hopefully catch it if it breaks again).

There were some dependencies updated in https://github.com/kinvolk/headlamp/pull/337 which broke typedoc. Updated to newer versions of typedoc and friends fixes it.
