### PR TITLE
backend: Fix oidc redirect url token type

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -356,7 +356,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 				redirectURL = "/"
 			}
 
-			redirectURL += fmt.Sprintf("auth?cluster=%1s&token=%2s", state, oauth2Token.AccessToken)
+			redirectURL += fmt.Sprintf("auth?cluster=%1s&token=%2s", state, rawIDToken)
 			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 		} else {
 			http.Error(w, "invalid request", http.StatusBadRequest)


### PR DESCRIPTION
In an oidc auth flow the id token is used for authentication and that is
what should be send in the redirect URI of the oidc callback so that
id_token is used to make request to the kubernetes cluster.
Access token should not be used because they are part of oauth 2.0 flow
and are used for authorization purposes.

## Testing done
Tested with cognito and EKS setup 
The fix is contained in this image  ```docker.io/ashu8912/headlamp-test```
