### PR TITLE
Fix plugin reinitialization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ function AppWithRedux(props: React.PropsWithChildren<{}>) {
 
   React.useEffect(() => {
     initializePlugins();
-  }, [themeName]);
+  }, []);
 
   return (
     <I18nextProvider i18n={i18n}>

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -5,6 +5,8 @@
  */
 
 import helpers from '../helpers';
+import { UI_RESET_PLUGIN_VIEWS } from '../redux/actions/actions';
+import store from '../redux/stores/store';
 import { Headlamp, Plugin } from './lib';
 import Registry from './registry';
 
@@ -98,6 +100,11 @@ function loadDevPlugins() {
  * Load external, then local plugins. Then initialize() them in order with a Registry.
  */
 export async function initializePlugins() {
+  // Reset plugins before initializing, or we could end up with duplicated
+  // logic/views.
+  window.plugins = {};
+  store.dispatch({ type: UI_RESET_PLUGIN_VIEWS });
+
   await loadExternalPlugins();
   await loadDevPlugins();
 

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -18,6 +18,7 @@ export const UI_DETAILS_VIEW_SET_HEADER_ACTION = 'UI_DETAILS_VIEW_SET_HEADER_ACT
 export const UI_SET_DETAILS_VIEW = 'UI_SET_DETAILS_VIEW';
 export const UI_APP_BAR_SET_ACTION = 'UI_APP_BAR_SET_ACTION';
 export const UI_THEME_SET = 'UI_THEME_SET';
+export const UI_RESET_PLUGIN_VIEWS = 'UI_RESET_PLUGIN_VIEWS';
 
 export interface ClusterActionButton {
   label: string;

--- a/frontend/src/redux/reducers/clusterAction.tsx
+++ b/frontend/src/redux/reducers/clusterAction.tsx
@@ -9,7 +9,7 @@ export const INITIAL_STATE: ClusterState = {
   // id: { message, ... } . See the ActionsNotifier.
 };
 
-function cluster(clusterActions = INITIAL_STATE, action: ClusterAction & Action) {
+function cluster(clusterActions = _.cloneDeep(INITIAL_STATE), action: ClusterAction & Action) {
   const { type, id, ...actionOptions } = action;
   const newState = { ...clusterActions };
   switch (type) {

--- a/frontend/src/redux/reducers/config.tsx
+++ b/frontend/src/redux/reducers/config.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Cluster } from '../../lib/k8s/cluster';
 import { Action, CONFIG_NEW } from '../actions/actions';
 
@@ -11,7 +12,7 @@ export const INITIAL_STATE: ConfigState = {
   clusters: null,
 };
 
-function reducer(state = INITIAL_STATE, action: Action) {
+function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
   const newState = { ...state };
   switch (action.type) {
     case CONFIG_NEW:

--- a/frontend/src/redux/reducers/filter.tsx
+++ b/frontend/src/redux/reducers/filter.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { FilterState } from '../../lib/util';
 import { Action, FILTER_RESET, FILTER_SET_NAMESPACE, FILTER_SET_SEARCH } from '../actions/actions';
 
@@ -6,7 +7,7 @@ export const INITIAL_STATE: FilterState = {
   search: '',
 };
 
-function filter(filters = INITIAL_STATE, action: Action) {
+function filter(filters = _.cloneDeep(INITIAL_STATE), action: Action) {
   let newFilters = { ...filters };
   switch (action.type) {
     case FILTER_SET_NAMESPACE:

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import themesConf, { setTheme } from '../../lib/themes';
 import { sectionFunc } from '../../plugin/registry';
 import {
@@ -113,7 +114,7 @@ export const INITIAL_STATE: UIState = {
   },
 };
 
-function reducer(state = INITIAL_STATE, action: Action) {
+function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
   const newFilters = { ...state };
   switch (action.type) {
     case UI_SIDEBAR_SET_SELECTED: {

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -6,6 +6,7 @@ import {
   HeaderActionFunc,
   UI_APP_BAR_SET_ACTION,
   UI_DETAILS_VIEW_SET_HEADER_ACTION,
+  UI_RESET_PLUGIN_VIEWS,
   UI_ROUTER_SET_ROUTE,
   UI_SET_DETAILS_VIEW,
   UI_SIDEBAR_SET_EXPANDED,
@@ -179,6 +180,12 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       newFilters.theme = action.theme;
       setTheme(newFilters.theme.name);
       break;
+    }
+    case UI_RESET_PLUGIN_VIEWS: {
+      const newState = _.cloneDeep(INITIAL_STATE);
+      // Keep the sidebar folding state in the current one
+      newState.sidebar = { ...newState.sidebar, ...setInitialSidebarOpen() };
+      return newState;
     }
     default:
       return state;


### PR DESCRIPTION
I have taken a look at why plugins some times re-render twice and this PR fixes that.

@ashu8912 do you know if this is enough for #323 ?

@illume , I don't know why I had made it so that the plugins would be reloaded on theme change (there's still an issue with the themes in the config maps' editors, but that's happening in main as well). Since you touched it, maybe you can at least confirm there's nothing I'm missing by removing this dependency.