### PR TITLE
frontend: Do not use objects for storing plugins functions

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -14,35 +14,33 @@ export default function RouteSwitcher() {
 
   return (
     <Switch>
-      {Object.values(routes)
-        .concat(defaultRoutes)
-        .map((route, index) =>
-          route.name === 'OidcAuth' ? (
-            <Route
-              path={route.path}
-              component={() => (
-                <PageTitle title={route.name ? route.name : route.sidebar}>
-                  <route.component />
-                </PageTitle>
-              )}
-              key={index}
-            />
-          ) : (
-            <AuthRoute
-              key={index}
-              path={getRoutePath(route)}
-              sidebar={route.sidebar}
-              requiresAuth={!route.noAuthRequired}
-              requiresCluster={!route.noCluster}
-              exact={!!route.exact}
-              children={
-                <PageTitle title={route.name ? route.name : route.sidebar}>
-                  <route.component />
-                </PageTitle>
-              }
-            />
-          )
-        )}
+      {[...routes.values()].concat(defaultRoutes).map((route, index) =>
+        route.name === 'OidcAuth' ? (
+          <Route
+            path={route.path}
+            component={() => (
+              <PageTitle title={route.name ? route.name : route.sidebar}>
+                <route.component />
+              </PageTitle>
+            )}
+            key={index}
+          />
+        ) : (
+          <AuthRoute
+            key={index}
+            path={getRoutePath(route)}
+            sidebar={route.sidebar}
+            requiresAuth={!route.noAuthRequired}
+            requiresCluster={!route.noCluster}
+            exact={!!route.exact}
+            children={
+              <PageTitle title={route.name ? route.name : route.sidebar}>
+                <route.component />
+              </PageTitle>
+            }
+          />
+        )
+      )}
     </Switch>
   );
 }

--- a/frontend/src/components/App/TopBar.stories.tsx
+++ b/frontend/src/components/App/TopBar.stories.tsx
@@ -33,21 +33,21 @@ const Template: Story<PureTopBarProps> = args => {
 
 export const NoToken = Template.bind({});
 NoToken.args = {
-  appBarActions: {},
+  appBarActions: [],
   logout: () => {},
   hasToken: false,
 };
 
 export const Token = Template.bind({});
 Token.args = {
-  appBarActions: {},
+  appBarActions: [],
   logout: () => {},
   hasToken: true,
 };
 
 export const OneCluster = Template.bind({});
 OneCluster.args = {
-  appBarActions: {},
+  appBarActions: [],
   logout: () => {},
   hasToken: true,
   cluster: 'ak8s-desktop',
@@ -56,7 +56,7 @@ OneCluster.args = {
 
 export const TwoCluster = Template.bind({});
 TwoCluster.args = {
-  appBarActions: {},
+  appBarActions: [],
   logout: () => {},
   hasToken: true,
   cluster: 'ak8s-desktop',

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -51,7 +51,7 @@ export default function TopBar({}: TopBarProps) {
 
   return (
     <PureTopBar
-      appBarActions={appBarActions}
+      appBarActions={[...appBarActions.values()]}
       logout={logout}
       hasToken={hasToken()}
       isSidebarOpen={isSidebarOpen}
@@ -73,9 +73,7 @@ export default function TopBar({}: TopBarProps) {
 
 export interface PureTopBarProps {
   /** If the sidebar is fully expanded open or shrunk. */
-  appBarActions: {
-    [name: string]: (...args: any[]) => JSX.Element | null;
-  };
+  appBarActions: ((...args: any[]) => JSX.Element | null)[];
   logout: () => void;
   hasToken: boolean;
 
@@ -204,7 +202,7 @@ export function PureTopBar({
       <MenuItem>
         <ClusterTitle cluster={cluster} clusters={clusters} />
       </MenuItem>
-      {Object.values(appBarActions).map((action, i) => (
+      {appBarActions.map((action, i) => (
         <MenuItem>
           <React.Fragment key={i}>{action()}</React.Fragment>
         </MenuItem>

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -124,7 +124,7 @@ function prepareRoutes(t: (arg: string) => string) {
   // @todo: Find a better way to avoid modifying the objects in LIST_ITEMS.
   const routes: SidebarEntry[] = JSON.parse(JSON.stringify(LIST_ITEMS));
 
-  for (const item of Object.values(items)) {
+  for (const item of items.values()) {
     const parent = item.parent ? routes.find(({ name }) => name === item.parent) : null;
     let placement = routes;
     if (parent) {

--- a/frontend/src/helpers/renderHelpers.test.tsx
+++ b/frontend/src/helpers/renderHelpers.test.tsx
@@ -1,9 +1,10 @@
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { render, screen } from '@testing-library/react';
+import _ from 'lodash';
 import { Provider } from 'react-redux';
 import { combineReducers, createStore } from 'redux';
 import { theme } from '../components/TestHelpers/theme';
-import uiReducer, { UIState } from '../redux/reducers/ui';
+import uiReducer, { INITIAL_STATE, UIState } from '../redux/reducers/ui';
 import DetailsViewPluginRenderer from './renderHelpers';
 
 function NodeDummyComponent(props: { resource: any }) {
@@ -12,45 +13,21 @@ function NodeDummyComponent(props: { resource: any }) {
 }
 describe('renders a detail view present in store', () => {
   const sectionTitle = 'Plugin Appended Details View';
-  const initialState: UIState = {
-    sidebar: {
-      selected: null,
-      isVisible: false,
-      entries: {},
-    },
-    routes: {
-      // path -> component
-    },
-    views: {
-      details: {
-        headerActions: {
-          // action-name -> action-callback
-        },
-        pluginAppendedDetailViews: [
-          {
-            sectionName: 'dummy details view',
-            sectionFunc: (resource: any) => {
-              if (resource.kind === 'Node') {
-                return {
-                  title: sectionTitle,
-                  component: props => <NodeDummyComponent {...props} />,
-                };
-              }
-              return null;
-            },
-          },
-        ],
-      },
-      appBar: {
-        actions: {
-          // action-name -> action-callback
-        },
+  const initialState: UIState = _.cloneDeep(INITIAL_STATE);
+  initialState.views.details.pluginAppendedDetailViews = [
+    {
+      sectionName: 'dummy details view',
+      sectionFunc: (resource: any) => {
+        if (resource.kind === 'Node') {
+          return {
+            title: sectionTitle,
+            component: props => <NodeDummyComponent {...props} />,
+          };
+        }
+        return null;
       },
     },
-    theme: {
-      name: '',
-    },
-  };
+  ];
   const mockStore = createStore(
     combineReducers({
       ui: uiReducer,

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -457,7 +457,7 @@ export interface RouteURLProps {
 
 export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
   const storeRoutes = store.getState().ui.routes;
-  const route = (storeRoutes && storeRoutes[routeName]) || getRoute(routeName);
+  const route = (storeRoutes && storeRoutes.get(routeName)) || getRoute(routeName);
 
   if (!route) {
     return '';

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,5 +1,6 @@
 import { IconProps } from '@iconify/react';
 import _ from 'lodash';
+import { Route } from '../../lib/router';
 import themesConf, { setTheme } from '../../lib/themes';
 import { sectionFunc } from '../../plugin/registry';
 import {
@@ -28,6 +29,8 @@ export interface SidebarEntry {
   icon?: IconProps['icon'];
 }
 
+class FunctionMap<T = any> extends Map<string, T> {}
+
 export interface UIState {
   sidebar: {
     selected: string | null;
@@ -35,27 +38,19 @@ export interface UIState {
     isSidebarOpen?: boolean;
     /** This is only set to true/false based on a user interaction. */
     isSidebarOpenUserSelected?: boolean;
-    entries: {
-      [propName: string]: SidebarEntry;
-    };
+    entries: FunctionMap<SidebarEntry>;
   };
-  routes: {
-    [path: string]: any;
-  };
+  routes: FunctionMap<Route>;
   views: {
     details: {
-      headerActions: {
-        [name: string]: HeaderActionFunc;
-      };
+      headerActions: FunctionMap<HeaderActionFunc>;
       pluginAppendedDetailViews: Array<{
         sectionName: string;
         sectionFunc: sectionFunc;
       }>;
     };
     appBar: {
-      actions: {
-        [name: string]: HeaderActionFunc;
-      };
+      actions: FunctionMap<HeaderActionFunc>;
     };
   };
   theme: {
@@ -93,22 +88,16 @@ export const INITIAL_STATE: UIState = {
     ...setInitialSidebarOpen(),
     selected: null,
     isVisible: false,
-    entries: {},
+    entries: new FunctionMap<SidebarEntry>(),
   },
-  routes: {
-    // path -> component
-  },
+  routes: new FunctionMap<Route>(),
   views: {
     details: {
-      headerActions: {
-        // action-name -> action-callback
-      },
+      headerActions: new FunctionMap<HeaderActionFunc>(),
       pluginAppendedDetailViews: [],
     },
     appBar: {
-      actions: {
-        // action-name -> action-callback
-      },
+      actions: new FunctionMap<HeaderActionFunc>(),
     },
   },
   theme: {
@@ -135,8 +124,8 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       break;
     }
     case UI_SIDEBAR_SET_ITEM: {
-      const entries = { ...newFilters.sidebar.entries };
-      entries[action.item.name] = action.item;
+      const entries = _.cloneDeep(newFilters.sidebar.entries);
+      entries.set(action.item.name, action.item);
 
       newFilters.sidebar = {
         ...newFilters.sidebar,
@@ -153,14 +142,14 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       break;
     }
     case UI_ROUTER_SET_ROUTE: {
-      const routes = { ...newFilters.routes };
-      routes[action.route.path] = action.route;
+      const routes = _.cloneDeep(newFilters.routes);
+      routes.set(action.route.path, action.route);
       newFilters.routes = routes;
       break;
     }
     case UI_DETAILS_VIEW_SET_HEADER_ACTION: {
-      const headerActions = { ...newFilters.views.details.headerActions };
-      headerActions[action.action as string] = action.action;
+      const headerActions = _.cloneDeep(newFilters.views.details.headerActions);
+      headerActions.set(action.action, action.action);
       newFilters.views.details.headerActions = headerActions;
       break;
     }
@@ -172,8 +161,8 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       break;
     }
     case UI_APP_BAR_SET_ACTION: {
-      const appBarActions = { ...newFilters.views.appBar.actions };
-      appBarActions[action.name as string] = action.action;
+      const appBarActions = _.cloneDeep(newFilters.views.appBar.actions);
+      appBarActions.set(action.name as string, action.action);
       newFilters.views.appBar.actions = appBarActions;
       break;
     }


### PR DESCRIPTION
Throughout the Redux code, we were using objects to store a map of
name -> something, but keys' order is not kept in objects, so we could
not predict which actions were being called after others.

This patch replaces that use with a Map subclass, so we can still use
it very similarly to what we used to, but now we guarantee that the
values can be used in insertion order.

As a side-effect, the serialization of a Map is more predictable than
that of an object (the Map is always {} by default), so we have a more
predictable use of the data within Redux (this comment has to do with
the fact that we shouldn't use unserializable data in Redux, but that
should be for cases where one's thinking of storing/persisting Redux's
values, which is not the case for this particular UI data).

@ashu8912 , after we discussed today that the unserializable data in Redux was only an issue if we had to serialize it (for possibly persist the data), I almost wrote to you to mention we shouldn't worry about changing our Redux use ATM and just focus on other things. However, I did notice that the use of objects may be an issue in Redux just because we lose any insertion order, and that order may be useful to keep, even if nowadays we don't do anything particular with it.
cc/ @illume 