### PR TITLE
Dockerfile: Fix alpine version typo, and separate front and back building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_BASE=alpine:3.53.0
+ARG IMAGE_BASE=alpine:3.15.0
 FROM $IMAGE_BASE as base-build
 
 ENV GOPATH=/go \


### PR DESCRIPTION
So that if a backend part is changed, then the frontend image is not rebuilt and vice versa.
Also if a frontend/src change is made, docker build doesn't do an npm install again.
