### PR TITLE
frontend: Add networkpolicy API

### DIFF
--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -17,6 +17,7 @@ import Deployment from './deployment';
 import Ingress from './ingress';
 import Job from './job';
 import Namespace from './namespace';
+import NetworkPolicy from './networkpolicy';
 import Node from './node';
 import PersistentVolume from './persistentVolume';
 import PersistentVolumeClaim from './persistentVolumeClaim';
@@ -43,6 +44,7 @@ const classList = [
   Ingress,
   Job,
   Namespace,
+  NetworkPolicy,
   Node,
   PersistentVolume,
   PersistentVolumeClaim,

--- a/frontend/src/lib/k8s/networkpolicy.tsx
+++ b/frontend/src/lib/k8s/networkpolicy.tsx
@@ -1,0 +1,42 @@
+import { apiFactoryWithNamespace } from './apiProxy';
+import { KubeObjectInterface, LabelSelector, makeKubeObject } from './cluster';
+
+interface NetworkPolicyPort {
+  port?: string | number;
+  protocol?: string;
+  endPort?: number;
+}
+
+interface IPBlock {
+  cidr: string;
+  except: string;
+}
+
+interface NetworkPolicyPeer {
+  ipBlock?: IPBlock;
+  namespaceSelector?: LabelSelector;
+  podSelector?: LabelSelector;
+}
+
+interface NetworkPolicyEgressRule {
+  ports: NetworkPolicyPort[];
+  to: NetworkPolicyPeer[];
+}
+
+interface NetworkPolicyIngressRule {
+  ports: NetworkPolicyPort[];
+  from: NetworkPolicyPeer[];
+}
+
+export interface KubeNetworkPolicy extends KubeObjectInterface {
+  egress: NetworkPolicyEgressRule[];
+  ingress: NetworkPolicyIngressRule[];
+  podSelector: LabelSelector;
+  policyTypes: string[];
+}
+
+class NetworkPolicy extends makeKubeObject<KubeNetworkPolicy>('NetworkPolicy') {
+  static apiEndpoint = apiFactoryWithNamespace('networking.k8s.io', 'v1', 'networkpolicies');
+}
+
+export default NetworkPolicy;


### PR DESCRIPTION
We would be needing the networkpolicy API for the security advisor
plugin. This patch adds the required API for it.

## Testing done
Tested by calling NetworkPolicies.useList to see if we get any network policies and we do get it with this PR
