### PR TITLE
backend: Update how we handle http callback URLs for oidc

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -150,7 +150,7 @@ func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
 		switch {
 		case fwdProto != "":
 			urlScheme = fwdProto
-		case r.Host == "localhost:"+config.port:
+		case strings.HasPrefix(r.Host, "localhost:") || r.TLS == nil:
 			urlScheme = "http"
 		default:
 			urlScheme = "https"


### PR DESCRIPTION
# [Title: describe the change in one sentence]
The conditions used to decide urlScheme for an http callback URI for oidc was broken


