### PR TITLE
frontend: Prevent repeated details view rendering

### DIFF
--- a/frontend/src/helpers/renderHelpers.tsx
+++ b/frontend/src/helpers/renderHelpers.tsx
@@ -19,7 +19,7 @@ export default function DetailsViewPluginRenderer(props: { resource: KubeObject 
           );
         }
       }),
-    [detailViews]
+    [detailViews.length]
   );
   return <>{memoizedComponents}</>;
 }

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -163,8 +163,18 @@ function reducer(state = INITIAL_STATE, action: Action) {
     }
     case UI_SET_DETAILS_VIEW: {
       const { sectionName, action: sectionFunc } = action;
-      const detailViews = [...newFilters.views.details.pluginAppendedDetailViews];
-      detailViews.push({ sectionName, sectionFunc });
+      const pluginDetailViews = newFilters.views.details.pluginAppendedDetailViews;
+      const detailViews = [...pluginDetailViews];
+      // only push if it's a unique section
+      if (
+        detailViews.length === 0 ||
+        !detailViews.find(
+          (view: { sectionName: string; sectionFunc: sectionFunc }) =>
+            view.sectionName === sectionName
+        )
+      ) {
+        detailViews.push({ sectionName, sectionFunc });
+      }
       newFilters.views.details.pluginAppendedDetailViews = detailViews;
       break;
     }


### PR DESCRIPTION
# [Title: describe the change in one sentence]
Details View that is meant to be rendered by a plugin was rendering repeated views at times, This patch prevents rendering of a section more than once. 

## Testing done
To reproduce this behaviour on main try changing the theme and you will see multiple rendering of the details view, on this branch the above behaviour is not reproducible