### PR TITLE
plugins/headlamp-plugins: Use internal tsconfig for plugins

### DIFF
--- a/plugins/headlamp-plugin/config/plugins-tsconfig.json
+++ b/plugins/headlamp-plugin/config/plugins-tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "node_modules/*.js",
+        "node_modules/*/index.js",
+        "node_modules/@kinvolk/headlamp-plugin/node_modules/*",
+        "node_modules/@kinvolk/headlamp-plugin/node_modules/*/index.js"
+      ],
+      "@iconify/react": [
+        "node_modules/@kinvolk/headlamp-plugin/node_modules/@iconify/react/src/icon.js"
+      ],
+      "@kinvolk/headlamp-plugin/lib/K8s": [
+        "node_modules/@kinvolk/headlamp-plugin/types/src/lib/k8s/index.d.ts"
+      ],
+      "@kinvolk/headlamp-plugin/lib/CommonComponents/*": [
+        "node_modules/@kinvolk/headlamp-plugin/types/src/components/common/*/index.d.ts",
+        "node_modules/@kinvolk/headlamp-plugin/types/src/components/common/*.d.ts"
+      ]
+    },
+    "rootDirs": ["node_modules/@kinvolk/headlamp-plugin/"],
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*"]
+}

--- a/plugins/headlamp-plugin/template/src/index.tsx
+++ b/plugins/headlamp-plugin/template/src/index.tsx
@@ -1,5 +1,5 @@
 import { Headlamp, Plugin, Registry } from '@kinvolk/headlamp-plugin/lib';
-
+import React from 'react';
 // import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 // import { K8s } from '@kinvolk/headlamp-plugin/lib/K8s';
 // import { Typography } from '@material-ui/core';

--- a/plugins/headlamp-plugin/template/tsconfig.json
+++ b/plugins/headlamp-plugin/template/tsconfig.json
@@ -1,30 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "es2017",
-    "allowSyntheticDefaultImports": true,
-    "jsx": "react-jsx",
-    "moduleResolution": "node",
-    "baseUrl": ".",
-    "paths": {
-      "*": [
-        "node_modules/*.js",
-        "node_modules/*/index.js",
-        "node_modules/@kinvolk/headlamp-plugin/node_modules/*",
-        "node_modules/@kinvolk/headlamp-plugin/node_modules/*/index.js"
-      ],
-      "@iconify/react": [
-        "node_modules/@kinvolk/headlamp-plugin/node_modules/@iconify/react/src/icon.js"
-      ],
-      "@kinvolk/headlamp-plugin/lib/K8s": [
-        "node_modules/@kinvolk/headlamp-plugin/types/src/lib/k8s/index.d.ts"
-      ],
-      "@kinvolk/headlamp-plugin/lib/CommonComponents/*": [
-        "node_modules/@kinvolk/headlamp-plugin/types/src/components/common/*/index.d.ts",
-        "node_modules/@kinvolk/headlamp-plugin/types/src/components/common/*.d.ts"
-      ]
-    },
-    "rootDirs": ["node_modules/@kinvolk/headlamp-plugin/"],
-    "skipLibCheck": true
-  },
-  "include": ["./src/**/*"]
+  "extends": "./node_modules/@kinvolk/headlamp-plugin/config/plugins-tsconfig.json"
 }


### PR DESCRIPTION
headlamp-plugin was adding a tsconfig.json file through a template.
However this left around a file in each plugin which could not be
easily updated.

This files prevents that by shipping a plugins-tsconfig.json in the
headlamp-plugin module, and including it from the templated tsconfig.

fixes #433 