### PR TITLE
plugins/headlamp-plugin: Do not ignore types when packing

### DIFF
--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinvolk/headlamp-plugin",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache 2.0",
       "dependencies": {
         "@babel/cli": "^7.14.5",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/headlamp-plugin",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "The needed infrastructure for building Headlamp plugins.",
   "bin": "bin/headlamp-plugin.js",
   "scripts": {

--- a/plugins/headlamp-plugin/types/.gitignore
+++ b/plugins/headlamp-plugin/types/.gitignore
@@ -1,2 +1,3 @@
 *
+!.npmignore
 !.gitignore

--- a/plugins/headlamp-plugin/types/.npmignore
+++ b/plugins/headlamp-plugin/types/.npmignore
@@ -1,0 +1,6 @@
+# We need .npmignore in order to "not ignore" the
+# generated types, as without this file npm will pick
+# .gitignore and effectively not include any types in
+# the resulting module.
+# See https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files
+.gitignore


### PR DESCRIPTION
We want to ignore the presence of generated types (types folder) in
git, but we want them to be shipped in the module. However, npm does
check .gitignore if a .npmignore file is missing, which meant that no
types were being packed/shipped.

This commit adds a .npmignore file that doesn't ignore the types,
effectively making npm pack the mentioned types.
