### PR TITLE
Fix UI warnings

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -165,7 +165,7 @@ export function PureSidebar({
         className={classes.sidebarGrid}
         container
         direction="column"
-        justify="space-between"
+        justifyContent="space-between"
         wrap="nowrap"
       >
         <Grid item>

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -96,14 +96,13 @@ export function PureAuthToken({
     }
   }, []);
 
+  function onClose() {
+    // Do nothing because we're not supposed to close on backdrop click
+  }
+
   return (
     <Box>
-      <ClusterDialog
-        useCover
-        disableEscapeKeyDown
-        disableBackdropClick
-        aria-labelledby="authtoken-dialog-title"
-      >
+      <ClusterDialog useCover onClose={onClose} aria-labelledby="authtoken-dialog-title">
         <DialogTitle id="authtoken-dialog-title">{title}</DialogTitle>
         <DialogContent>
           <DialogContentText>

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -228,13 +228,12 @@ export function PureAuthChooser({
     }
   }, []);
 
+  function onClose() {
+    // Do nothing because we're not supposed to close on backdrop click or escape.
+  }
+
   return (
-    <ClusterDialog
-      useCover
-      disableEscapeKeyDown
-      disableBackdropClick
-      aria-labelledby="authchooser-dialog-title"
-    >
+    <ClusterDialog useCover onClose={onClose} aria-labelledby="authchooser-dialog-title">
       {testingAuth ? (
         <Box textAlign="center">
           <DialogTitle ref={focusedRef} id="authchooser-dialog-title">

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -154,7 +154,7 @@ function ClusterList(props: ClusterListProps) {
   }, []);
 
   return (
-    <Grid container alignItems="center" justify="space-around" spacing={2}>
+    <Grid container alignItems="center" justifyContent="space-around" spacing={2}>
       {clusters.map((cluster, i) => (
         <Grid item key={cluster.name}>
           <ClusterButton

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -35,7 +35,7 @@ export default function Overview() {
         {noPermissions ? (
           <Empty color="error">{t('auth|No permissions to list pods.')}</Empty>
         ) : (
-          <Grid container justify="space-around" alignItems="flex-start">
+          <Grid container justifyContent="space-around" alignItems="flex-start">
             <Grid item>
               <CpuCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
             </Grid>

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -46,7 +46,7 @@ export function InfoLabel(props: React.PropsWithChildren<InfoLabelProps>) {
   const { name, value = null } = props;
 
   return (
-    <Grid container item spacing={2} justify="flex-start" alignItems="flex-start">
+    <Grid container item spacing={2} justifyContent="flex-start" alignItems="flex-start">
       <Grid item xs className={classes.nameLabelItem}>
         <NameLabel>{name}</NameLabel>{' '}
       </Grid>
@@ -142,7 +142,7 @@ export function HeaderLabel(props: HeaderLabelProps) {
         </Typography>
         {!!tooltip && <TooltipIcon>{tooltip}</TooltipIcon>}
       </Grid>
-      <Grid item container alignItems="center" justify="center">
+      <Grid item container alignItems="center" justifyContent="center">
         <Grid item>
           <Typography className={classes.value}>{value}</Typography>
         </Grid>

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -67,7 +67,7 @@ export function LogViewer(props: LogViewerProps) {
   }, [logs]);
 
   return (
-    <Dialog maxWidth="lg" scroll="paper" fullWidth onBackdropClick={onClose} {...other}>
+    <Dialog maxWidth="lg" scroll="paper" fullWidth onClose={onClose} {...other}>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent className={classes.dialogContent}>
         <Grid container justifyContent="space-between" alignItems="center" wrap="nowrap">

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -70,7 +70,7 @@ export function LogViewer(props: LogViewerProps) {
     <Dialog maxWidth="lg" scroll="paper" fullWidth onBackdropClick={onClose} {...other}>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent className={classes.dialogContent}>
-        <Grid container justify="space-between" alignItems="center" wrap="nowrap">
+        <Grid container justifyContent="space-between" alignItems="center" wrap="nowrap">
           <Grid item container spacing={1}>
             {topActions.map((component, i) => (
               <Grid item key={i}>

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -228,7 +228,7 @@ export default function EditorDialog(props: EditorDialogProps) {
       scroll="paper"
       fullWidth
       fullScreen={fullScreen}
-      onBackdropClick={onClose}
+      onClose={onClose}
       {...other}
       aria-labelledby="editor-dialog-title"
     >

--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -160,7 +160,7 @@ export function MetadataDictGrid(props: MetadataDictGridProps) {
   }
 
   return (
-    <Grid container spacing={1} justify="flex-start">
+    <Grid container spacing={1} justifyContent="flex-start">
       {keys.length > defaultNumShown && (
         <Grid item>
           <IconButton onClick={() => setExpanded(!expanded)} size="small">
@@ -171,7 +171,7 @@ export function MetadataDictGrid(props: MetadataDictGridProps) {
       <Grid
         container
         item
-        justify="flex-start"
+        justifyContent="flex-start"
         spacing={1}
         style={{
           maxWidth: '80%',

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -217,7 +217,7 @@ export function PageGrid(props: PageGridProps) {
   const { sections = [], children = [], ...other } = props;
   const childrenArray = React.Children.toArray(children).concat(sections);
   return (
-    <Grid container spacing={1} justify="flex-start" alignItems="stretch" {...other}>
+    <Grid container spacing={1} justifyContent="flex-start" alignItems="stretch" {...other}>
       {childrenArray.map((section, i) => (
         <Grid item key={i} xs={12}>
           <Box mt={[4, 0, 0]}>{section}</Box>
@@ -235,7 +235,7 @@ interface SectionGridProps {
 export function SectionGrid(props: SectionGridProps) {
   const { items } = props;
   return (
-    <Grid container justify="space-between">
+    <Grid container justifyContent="space-between">
       {items.map((item, i) => {
         return (
           <Grid item md={12} xs={12} key={i}>

--- a/frontend/src/components/common/SectionFilterHeader.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.tsx
@@ -89,7 +89,7 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
     );
   } else {
     actions.push(
-      <Grid container alignItems="flex-end" justify="flex-end" spacing={1} wrap="nowrap">
+      <Grid container alignItems="flex-end" justifyContent="flex-end" spacing={1} wrap="nowrap">
         {!noNamespaceFilter && (
           <Grid item>
             <NamespacesAutocomplete />

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -44,7 +44,7 @@ export default function SectionHeader(props: SectionHeaderProps) {
     <Grid
       container
       alignItems="center"
-      justify="space-between"
+      justifyContent="space-between"
       className={classes.sectionHeader}
       spacing={2}
     >
@@ -57,7 +57,7 @@ export default function SectionHeader(props: SectionHeaderProps) {
       )}
       {actions.length > 0 && (
         <Grid item>
-          <Grid item container alignItems="center" justify="flex-end">
+          <Grid item container alignItems="center" justifyContent="flex-end">
             {actions.map((action, i) => (
               <Grid item key={i}>
                 {action}

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -151,7 +151,7 @@ export default function Terminal(props: TerminalProps) {
   }
 
   return (
-    <Dialog maxWidth="lg" scroll="paper" fullWidth onBackdropClick={onClose} keepMounted {...other}>
+    <Dialog maxWidth="lg" scroll="paper" fullWidth onClose={onClose} keepMounted {...other}>
       <DialogTitle>{t('Terminal: {{ itemName }}', { itemName: item.metadata.name })}</DialogTitle>
       <DialogContent className={classes.dialogContent}>
         <Grid container direction="column" spacing={1}>

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -93,7 +93,7 @@ function ChartsSection(props: ChartsSectionProps) {
     <Box py={2}>
       <Grid
         container
-        justify="space-around"
+        justifyContent="space-around"
         style={{
           marginBottom: '2rem',
         }}

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -67,7 +67,7 @@ export default function Overview() {
   return (
     <PageGrid>
       <SectionBox py={2}>
-        <Grid container justify="space-around" alignItems="flex-start" spacing={1}>
+        <Grid container justifyContent="space-around" alignItems="flex-start" spacing={1}>
           {workloads.map(({ className: name }) => (
             <Grid item lg={2} md={4} xs={6} key={name}>
               <WorkloadCircleChart


### PR DESCRIPTION
- frontend: Replace Grid's justify prop by justifyContent
- frontend: Don't use deprecated props for dialogs
- frontend: Don't use deprecated onBackdropClick property on dialogs
