### PR TITLE
frontend: Check for a pod's conditions before using them

### DIFF
--- a/frontend/src/components/cluster/Charts.tsx
+++ b/frontend/src/components/cluster/Charts.tsx
@@ -170,7 +170,7 @@ export function PodsStatusCircleChart(props: Pick<ResourceCircularChartProps, 'i
       return true;
     }
 
-    const readyCondition = pod.status?.conditions.find(condition => condition.type === 'Ready');
+    const readyCondition = pod.status?.conditions?.find(condition => condition.type === 'Ready');
     return readyCondition?.status === 'True';
   });
 


### PR DESCRIPTION
This prevents the issue of calling a function on a variable that may
be undefined.
