### PR TITLE
frontend: Make workload details go back to the correct list view

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -18,7 +18,7 @@ import _ from 'lodash';
 import * as monaco from 'monaco-editor';
 import React, { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { generatePath, Link as RouterLink, NavLinkProps, useLocation } from 'react-router-dom';
 import DetailsViewPluginRenderer from '../../../helpers/renderHelpers';
 import { ApiError } from '../../../lib/k8s/apiProxy';
 import {
@@ -171,8 +171,14 @@ export function DetailsGrid(props: DetailsGridProps) {
     props;
   const [item, setItem] = React.useState<KubeObject | null>(null);
   const [error, setError] = React.useState<ApiError | string | null>(null);
+  const location = useLocation<{ backLink: NavLinkProps['location'] }>();
 
-  const backLink = React.useMemo(() => {
+  const backLink: string | undefined = React.useMemo(() => {
+    const stateLink = location.state?.backLink || null;
+    if (!!stateLink) {
+      return generatePath(stateLink.pathname);
+    }
+
     let route;
     try {
       route = new resourceType().listRoute;
@@ -197,7 +203,7 @@ export function DetailsGrid(props: DetailsGridProps) {
       <MainInfoSection
         resource={item}
         error={error}
-        backLink={!item ? backLink : undefined}
+        backLink={backLink}
         {...otherMainInfoSectionProps}
       />
       <>{!!sectionsFunc && sectionsFunc(item)}</>

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLinkProps, useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import DetailsViewPluginRenderer from '../../helpers/renderHelpers';
 import { KubeObject } from '../../lib/k8s/cluster';
 import {
@@ -16,14 +16,12 @@ interface WorkloadDetailsProps {
 
 export default function WorkloadDetails(props: WorkloadDetailsProps) {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
-  const location = useLocation<{ backLink: NavLinkProps['location'] }>();
   const { workloadKind } = props;
   const { t } = useTranslation('glossary');
 
   return (
     <DetailsGrid
       resourceType={workloadKind}
-      backLink={location.state?.backLink}
       name={name}
       namespace={namespace}
       extraInfo={item =>

--- a/frontend/src/lib/k8s/cronJob.ts
+++ b/frontend/src/lib/k8s/cronJob.ts
@@ -23,10 +23,6 @@ class CronJob extends makeKubeObject<KubeCronJob>('CronJob') {
   get status() {
     return this.getValue('status');
   }
-
-  get listRoute() {
-    return 'workloads';
-  }
 }
 
 export default CronJob;

--- a/frontend/src/lib/k8s/daemonSet.ts
+++ b/frontend/src/lib/k8s/daemonSet.ts
@@ -27,10 +27,6 @@ class DaemonSet extends makeKubeObject<KubeDaemonSet>('DaemonSet') {
   get status() {
     return this.jsonData!.status;
   }
-
-  get listRoute() {
-    return 'workloads';
-  }
 }
 
 export default DaemonSet;

--- a/frontend/src/lib/k8s/job.ts
+++ b/frontend/src/lib/k8s/job.ts
@@ -21,10 +21,6 @@ class Job extends makeKubeObject<KubeJob>('Job') {
   get status() {
     return this.jsonData!.status;
   }
-
-  get listRoute() {
-    return 'workloads';
-  }
 }
 
 export default Job;

--- a/frontend/src/lib/k8s/statefulSet.ts
+++ b/frontend/src/lib/k8s/statefulSet.ts
@@ -27,10 +27,6 @@ class StatefulSet extends makeKubeObject<KubeStatefulSet>('StatefulSet') {
   get status() {
     return this.jsonData!.status;
   }
-
-  get listRoute() {
-    return 'workloads';
-  }
 }
 
 export default StatefulSet;


### PR DESCRIPTION
The back link from their details view would go to the workloads'
list view but it should go to the resources' own list view.
