### PR TITLE
Fix windows app not closing server.exe on quit

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,6 +6,7 @@ on:
     - 'frontend/**'
     - 'Makefile'
     - '.github/**'
+    - 'app/**'
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
     - 'frontend/**'
     - Makefile
     - '.github/**'
+    - 'app/**'
 
 jobs:
   build:

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,4 +1,4 @@
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams, exec, spawn } from 'child_process';
 import { app, BrowserWindow, ipcMain, Menu, MenuItem, screen, shell } from 'electron';
 import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import log from 'electron-log';
@@ -73,7 +73,7 @@ let intentionalQuit: boolean;
 let serverProcessQuit: boolean;
 
 function quitServerProcess() {
-  if (!serverProcess || serverProcessQuit) {
+  if ((!serverProcess || serverProcessQuit) && process.platform !== 'win32') {
     log.error('server process already not running');
     return;
   }
@@ -84,6 +84,9 @@ function quitServerProcess() {
     // Negative pid because it should kill the whole group of processes:
     //    https://azimi.me/2014/12/31/kill-child_process-node-js.html
     process.kill(-serverProcess.pid);
+  } else if (process.platform === 'win32' && serverProcess) {
+    // Otherwise on Windows the process will stick around.
+    exec('taskkill /pid ' + serverProcess.pid + ' /T /F');
   }
 
   serverProcess.stdin.destroy();


### PR DESCRIPTION
# Now when the app is quit the server.exe process is also stopped.

Related to issue: https://github.com/kinvolk/headlamp/issues/389

## How to use

Check task manager for a server.exe process still around when the app quits.

Or with cmd you can find it with:
```
tasklist | findstr /c:"server.exe"
```

## Testing done

- [x] when app is quit it kills server.exe as well
