### PR TITLE
Plugin example fixes

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -43,6 +43,9 @@ function loadScripts(array: string[], onLoadFinished: (value?: any) => void) {
   var loader = function (src: string, handler: () => void) {
     const script: HTMLScriptElement = document.createElement('script');
     script.src = src;
+    if (process.env.NODE_ENV !== 'production') {
+      script.crossOrigin = 'anonymous';
+    }
     script.onload = (script as any).onreadystatechange = function () {
       (script as any).onreadystatechange = script.onload = null;
       handler();

--- a/plugins/examples/pod-counter/package.json
+++ b/plugins/examples/pod-counter/package.json
@@ -31,6 +31,6 @@
     ]
   },
   "devDependencies": {
-    "@kinvolk/headlamp-plugin": "^0.4.1"
+    "@kinvolk/headlamp-plugin": "^0.4.2"
   }
 }

--- a/plugins/examples/pod-counter/src/index.tsx
+++ b/plugins/examples/pod-counter/src/index.tsx
@@ -1,11 +1,11 @@
-import { Headlamp, Plugin, Registry } from '@kinvolk/headlamp-plugin/lib';
+import React from 'react';
+import { Headlamp, Plugin, Registry, K8s } from '@kinvolk/headlamp-plugin/lib';
 import { Typography } from '@material-ui/core';
 
 // import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-// import { K8s } from '@kinvolk/headlamp-plugin/lib/K8s';
 
 function PodCounter() {
-  const [pods, error] = K8s.Pod.useList();
+  const [pods, error] = K8s.ResourceClasses.Pod.useList();
   const msg = pods === null ? 'Loading…' : pods.length.toString();
 
   return (

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache 2.0",
       "dependencies": {
         "@babel/cli": "^7.14.5",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "bin": "bin/headlamp-plugin.js",
   "scripts": {


### PR DESCRIPTION
- fix traceback cross origin issue, so the real error can be shown (without having a look into the dev console)
- Add missing React import in pod-counter plugin example
- K8s.ResourceClasses.Pod.useList(); needed to be used in pod-counter plugin example
- Updated @kinvolk/headlamp-plugin version to 0.4.2

Note, the types are not in the distributed headlamp-plugin package. I think `npm run build` was forgotten, or the publish script is somehow broken.

## How to use

```
cd plugins/examples/pod-counter
npm install
npm run start
```

## Testing done

After copying in the types made with `cd headlamp-plugin; npm run build && cp -a types/* node_modules/@kinvolk/headlamp-plugin/types` the pod-counter plugin works inside headlamp.
