### PR TITLE
frontend: Don't use toLocaleString to generate date for tests

### DIFF
--- a/frontend/src/components/pod/Pod.stories.tsx
+++ b/frontend/src/components/pod/Pod.stories.tsx
@@ -44,7 +44,7 @@ Pods.args = {
       metadata: {
         uid: 'Dummy_UID',
         resourceVersion: 'v1',
-        creationTimestamp: new Date().toLocaleString(),
+        creationTimestamp: new Date().toISOString(),
         selfLink: 'https://',
         name: 'Dummy_POD',
         namespace: 'Dummy_Namespace',


### PR DESCRIPTION
refer https://stackoverflow.com/questions/40935886/components-using-date-objects-produce-different-snapshots-in-different-timezones
Using toLocaleString makes the CI fail at times
