### PR TITLE
app: Allow to open about:blank URLs

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -358,8 +358,9 @@ function startElecron() {
     mainWindow.loadURL(startUrl);
 
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-      // allow all urls starting with app startUrl to open in electron
-      if (url.startsWith(startUrl)) {
+      // Allow all app's domain URLs and also ones that are "about:blank"
+      // (so plugins can open e.g. popups for authentication).
+      if (url.startsWith(startUrl) || url === 'about:blank') {
         return { action: 'allow' };
       }
       // otherwise open url in a browser and prevent default


### PR DESCRIPTION
Some plugins may want to show popups, e.g. for authentication, so we
should allow such popups.

### How to test:
In a plugin's component that gets loaded, add something like:
```javascript
React.useEffect(() => {
    window.open('about:blank')
  },
  [])
```
Launch headlamp desktop.

You should see an empty popup window from the app, not the external browser.

fixes #455 
