### PR TITLE
build: Don't check for a chart version bump

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,1 +1,2 @@
 target-branch: main
+check-version-increment: false


### PR DESCRIPTION
We don't need this when testing/linting the charts' PRs.
