### PR TITLE
.github: Remove file rename from app-artifacts-mac action

### DIFF
--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -26,9 +26,6 @@ jobs:
     - name: App Mac
       run: |
         make app-mac
-    - name: Rename Mac 64bit to include arch
-      run: |
-        FILE_PATH=$(echo app/dist/Headlamp*mac.dmg); mv ${FILE_PATH} $(echo ${FILE_PATH}|sed s/mac/mac-x64/)
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
The newly used electron-build version no longer requires that rename
as it honors the passed architecture.
