### PR TITLE
frontend: Add router to pluginLib

### DIFF
--- a/docs/development/api/classes/lib_k8s_clusterRole.ClusterRole.md
+++ b/docs/development/api/classes/lib_k8s_clusterRole.ClusterRole.md
@@ -30,7 +30,7 @@ slug: "lib_k8s_clusterRole.ClusterRole"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -56,7 +56,7 @@ slug: "lib_k8s_clusterRole.ClusterRole"
 
 #### Defined in
 
-[lib/k8s/clusterRole.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/clusterRole.ts#L5)
+[lib/k8s/clusterRole.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/clusterRole.ts#L5)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/clusterRole.ts:7](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/clusterRole.ts#L7)
+[lib/k8s/clusterRole.ts:7](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/clusterRole.ts#L7)
 
 ___
 
@@ -102,7 +102,7 @@ Role.rules
 
 #### Defined in
 
-[lib/k8s/role.ts:17](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/role.ts#L17)
+[lib/k8s/role.ts:17](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/role.ts#L17)
 
 ## Methods
 
@@ -126,7 +126,7 @@ Role.rules
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -177,7 +177,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -227,4 +227,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_clusterRoleBinding.ClusterRoleBinding.md
+++ b/docs/development/api/classes/lib_k8s_clusterRoleBinding.ClusterRoleBinding.md
@@ -30,7 +30,7 @@ slug: "lib_k8s_clusterRoleBinding.ClusterRoleBinding"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -56,7 +56,7 @@ slug: "lib_k8s_clusterRoleBinding.ClusterRoleBinding"
 
 #### Defined in
 
-[lib/k8s/clusterRoleBinding.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/clusterRoleBinding.ts#L5)
+[lib/k8s/clusterRoleBinding.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/clusterRoleBinding.ts#L5)
 
 ## Accessors
 
@@ -70,7 +70,7 @@ slug: "lib_k8s_clusterRoleBinding.ClusterRoleBinding"
 
 #### Defined in
 
-[lib/k8s/clusterRoleBinding.ts:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/clusterRoleBinding.ts#L11)
+[lib/k8s/clusterRoleBinding.ts:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/clusterRoleBinding.ts#L11)
 
 ___
 
@@ -88,7 +88,7 @@ RoleBinding.roleRef
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L21)
+[lib/k8s/roleBinding.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L21)
 
 ___
 
@@ -106,7 +106,7 @@ RoleBinding.subjects
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L25)
+[lib/k8s/roleBinding.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L25)
 
 ___
 
@@ -124,7 +124,7 @@ RoleBinding.className
 
 #### Defined in
 
-[lib/k8s/clusterRoleBinding.ts:7](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/clusterRoleBinding.ts#L7)
+[lib/k8s/clusterRoleBinding.ts:7](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/clusterRoleBinding.ts#L7)
 
 ## Methods
 
@@ -148,7 +148,7 @@ RoleBinding.className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -249,4 +249,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_configMap.ConfigMap.md
+++ b/docs/development/api/classes/lib_k8s_configMap.ConfigMap.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeConfigMap\>('configMap').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeConfigMap\>('configMap').constructor
 
 #### Defined in
 
-[lib/k8s/configMap.ts:9](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/configMap.ts#L9)
+[lib/k8s/configMap.ts:9](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/configMap.ts#L9)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeConfigMap\>('configMap').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeConfigMap\>('configMap').className
 
 #### Defined in
 
-[lib/k8s/configMap.ts:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/configMap.ts#L11)
+[lib/k8s/configMap.ts:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/configMap.ts#L11)
 
 ## Methods
 
@@ -96,7 +96,7 @@ makeKubeObject<KubeConfigMap\>('configMap').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -120,7 +120,7 @@ makeKubeObject<KubeConfigMap\>('configMap').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -147,7 +147,7 @@ makeKubeObject<KubeConfigMap\>('configMap').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -173,7 +173,7 @@ makeKubeObject<KubeConfigMap\>('configMap').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -197,4 +197,4 @@ makeKubeObject<KubeConfigMap\>('configMap').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_crd.CustomResourceDefinition.md
+++ b/docs/development/api/classes/lib_k8s_crd.CustomResourceDefinition.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeCRD\>('crd').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -52,7 +52,7 @@ makeKubeObject<KubeCRD\>('crd').constructor
 
 #### Defined in
 
-[lib/k8s/crd.ts:35](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L35)
+[lib/k8s/crd.ts:35](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L35)
 
 ## Accessors
 
@@ -66,7 +66,7 @@ makeKubeObject<KubeCRD\>('crd').constructor
 
 #### Defined in
 
-[lib/k8s/crd.ts:48](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L48)
+[lib/k8s/crd.ts:48](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L48)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/crd.ts:44](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L44)
+[lib/k8s/crd.ts:44](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L44)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/crd.ts:52](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L52)
+[lib/k8s/crd.ts:52](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L52)
 
 ___
 
@@ -112,7 +112,7 @@ makeKubeObject&lt;KubeCRD\&gt;(&#x27;crd&#x27;).className
 
 #### Defined in
 
-[lib/k8s/crd.ts:40](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L40)
+[lib/k8s/crd.ts:40](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L40)
 
 ## Methods
 
@@ -136,7 +136,7 @@ makeKubeObject<KubeCRD\>('crd').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -160,7 +160,7 @@ makeKubeObject<KubeCRD\>('crd').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeCRD\>('crd').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -213,7 +213,7 @@ makeKubeObject<KubeCRD\>('crd').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -237,4 +237,4 @@ makeKubeObject<KubeCRD\>('crd').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_cronJob.CronJob.md
+++ b/docs/development/api/classes/lib_k8s_cronJob.CronJob.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeCronJob\>('CronJob').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeCronJob\>('CronJob').constructor
 
 #### Defined in
 
-[lib/k8s/cronJob.ts:20](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cronJob.ts#L20)
+[lib/k8s/cronJob.ts:20](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cronJob.ts#L20)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeCronJob\>('CronJob').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeCronJob\>('CronJob').className
 
 #### Defined in
 
-[lib/k8s/cronJob.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cronJob.ts#L25)
+[lib/k8s/cronJob.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cronJob.ts#L25)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cronJob.ts:29](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cronJob.ts#L29)
+[lib/k8s/cronJob.ts:29](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cronJob.ts#L29)
 
 ## Methods
 
@@ -110,7 +110,7 @@ makeKubeObject<KubeCronJob\>('CronJob').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -134,7 +134,7 @@ makeKubeObject<KubeCronJob\>('CronJob').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -161,7 +161,7 @@ makeKubeObject<KubeCronJob\>('CronJob').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeCronJob\>('CronJob').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -211,4 +211,4 @@ makeKubeObject<KubeCronJob\>('CronJob').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_daemonSet.DaemonSet.md
+++ b/docs/development/api/classes/lib_k8s_daemonSet.DaemonSet.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').constructor
 
 #### Defined in
 
-[lib/k8s/daemonSet.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/daemonSet.ts#L21)
+[lib/k8s/daemonSet.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/daemonSet.ts#L21)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').className
 
 #### Defined in
 
-[lib/k8s/daemonSet.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/daemonSet.ts#L23)
+[lib/k8s/daemonSet.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/daemonSet.ts#L23)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/daemonSet.ts:27](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/daemonSet.ts#L27)
+[lib/k8s/daemonSet.ts:27](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/daemonSet.ts#L27)
 
 ## Methods
 
@@ -110,7 +110,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -134,7 +134,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -161,7 +161,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -211,4 +211,4 @@ makeKubeObject<KubeDaemonSet\>('DaemonSet').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_deployment.Deployment.md
+++ b/docs/development/api/classes/lib_k8s_deployment.Deployment.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeDeployment\>('Deployment').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeDeployment\>('Deployment').constructor
 
 #### Defined in
 
-[lib/k8s/deployment.ts:19](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/deployment.ts#L19)
+[lib/k8s/deployment.ts:19](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/deployment.ts#L19)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeDeployment\>('Deployment').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeDeployment\>('Deployment').className
 
 #### Defined in
 
-[lib/k8s/deployment.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/deployment.ts#L21)
+[lib/k8s/deployment.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/deployment.ts#L21)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/deployment.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/deployment.ts#L25)
+[lib/k8s/deployment.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/deployment.ts#L25)
 
 ## Methods
 
@@ -110,7 +110,7 @@ makeKubeObject<KubeDeployment\>('Deployment').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -134,7 +134,7 @@ makeKubeObject<KubeDeployment\>('Deployment').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -161,7 +161,7 @@ makeKubeObject<KubeDeployment\>('Deployment').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeDeployment\>('Deployment').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -211,4 +211,4 @@ makeKubeObject<KubeDeployment\>('Deployment').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_event.Event.md
+++ b/docs/development/api/classes/lib_k8s_event.Event.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeEvent\>('Event').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeEvent\>('Event').constructor
 
 #### Defined in
 
-[lib/k8s/event.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L23)
+[lib/k8s/event.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L23)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeEvent\>('Event').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeEvent\>('Event').className
 
 #### Defined in
 
-[lib/k8s/event.ts:33](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L33)
+[lib/k8s/event.ts:33](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L33)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:49](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L49)
+[lib/k8s/event.ts:49](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L49)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:45](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L45)
+[lib/k8s/event.ts:45](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L45)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:41](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L41)
+[lib/k8s/event.ts:41](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L41)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L25)
+[lib/k8s/event.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L25)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:29](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L29)
+[lib/k8s/event.ts:29](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L29)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:37](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L37)
+[lib/k8s/event.ts:37](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L37)
 
 ## Methods
 
@@ -180,7 +180,7 @@ makeKubeObject<KubeEvent\>('Event').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -204,7 +204,7 @@ makeKubeObject<KubeEvent\>('Event').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -231,7 +231,7 @@ makeKubeObject<KubeEvent\>('Event').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -257,7 +257,7 @@ makeKubeObject<KubeEvent\>('Event').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -281,4 +281,4 @@ makeKubeObject<KubeEvent\>('Event').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_ingress.Ingress.md
+++ b/docs/development/api/classes/lib_k8s_ingress.Ingress.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeIngress\>('ingress').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeIngress\>('ingress').constructor
 
 #### Defined in
 
-[lib/k8s/ingress.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/ingress.ts#L22)
+[lib/k8s/ingress.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/ingress.ts#L22)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeIngress\>('ingress').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeIngress\>('ingress').className
 
 #### Defined in
 
-[lib/k8s/ingress.ts:35](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/ingress.ts#L35)
+[lib/k8s/ingress.ts:35](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/ingress.ts#L35)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/ingress.ts:27](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/ingress.ts#L27)
+[lib/k8s/ingress.ts:27](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/ingress.ts#L27)
 
 ## Methods
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/ingress.ts:31](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/ingress.ts#L31)
+[lib/k8s/ingress.ts:31](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/ingress.ts#L31)
 
 ___
 
@@ -128,7 +128,7 @@ makeKubeObject<KubeIngress\>('ingress').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -152,7 +152,7 @@ makeKubeObject<KubeIngress\>('ingress').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -179,7 +179,7 @@ makeKubeObject<KubeIngress\>('ingress').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -205,7 +205,7 @@ makeKubeObject<KubeIngress\>('ingress').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -229,4 +229,4 @@ makeKubeObject<KubeIngress\>('ingress').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_job.Job.md
+++ b/docs/development/api/classes/lib_k8s_job.Job.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeJob\>('Job').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeJob\>('Job').constructor
 
 #### Defined in
 
-[lib/k8s/job.ts:15](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/job.ts#L15)
+[lib/k8s/job.ts:15](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/job.ts#L15)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeJob\>('Job').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeJob\>('Job').className
 
 #### Defined in
 
-[lib/k8s/job.ts:17](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/job.ts#L17)
+[lib/k8s/job.ts:17](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/job.ts#L17)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/job.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/job.ts#L21)
+[lib/k8s/job.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/job.ts#L21)
 
 ## Methods
 
@@ -110,7 +110,7 @@ makeKubeObject<KubeJob\>('Job').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -134,7 +134,7 @@ makeKubeObject<KubeJob\>('Job').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -161,7 +161,7 @@ makeKubeObject<KubeJob\>('Job').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeJob\>('Job').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -211,4 +211,4 @@ makeKubeObject<KubeJob\>('Job').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_namespace.Namespace.md
+++ b/docs/development/api/classes/lib_k8s_namespace.Namespace.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeNamespace\>('namespace').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -52,7 +52,7 @@ makeKubeObject<KubeNamespace\>('namespace').constructor
 
 #### Defined in
 
-[lib/k8s/namespace.ts:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/namespace.ts#L11)
+[lib/k8s/namespace.ts:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/namespace.ts#L11)
 
 ___
 
@@ -66,7 +66,7 @@ makeKubeObject<KubeNamespace\>('namespace').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -80,7 +80,7 @@ makeKubeObject<KubeNamespace\>('namespace').className
 
 #### Defined in
 
-[lib/k8s/namespace.ts:13](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/namespace.ts#L13)
+[lib/k8s/namespace.ts:13](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/namespace.ts#L13)
 
 ## Methods
 
@@ -104,7 +104,7 @@ makeKubeObject<KubeNamespace\>('namespace').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -128,7 +128,7 @@ makeKubeObject<KubeNamespace\>('namespace').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -155,7 +155,7 @@ makeKubeObject<KubeNamespace\>('namespace').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -181,7 +181,7 @@ makeKubeObject<KubeNamespace\>('namespace').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -205,4 +205,4 @@ makeKubeObject<KubeNamespace\>('namespace').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_networkpolicy.NetworkPolicy.md
+++ b/docs/development/api/classes/lib_k8s_networkpolicy.NetworkPolicy.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').constructor
 
 #### Defined in
 
-[lib/k8s/networkpolicy.tsx:39](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/networkpolicy.tsx#L39)
+[lib/k8s/networkpolicy.tsx:39](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/networkpolicy.tsx#L39)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Methods
 
@@ -82,7 +82,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -106,7 +106,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -133,7 +133,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -159,7 +159,7 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -183,4 +183,4 @@ makeKubeObject<KubeNetworkPolicy\>('NetworkPolicy').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_node.Node.md
+++ b/docs/development/api/classes/lib_k8s_node.Node.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeNode\>('node').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -52,7 +52,7 @@ makeKubeObject<KubeNode\>('node').constructor
 
 #### Defined in
 
-[lib/k8s/node.ts:40](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/node.ts#L40)
+[lib/k8s/node.ts:40](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/node.ts#L40)
 
 ___
 
@@ -66,7 +66,7 @@ makeKubeObject<KubeNode\>('node').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -84,7 +84,7 @@ makeKubeObject<KubeNode\>('node').className
 
 #### Defined in
 
-[lib/k8s/node.ts:46](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/node.ts#L46)
+[lib/k8s/node.ts:46](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/node.ts#L46)
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/node.ts:42](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/node.ts#L42)
+[lib/k8s/node.ts:42](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/node.ts#L42)
 
 ## Methods
 
@@ -141,7 +141,7 @@ makeKubeObject<KubeNode\>('node').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -165,7 +165,7 @@ makeKubeObject<KubeNode\>('node').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -192,7 +192,7 @@ makeKubeObject<KubeNode\>('node').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -218,7 +218,7 @@ makeKubeObject<KubeNode\>('node').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -242,7 +242,7 @@ makeKubeObject<KubeNode\>('node').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)
 
 ___
 
@@ -256,4 +256,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/node.ts:50](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/node.ts#L50)
+[lib/k8s/node.ts:50](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/node.ts#L50)

--- a/docs/development/api/classes/lib_k8s_persistentVolume.PersistentVolume.md
+++ b/docs/development/api/classes/lib_k8s_persistentVolume.PersistentVolume.md
@@ -30,7 +30,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -52,7 +52,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').constructor
 
 #### Defined in
 
-[lib/k8s/persistentVolume.ts:19](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolume.ts#L19)
+[lib/k8s/persistentVolume.ts:19](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolume.ts#L19)
 
 ___
 
@@ -66,7 +66,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -80,7 +80,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').className
 
 #### Defined in
 
-[lib/k8s/persistentVolume.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolume.ts#L21)
+[lib/k8s/persistentVolume.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolume.ts#L21)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/persistentVolume.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolume.ts#L25)
+[lib/k8s/persistentVolume.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolume.ts#L25)
 
 ## Methods
 
@@ -118,7 +118,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -142,7 +142,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -169,7 +169,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -195,7 +195,7 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -219,4 +219,4 @@ makeKubeObject<KubePersistentVolume\>('persistentVolume').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_persistentVolumeClaim.PersistentVolumeClaim.md
+++ b/docs/development/api/classes/lib_k8s_persistentVolumeClaim.PersistentVolumeClaim.md
@@ -32,7 +32,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -46,7 +46,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/persistentVolumeClaim.ts:30](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolumeClaim.ts#L30)
+[lib/k8s/persistentVolumeClaim.ts:30](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolumeClaim.ts#L30)
 
 ___
 
@@ -62,7 +62,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/persistentVolumeClaim.ts:32](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolumeClaim.ts#L32)
+[lib/k8s/persistentVolumeClaim.ts:32](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolumeClaim.ts#L32)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/persistentVolumeClaim.ts:36](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolumeClaim.ts#L36)
+[lib/k8s/persistentVolumeClaim.ts:36](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolumeClaim.ts#L36)
 
 ## Methods
 
@@ -116,7 +116,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -142,7 +142,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -171,7 +171,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -199,7 +199,7 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -225,4 +225,4 @@ makeKubeObject<KubePersistentVolumeClaim\>(
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_pod.Pod.md
+++ b/docs/development/api/classes/lib_k8s_pod.Pod.md
@@ -30,7 +30,7 @@ makeKubeObject<KubePod\>('Pod').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubePod\>('Pod').constructor
 
 #### Defined in
 
-[lib/k8s/pod.ts:35](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L35)
+[lib/k8s/pod.ts:35](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L35)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubePod\>('Pod').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -77,7 +77,7 @@ makeKubeObject<KubePod\>('Pod').className
 
 #### Defined in
 
-[lib/k8s/pod.ts:37](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L37)
+[lib/k8s/pod.ts:37](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L37)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/pod.ts:41](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L41)
+[lib/k8s/pod.ts:41](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L41)
 
 ## Methods
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/pod.ts:68](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L68)
+[lib/k8s/pod.ts:68](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L68)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/pod.ts:45](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L45)
+[lib/k8s/pod.ts:45](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L45)
 
 ___
 
@@ -182,7 +182,7 @@ makeKubeObject<KubePod\>('Pod').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -206,7 +206,7 @@ makeKubeObject<KubePod\>('Pod').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -233,7 +233,7 @@ makeKubeObject<KubePod\>('Pod').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -259,7 +259,7 @@ makeKubeObject<KubePod\>('Pod').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -283,4 +283,4 @@ makeKubeObject<KubePod\>('Pod').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_replicaSet.ReplicaSet.md
+++ b/docs/development/api/classes/lib_k8s_replicaSet.ReplicaSet.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').constructor
 
 #### Defined in
 
-[lib/k8s/replicaSet.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/replicaSet.ts#L22)
+[lib/k8s/replicaSet.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/replicaSet.ts#L22)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -78,7 +78,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').className
 
 #### Defined in
 
-[lib/k8s/replicaSet.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/replicaSet.ts#L24)
+[lib/k8s/replicaSet.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/replicaSet.ts#L24)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/replicaSet.ts:28](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/replicaSet.ts#L28)
+[lib/k8s/replicaSet.ts:28](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/replicaSet.ts#L28)
 
 ## Methods
 
@@ -125,7 +125,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -149,7 +149,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -176,7 +176,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -202,7 +202,7 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -226,4 +226,4 @@ makeKubeObject<KubeReplicaSet\>('ReplicaSet').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_role.Role.md
+++ b/docs/development/api/classes/lib_k8s_role.Role.md
@@ -32,7 +32,7 @@ makeKubeObject<KubeRole\>('role').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -46,7 +46,7 @@ makeKubeObject<KubeRole\>('role').constructor
 
 #### Defined in
 
-[lib/k8s/role.ts:15](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/role.ts#L15)
+[lib/k8s/role.ts:15](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/role.ts#L15)
 
 ___
 
@@ -60,7 +60,7 @@ makeKubeObject<KubeRole\>('role').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -74,7 +74,7 @@ makeKubeObject<KubeRole\>('role').className
 
 #### Defined in
 
-[lib/k8s/role.ts:17](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/role.ts#L17)
+[lib/k8s/role.ts:17](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/role.ts#L17)
 
 ## Methods
 
@@ -98,7 +98,7 @@ makeKubeObject<KubeRole\>('role').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -122,7 +122,7 @@ makeKubeObject<KubeRole\>('role').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -149,7 +149,7 @@ makeKubeObject<KubeRole\>('role').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -175,7 +175,7 @@ makeKubeObject<KubeRole\>('role').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -199,4 +199,4 @@ makeKubeObject<KubeRole\>('role').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_roleBinding.RoleBinding.md
+++ b/docs/development/api/classes/lib_k8s_roleBinding.RoleBinding.md
@@ -32,7 +32,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -46,7 +46,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').constructor
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:19](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L19)
+[lib/k8s/roleBinding.ts:19](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L19)
 
 ___
 
@@ -60,7 +60,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -74,7 +74,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').className
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L21)
+[lib/k8s/roleBinding.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L21)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L25)
+[lib/k8s/roleBinding.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L25)
 
 ## Methods
 
@@ -112,7 +112,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -136,7 +136,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -163,7 +163,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -189,7 +189,7 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -213,4 +213,4 @@ makeKubeObject<KubeRoleBinding\>('roleBinding').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_secret.Secret.md
+++ b/docs/development/api/classes/lib_k8s_secret.Secret.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeSecret\>('secret').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeSecret\>('secret').constructor
 
 #### Defined in
 
-[lib/k8s/secret.ts:10](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/secret.ts#L10)
+[lib/k8s/secret.ts:10](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/secret.ts#L10)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeSecret\>('secret').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeSecret\>('secret').className
 
 #### Defined in
 
-[lib/k8s/secret.ts:12](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/secret.ts#L12)
+[lib/k8s/secret.ts:12](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/secret.ts#L12)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/secret.ts:16](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/secret.ts#L16)
+[lib/k8s/secret.ts:16](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/secret.ts#L16)
 
 ## Methods
 
@@ -110,7 +110,7 @@ makeKubeObject<KubeSecret\>('secret').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -134,7 +134,7 @@ makeKubeObject<KubeSecret\>('secret').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -161,7 +161,7 @@ makeKubeObject<KubeSecret\>('secret').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeSecret\>('secret').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -211,4 +211,4 @@ makeKubeObject<KubeSecret\>('secret').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_service.Service.md
+++ b/docs/development/api/classes/lib_k8s_service.Service.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeService\>('service').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeService\>('service').constructor
 
 #### Defined in
 
-[lib/k8s/service.ts:20](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/service.ts#L20)
+[lib/k8s/service.ts:20](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/service.ts#L20)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeService\>('service').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeService\>('service').className
 
 #### Defined in
 
-[lib/k8s/service.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/service.ts#L22)
+[lib/k8s/service.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/service.ts#L22)
 
 ## Methods
 
@@ -96,7 +96,7 @@ makeKubeObject<KubeService\>('service').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -120,7 +120,7 @@ makeKubeObject<KubeService\>('service').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -147,7 +147,7 @@ makeKubeObject<KubeService\>('service').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -173,7 +173,7 @@ makeKubeObject<KubeService\>('service').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -197,4 +197,4 @@ makeKubeObject<KubeService\>('service').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_serviceAccount.ServiceAccount.md
+++ b/docs/development/api/classes/lib_k8s_serviceAccount.ServiceAccount.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').constructor
 
 #### Defined in
 
-[lib/k8s/serviceAccount.ts:16](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/serviceAccount.ts#L16)
+[lib/k8s/serviceAccount.ts:16](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/serviceAccount.ts#L16)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').className
 
 #### Defined in
 
-[lib/k8s/serviceAccount.ts:18](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/serviceAccount.ts#L18)
+[lib/k8s/serviceAccount.ts:18](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/serviceAccount.ts#L18)
 
 ## Methods
 
@@ -96,7 +96,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -120,7 +120,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -147,7 +147,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -173,7 +173,7 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -197,4 +197,4 @@ makeKubeObject<KubeServiceAccount\>('serviceAccount').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_statefulSet.StatefulSet.md
+++ b/docs/development/api/classes/lib_k8s_statefulSet.StatefulSet.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -44,7 +44,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').constructor
 
 #### Defined in
 
-[lib/k8s/statefulSet.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/statefulSet.ts#L21)
+[lib/k8s/statefulSet.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/statefulSet.ts#L21)
 
 ___
 
@@ -58,7 +58,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').className
 
 #### Defined in
 
-[lib/k8s/statefulSet.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/statefulSet.ts#L23)
+[lib/k8s/statefulSet.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/statefulSet.ts#L23)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/statefulSet.ts:27](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/statefulSet.ts#L27)
+[lib/k8s/statefulSet.ts:27](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/statefulSet.ts#L27)
 
 ## Methods
 
@@ -110,7 +110,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -134,7 +134,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -161,7 +161,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -211,4 +211,4 @@ makeKubeObject<KubeStatefulSet\>('StatefulSet').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/lib_k8s_storageClass.StorageClass.md
+++ b/docs/development/api/classes/lib_k8s_storageClass.StorageClass.md
@@ -30,7 +30,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').constructor
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -52,7 +52,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').constructor
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L11)
+[lib/k8s/storageClass.ts:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L11)
 
 ___
 
@@ -66,7 +66,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').className
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Accessors
 
@@ -80,7 +80,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').className
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:25](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L25)
+[lib/k8s/storageClass.ts:25](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L25)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:13](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L13)
+[lib/k8s/storageClass.ts:13](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L13)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:17](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L17)
+[lib/k8s/storageClass.ts:17](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L17)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L21)
+[lib/k8s/storageClass.ts:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L21)
 
 ## Methods
 
@@ -146,7 +146,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').apiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -170,7 +170,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').getErrorMessage
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -197,7 +197,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').useApiGet
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -223,7 +223,7 @@ makeKubeObject<KubeStorageClass\>('storageClass').useApiList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -247,4 +247,4 @@ makeKubeObject<KubeStorageClass\>('storageClass').useList
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/classes/plugin_lib.Headlamp.md
+++ b/docs/development/api/classes/plugin_lib.Headlamp.md
@@ -50,4 +50,4 @@ Headlamp.registerPlugin("aPluginIdString", myPlugin)
 
 #### Defined in
 
-[plugin/lib.ts:134](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/lib.ts#L134)
+[plugin/lib.ts:134](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/lib.ts#L134)

--- a/docs/development/api/classes/plugin_lib.Plugin.md
+++ b/docs/development/api/classes/plugin_lib.Plugin.md
@@ -38,4 +38,4 @@ initialize is called for each plugin with a Registry which gives the plugin meth
 
 #### Defined in
 
-[plugin/lib.ts:94](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/lib.ts#L94)
+[plugin/lib.ts:94](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/lib.ts#L94)

--- a/docs/development/api/classes/plugin_registry.Registry.md
+++ b/docs/development/api/classes/plugin_registry.Registry.md
@@ -39,7 +39,7 @@ register.registerAppBarAction('monitor', () => <MonitorLink /> );
 
 #### Defined in
 
-[plugin/registry.tsx:117](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L117)
+[plugin/registry.tsx:117](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L117)
 
 ___
 
@@ -64,7 +64,7 @@ register.registerAppLogo((props: { logoType: 'small' | 'large', themeName: strin
 
 #### Defined in
 
-[plugin/registry.tsx:148](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L148)
+[plugin/registry.tsx:148](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L148)
 
 ___
 
@@ -95,7 +95,7 @@ register.registerDetailsViewHeaderAction('traces', (props) =>
 
 #### Defined in
 
-[plugin/registry.tsx:98](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L98)
+[plugin/registry.tsx:98](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L98)
 
 ___
 
@@ -124,7 +124,7 @@ register.registerDetailsViewSection("biolatency", (resource: KubeObject) => { ti
 
 #### Defined in
 
-[plugin/registry.tsx:133](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L133)
+[plugin/registry.tsx:133](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L133)
 
 ___
 
@@ -160,7 +160,7 @@ register.registerRoute({
 
 #### Defined in
 
-[plugin/registry.tsx:79](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L79)
+[plugin/registry.tsx:79](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L79)
 
 ___
 
@@ -192,4 +192,4 @@ registerSidebarItem('cluster', 'traces', 'Traces', '/traces');
 
 #### Defined in
 
-[plugin/registry.tsx:40](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L40)
+[plugin/registry.tsx:40](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L40)

--- a/docs/development/api/interfaces/lib_k8s_apiProxy.ApiError.md
+++ b/docs/development/api/interfaces/lib_k8s_apiProxy.ApiError.md
@@ -20,4 +20,4 @@ slug: "lib_k8s_apiProxy.ApiError"
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:641](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L641)
+[lib/k8s/apiProxy.ts:641](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L641)

--- a/docs/development/api/interfaces/lib_k8s_apiProxy.RequestParams.md
+++ b/docs/development/api/interfaces/lib_k8s_apiProxy.RequestParams.md
@@ -18,4 +18,4 @@ slug: "lib_k8s_apiProxy.RequestParams"
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L23)
+[lib/k8s/apiProxy.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L23)

--- a/docs/development/api/interfaces/lib_k8s_apiProxy.StreamArgs.md
+++ b/docs/development/api/interfaces/lib_k8s_apiProxy.StreamArgs.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_apiProxy.StreamArgs"
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:507](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L507)
+[lib/k8s/apiProxy.ts:507](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L507)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:506](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L506)
+[lib/k8s/apiProxy.ts:506](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L506)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:509](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L509)
+[lib/k8s/apiProxy.ts:509](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L509)
 
 ## Methods
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:508](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L508)
+[lib/k8s/apiProxy.ts:508](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L508)

--- a/docs/development/api/interfaces/lib_k8s_cluster.ApiListOptions.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.ApiListOptions.md
@@ -14,4 +14,4 @@ slug: "lib_k8s_cluster.ApiListOptions"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:54](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L54)
+[lib/k8s/cluster.ts:54](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L54)

--- a/docs/development/api/interfaces/lib_k8s_cluster.Cluster.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.Cluster.md
@@ -18,7 +18,7 @@ slug: "lib_k8s_cluster.Cluster"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:16](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L16)
+[lib/k8s/cluster.ts:16](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L16)
 
 ___
 
@@ -28,4 +28,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:17](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L17)
+[lib/k8s/cluster.ts:17](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L17)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeCondition.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeCondition.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_cluster.KubeCondition"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:373](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L373)
+[lib/k8s/cluster.ts:373](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L373)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:374](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L374)
+[lib/k8s/cluster.ts:374](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L374)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:375](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L375)
+[lib/k8s/cluster.ts:375](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L375)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:377](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L377)
+[lib/k8s/cluster.ts:377](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L377)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:376](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L376)
+[lib/k8s/cluster.ts:376](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L376)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:372](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L372)
+[lib/k8s/cluster.ts:372](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L372)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:371](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L371)
+[lib/k8s/cluster.ts:371](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L371)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeContainer.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeContainer.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_cluster.KubeContainer"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:384](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L384)
+[lib/k8s/cluster.ts:384](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L384)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:383](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L383)
+[lib/k8s/cluster.ts:383](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L383)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:400](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L400)
+[lib/k8s/cluster.ts:400](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L400)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:418](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L418)
+[lib/k8s/cluster.ts:418](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L418)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:382](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L382)
+[lib/k8s/cluster.ts:382](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L382)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:430](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L430)
+[lib/k8s/cluster.ts:430](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L430)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:428](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L428)
+[lib/k8s/cluster.ts:428](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L428)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:381](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L381)
+[lib/k8s/cluster.ts:381](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L381)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:385](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L385)
+[lib/k8s/cluster.ts:385](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L385)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:429](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L429)
+[lib/k8s/cluster.ts:429](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L429)
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:390](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L390)
+[lib/k8s/cluster.ts:390](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L390)
 
 ___
 
@@ -135,4 +135,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:423](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L423)
+[lib/k8s/cluster.ts:423](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L423)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeContainerProbe.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeContainerProbe.md
@@ -20,7 +20,7 @@ slug: "lib_k8s_cluster.KubeContainerProbe"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:440](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L440)
+[lib/k8s/cluster.ts:440](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L440)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:450](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L450)
+[lib/k8s/cluster.ts:450](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L450)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:434](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L434)
+[lib/k8s/cluster.ts:434](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L434)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:446](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L446)
+[lib/k8s/cluster.ts:446](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L446)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:448](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L448)
+[lib/k8s/cluster.ts:448](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L448)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:449](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L449)
+[lib/k8s/cluster.ts:449](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L449)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:443](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L443)
+[lib/k8s/cluster.ts:443](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L443)
 
 ___
 
@@ -105,4 +105,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:447](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L447)
+[lib/k8s/cluster.ts:447](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L447)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeContainerStatus.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeContainerStatus.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_cluster.KubeContainerStatus"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:479](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L479)
+[lib/k8s/cluster.ts:479](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L479)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:480](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L480)
+[lib/k8s/cluster.ts:480](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L480)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:481](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L481)
+[lib/k8s/cluster.ts:481](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L481)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:482](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L482)
+[lib/k8s/cluster.ts:482](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L482)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:483](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L483)
+[lib/k8s/cluster.ts:483](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L483)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:484](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L484)
+[lib/k8s/cluster.ts:484](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L484)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:485](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L485)
+[lib/k8s/cluster.ts:485](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L485)
 
 ___
 
@@ -102,4 +102,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:486](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L486)
+[lib/k8s/cluster.ts:486](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L486)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeMetadata.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeMetadata.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_cluster.KubeMetadata"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:40](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L40)
+[lib/k8s/cluster.ts:40](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L40)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:36](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L36)
+[lib/k8s/cluster.ts:36](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L36)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:39](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L39)
+[lib/k8s/cluster.ts:39](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L39)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:34](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L34)
+[lib/k8s/cluster.ts:34](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L34)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:35](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L35)
+[lib/k8s/cluster.ts:35](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L35)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:41](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L41)
+[lib/k8s/cluster.ts:41](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L41)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:37](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L37)
+[lib/k8s/cluster.ts:37](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L37)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:38](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L38)
+[lib/k8s/cluster.ts:38](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L38)
 
 ___
 
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:33](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L33)
+[lib/k8s/cluster.ts:33](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L33)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeMetrics.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeMetrics.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_cluster.KubeMetrics"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:465](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L465)
+[lib/k8s/cluster.ts:465](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L465)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:470](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L470)
+[lib/k8s/cluster.ts:470](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L470)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:466](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L466)
+[lib/k8s/cluster.ts:466](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L466)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeObjectIface.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeObjectIface.md
@@ -30,7 +30,7 @@ slug: "lib_k8s_cluster.KubeObjectIface"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L76)
+[lib/k8s/cluster.ts:76](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L76)
 
 ## Properties
 
@@ -40,7 +40,7 @@ slug: "lib_k8s_cluster.KubeObjectIface"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L77)
+[lib/k8s/cluster.ts:77](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L77)
 
 ## Methods
 
@@ -60,7 +60,7 @@ slug: "lib_k8s_cluster.KubeObjectIface"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L60)
+[lib/k8s/cluster.ts:60](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L60)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L75)
+[lib/k8s/cluster.ts:75](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L75)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L66)
+[lib/k8s/cluster.ts:66](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L66)
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L61)
+[lib/k8s/cluster.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L61)
 
 ___
 
@@ -145,4 +145,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L72)
+[lib/k8s/cluster.ts:72](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L72)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeObjectInterface.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeObjectInterface.md
@@ -64,7 +64,7 @@ slug: "lib_k8s_cluster.KubeObjectInterface"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)

--- a/docs/development/api/interfaces/lib_k8s_cluster.KubeOwnerReference.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.KubeOwnerReference.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_cluster.KubeOwnerReference"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:45](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L45)
+[lib/k8s/cluster.ts:45](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L45)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:46](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L46)
+[lib/k8s/cluster.ts:46](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L46)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:47](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L47)
+[lib/k8s/cluster.ts:47](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L47)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:48](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L48)
+[lib/k8s/cluster.ts:48](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L48)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:49](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L49)
+[lib/k8s/cluster.ts:49](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L49)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:50](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L50)
+[lib/k8s/cluster.ts:50](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L50)

--- a/docs/development/api/interfaces/lib_k8s_cluster.LabelSelector.md
+++ b/docs/development/api/interfaces/lib_k8s_cluster.LabelSelector.md
@@ -22,7 +22,7 @@ slug: "lib_k8s_cluster.LabelSelector"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:454](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L454)
+[lib/k8s/cluster.ts:454](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L454)
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:459](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L459)
+[lib/k8s/cluster.ts:459](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L459)

--- a/docs/development/api/interfaces/lib_k8s_configMap.KubeConfigMap.md
+++ b/docs/development/api/interfaces/lib_k8s_configMap.KubeConfigMap.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_configMap.KubeConfigMap"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/configMap.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/configMap.ts#L5)
+[lib/k8s/configMap.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/configMap.ts#L5)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)

--- a/docs/development/api/interfaces/lib_k8s_crd.KubeCRD.md
+++ b/docs/development/api/interfaces/lib_k8s_crd.KubeCRD.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_crd.KubeCRD"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -80,4 +80,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/crd.ts:7](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L7)
+[lib/k8s/crd.ts:7](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L7)

--- a/docs/development/api/interfaces/lib_k8s_cronJob.KubeCronJob.md
+++ b/docs/development/api/interfaces/lib_k8s_cronJob.KubeCronJob.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_cronJob.KubeCronJob"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cronJob.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cronJob.ts#L5)
+[lib/k8s/cronJob.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cronJob.ts#L5)
 
 ___
 
@@ -91,4 +91,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/cronJob.ts:14](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cronJob.ts#L14)
+[lib/k8s/cronJob.ts:14](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cronJob.ts#L14)

--- a/docs/development/api/interfaces/lib_k8s_daemonSet.KubeDaemonSet.md
+++ b/docs/development/api/interfaces/lib_k8s_daemonSet.KubeDaemonSet.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_daemonSet.KubeDaemonSet"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/daemonSet.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/daemonSet.ts#L5)
+[lib/k8s/daemonSet.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/daemonSet.ts#L5)
 
 ___
 
@@ -90,4 +90,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/daemonSet.ts:15](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/daemonSet.ts#L15)
+[lib/k8s/daemonSet.ts:15](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/daemonSet.ts#L15)

--- a/docs/development/api/interfaces/lib_k8s_deployment.KubeDeployment.md
+++ b/docs/development/api/interfaces/lib_k8s_deployment.KubeDeployment.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_deployment.KubeDeployment"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/deployment.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/deployment.ts#L5)
+[lib/k8s/deployment.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/deployment.ts#L5)
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/deployment.ts:13](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/deployment.ts#L13)
+[lib/k8s/deployment.ts:13](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/deployment.ts#L13)

--- a/docs/development/api/interfaces/lib_k8s_event.KubeEvent.md
+++ b/docs/development/api/interfaces/lib_k8s_event.KubeEvent.md
@@ -30,7 +30,7 @@ slug: "lib_k8s_event.KubeEvent"
 
 #### Defined in
 
-[lib/k8s/event.ts:10](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L10)
+[lib/k8s/event.ts:10](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L10)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:8](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L8)
+[lib/k8s/event.ts:8](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L8)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:9](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L9)
+[lib/k8s/event.ts:9](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L9)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:7](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L7)
+[lib/k8s/event.ts:7](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L7)
 
 ___
 
@@ -70,4 +70,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/event.ts:6](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/event.ts#L6)
+[lib/k8s/event.ts:6](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/event.ts#L6)

--- a/docs/development/api/interfaces/lib_k8s_ingress.KubeIngress.md
+++ b/docs/development/api/interfaces/lib_k8s_ingress.KubeIngress.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_ingress.KubeIngress"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -68,4 +68,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/ingress.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/ingress.ts#L5)
+[lib/k8s/ingress.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/ingress.ts#L5)

--- a/docs/development/api/interfaces/lib_k8s_job.KubeJob.md
+++ b/docs/development/api/interfaces/lib_k8s_job.KubeJob.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_job.KubeJob"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/job.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/job.ts#L5)
+[lib/k8s/job.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/job.ts#L5)
 
 ___
 
@@ -86,4 +86,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/job.ts:9](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/job.ts#L9)
+[lib/k8s/job.ts:9](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/job.ts#L9)

--- a/docs/development/api/interfaces/lib_k8s_namespace.KubeNamespace.md
+++ b/docs/development/api/interfaces/lib_k8s_namespace.KubeNamespace.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_namespace.KubeNamespace"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -68,4 +68,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/namespace.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/namespace.ts#L5)
+[lib/k8s/namespace.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/namespace.ts#L5)

--- a/docs/development/api/interfaces/lib_k8s_networkpolicy.KubeNetworkPolicy.md
+++ b/docs/development/api/interfaces/lib_k8s_networkpolicy.KubeNetworkPolicy.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_networkpolicy.KubeNetworkPolicy"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/networkpolicy.tsx:32](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/networkpolicy.tsx#L32)
+[lib/k8s/networkpolicy.tsx:32](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/networkpolicy.tsx#L32)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/networkpolicy.tsx:33](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/networkpolicy.tsx#L33)
+[lib/k8s/networkpolicy.tsx:33](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/networkpolicy.tsx#L33)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/networkpolicy.tsx:34](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/networkpolicy.tsx#L34)
+[lib/k8s/networkpolicy.tsx:34](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/networkpolicy.tsx#L34)
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/networkpolicy.tsx:35](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/networkpolicy.tsx#L35)
+[lib/k8s/networkpolicy.tsx:35](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/networkpolicy.tsx#L35)

--- a/docs/development/api/interfaces/lib_k8s_node.KubeNode.md
+++ b/docs/development/api/interfaces/lib_k8s_node.KubeNode.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_node.KubeNode"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/node.ts:33](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/node.ts#L33)
+[lib/k8s/node.ts:33](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/node.ts#L33)
 
 ___
 
@@ -103,4 +103,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/node.ts:8](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/node.ts#L8)
+[lib/k8s/node.ts:8](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/node.ts#L8)

--- a/docs/development/api/interfaces/lib_k8s_persistentVolume.KubePersistentVolume.md
+++ b/docs/development/api/interfaces/lib_k8s_persistentVolume.KubePersistentVolume.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_persistentVolume.KubePersistentVolume"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/persistentVolume.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolume.ts#L5)
+[lib/k8s/persistentVolume.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolume.ts#L5)
 
 ___
 
@@ -91,4 +91,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/persistentVolume.ts:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolume.ts#L11)
+[lib/k8s/persistentVolume.ts:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolume.ts#L11)

--- a/docs/development/api/interfaces/lib_k8s_persistentVolumeClaim.KubePersistentVolumeClaim.md
+++ b/docs/development/api/interfaces/lib_k8s_persistentVolumeClaim.KubePersistentVolumeClaim.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_persistentVolumeClaim.KubePersistentVolumeClaim"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/persistentVolumeClaim.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolumeClaim.ts#L5)
+[lib/k8s/persistentVolumeClaim.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolumeClaim.ts#L5)
 
 ___
 
@@ -97,4 +97,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/persistentVolumeClaim.ts:19](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/persistentVolumeClaim.ts#L19)
+[lib/k8s/persistentVolumeClaim.ts:19](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/persistentVolumeClaim.ts#L19)

--- a/docs/development/api/interfaces/lib_k8s_pod.ExecOptions.md
+++ b/docs/development/api/interfaces/lib_k8s_pod.ExecOptions.md
@@ -14,7 +14,7 @@ slug: "lib_k8s_pod.ExecOptions"
 
 #### Defined in
 
-[lib/k8s/pod.ts:30](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L30)
+[lib/k8s/pod.ts:30](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L30)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/pod.ts:31](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L31)
+[lib/k8s/pod.ts:31](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L31)

--- a/docs/development/api/interfaces/lib_k8s_pod.KubePod.md
+++ b/docs/development/api/interfaces/lib_k8s_pod.KubePod.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_pod.KubePod"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/pod.ts:12](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L12)
+[lib/k8s/pod.ts:12](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L12)
 
 ___
 
@@ -96,4 +96,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/pod.ts:16](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/pod.ts#L16)
+[lib/k8s/pod.ts:16](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/pod.ts#L16)

--- a/docs/development/api/interfaces/lib_k8s_replicaSet.KubeReplicaSet.md
+++ b/docs/development/api/interfaces/lib_k8s_replicaSet.KubeReplicaSet.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_replicaSet.KubeReplicaSet"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/replicaSet.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/replicaSet.ts#L5)
+[lib/k8s/replicaSet.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/replicaSet.ts#L5)
 
 ___
 
@@ -95,4 +95,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/replicaSet.ts:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/replicaSet.ts#L11)
+[lib/k8s/replicaSet.ts:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/replicaSet.ts#L11)

--- a/docs/development/api/interfaces/lib_k8s_role.KubeRole.md
+++ b/docs/development/api/interfaces/lib_k8s_role.KubeRole.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_role.KubeRole"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -72,4 +72,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/role.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/role.ts#L5)
+[lib/k8s/role.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/role.ts#L5)

--- a/docs/development/api/interfaces/lib_k8s_roleBinding.KubeRoleBinding.md
+++ b/docs/development/api/interfaces/lib_k8s_roleBinding.KubeRoleBinding.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_roleBinding.KubeRoleBinding"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L5)
+[lib/k8s/roleBinding.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L5)
 
 ___
 
@@ -80,4 +80,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/roleBinding.ts:10](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/roleBinding.ts#L10)
+[lib/k8s/roleBinding.ts:10](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/roleBinding.ts#L10)

--- a/docs/development/api/interfaces/lib_k8s_secret.KubeSecret.md
+++ b/docs/development/api/interfaces/lib_k8s_secret.KubeSecret.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_secret.KubeSecret"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/secret.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/secret.ts#L5)
+[lib/k8s/secret.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/secret.ts#L5)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -72,4 +72,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/secret.ts:6](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/secret.ts#L6)
+[lib/k8s/secret.ts:6](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/secret.ts#L6)

--- a/docs/development/api/interfaces/lib_k8s_service.KubeService.md
+++ b/docs/development/api/interfaces/lib_k8s_service.KubeService.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_service.KubeService"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/service.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/service.ts#L5)
+[lib/k8s/service.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/service.ts#L5)

--- a/docs/development/api/interfaces/lib_k8s_serviceAccount.KubeServiceAccount.md
+++ b/docs/development/api/interfaces/lib_k8s_serviceAccount.KubeServiceAccount.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_serviceAccount.KubeServiceAccount"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/serviceAccount.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/serviceAccount.ts#L5)
+[lib/k8s/serviceAccount.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/serviceAccount.ts#L5)

--- a/docs/development/api/interfaces/lib_k8s_statefulSet.KubeStatefulSet.md
+++ b/docs/development/api/interfaces/lib_k8s_statefulSet.KubeStatefulSet.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_statefulSet.KubeStatefulSet"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/statefulSet.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/statefulSet.ts#L5)
+[lib/k8s/statefulSet.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/statefulSet.ts#L5)
 
 ___
 
@@ -90,4 +90,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/statefulSet.ts:15](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/statefulSet.ts#L15)
+[lib/k8s/statefulSet.ts:15](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/statefulSet.ts#L15)

--- a/docs/development/api/interfaces/lib_k8s_storageClass.KubeStorageClass.md
+++ b/docs/development/api/interfaces/lib_k8s_storageClass.KubeStorageClass.md
@@ -24,7 +24,7 @@ slug: "lib_k8s_storageClass.KubeStorageClass"
 
 #### Defined in
 
-[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L23)
+[lib/k8s/cluster.ts:23](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L23)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L22)
+[lib/k8s/cluster.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/cluster.ts#L24)
+[lib/k8s/cluster.ts:24](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/cluster.ts#L24)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:5](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L5)
+[lib/k8s/storageClass.ts:5](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L5)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:6](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L6)
+[lib/k8s/storageClass.ts:6](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L6)
 
 ___
 
@@ -82,4 +82,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/storageClass.ts:7](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/storageClass.ts#L7)
+[lib/k8s/storageClass.ts:7](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/storageClass.ts#L7)

--- a/docs/development/api/interfaces/lib_router.Route.md
+++ b/docs/development/api/interfaces/lib_router.Route.md
@@ -16,7 +16,7 @@ When true, will only match if the path matches the location.pathname exactly.
 
 #### Defined in
 
-[lib/router.tsx:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L61)
+[lib/router.tsx:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L61)
 
 ___
 
@@ -28,7 +28,7 @@ Human readable name. Capitalized and short.
 
 #### Defined in
 
-[lib/router.tsx:63](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L63)
+[lib/router.tsx:63](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L63)
 
 ___
 
@@ -40,7 +40,7 @@ This route does not require Authentication.
 
 #### Defined in
 
-[lib/router.tsx:67](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L67)
+[lib/router.tsx:67](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L67)
 
 ___
 
@@ -52,7 +52,7 @@ In case this route does *not* need a cluster prefix and context.
 
 #### Defined in
 
-[lib/router.tsx:65](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L65)
+[lib/router.tsx:65](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L65)
 
 ___
 
@@ -64,7 +64,7 @@ Any valid URL path or array of paths that path-to-regexp@^1.7.0 understands.
 
 #### Defined in
 
-[lib/router.tsx:59](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L59)
+[lib/router.tsx:59](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L59)
 
 ___
 
@@ -76,7 +76,7 @@ The sidebar group this Route should be in, or null if it is in no group.
 
 #### Defined in
 
-[lib/router.tsx:69](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L69)
+[lib/router.tsx:69](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L69)
 
 ## Methods
 
@@ -92,4 +92,4 @@ Shown component for this route.
 
 #### Defined in
 
-[lib/router.tsx:71](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L71)
+[lib/router.tsx:71](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L71)

--- a/docs/development/api/interfaces/lib_router.RouteURLProps.md
+++ b/docs/development/api/interfaces/lib_router.RouteURLProps.md
@@ -18,4 +18,4 @@ slug: "lib_router.RouteURLProps"
 
 #### Defined in
 
-[lib/router.tsx:454](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L454)
+[lib/router.tsx:453](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L453)

--- a/docs/development/api/interfaces/lib_util.FilterState.md
+++ b/docs/development/api/interfaces/lib_util.FilterState.md
@@ -14,7 +14,7 @@ slug: "lib_util.FilterState"
 
 #### Defined in
 
-[lib/util.ts:81](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L81)
+[lib/util.ts:81](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L81)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[lib/util.ts:82](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L82)
+[lib/util.ts:82](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L82)

--- a/docs/development/api/interfaces/plugin_registry.SectionFuncProps.md
+++ b/docs/development/api/interfaces/plugin_registry.SectionFuncProps.md
@@ -14,7 +14,7 @@ slug: "plugin_registry.SectionFuncProps"
 
 #### Defined in
 
-[plugin/registry.tsx:16](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L16)
+[plugin/registry.tsx:16](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L16)
 
 ## Methods
 
@@ -35,4 +35,4 @@ slug: "plugin_registry.SectionFuncProps"
 
 #### Defined in
 
-[plugin/registry.tsx:17](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L17)
+[plugin/registry.tsx:17](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L17)

--- a/docs/development/api/interfaces/redux_reducers_config.ConfigAction.md
+++ b/docs/development/api/interfaces/redux_reducers_config.ConfigAction.md
@@ -26,7 +26,7 @@ slug: "redux_reducers_config.ConfigAction"
 
 #### Defined in
 
-[redux/reducers/config.tsx:16](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/redux/reducers/config.tsx#L16)
+[redux/reducers/config.tsx:16](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/redux/reducers/config.tsx#L16)
 
 ___
 
@@ -40,4 +40,4 @@ Action.type
 
 #### Defined in
 
-[redux/actions/actions.tsx:68](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/redux/actions/actions.tsx#L68)
+[redux/actions/actions.tsx:71](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/redux/actions/actions.tsx#L71)

--- a/docs/development/api/interfaces/redux_reducers_config.ConfigState.md
+++ b/docs/development/api/interfaces/redux_reducers_config.ConfigState.md
@@ -14,4 +14,4 @@ slug: "redux_reducers_config.ConfigState"
 
 #### Defined in
 
-[redux/reducers/config.tsx:6](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/redux/reducers/config.tsx#L6)
+[redux/reducers/config.tsx:6](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/redux/reducers/config.tsx#L6)

--- a/docs/development/api/modules/lib_k8s.md
+++ b/docs/development/api/modules/lib_k8s.md
@@ -156,7 +156,7 @@ Renames and re-exports [lib/k8s/storageClass](lib_k8s_storageClass.md)
 
 #### Defined in
 
-[lib/k8s/index.ts:149](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/index.ts#L149)
+[lib/k8s/index.ts:149](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/index.ts#L149)
 
 ## Variables
 
@@ -170,7 +170,7 @@ Renames and re-exports [lib/k8s/storageClass](lib_k8s_storageClass.md)
 
 #### Defined in
 
-[lib/k8s/index.ts:73](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/index.ts#L73)
+[lib/k8s/index.ts:73](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/index.ts#L73)
 
 ## Functions
 
@@ -184,7 +184,7 @@ Renames and re-exports [lib/k8s/storageClass](lib_k8s_storageClass.md)
 
 #### Defined in
 
-[lib/k8s/index.ts:145](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/index.ts#L145)
+[lib/k8s/index.ts:145](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/index.ts#L145)
 
 ___
 
@@ -198,7 +198,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/index.ts:128](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/index.ts#L128)
+[lib/k8s/index.ts:128](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/index.ts#L128)
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/index.ts:80](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/index.ts#L80)
+[lib/k8s/index.ts:80](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/index.ts#L80)
 
 ___
 
@@ -232,4 +232,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/index.ts:151](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/index.ts#L151)
+[lib/k8s/index.ts:151](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/index.ts#L151)

--- a/docs/development/api/modules/lib_k8s_apiProxy.md
+++ b/docs/development/api/modules/lib_k8s_apiProxy.md
@@ -33,7 +33,7 @@ slug: "lib_k8s_apiProxy"
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:109](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L109)
+[lib/k8s/apiProxy.ts:109](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L109)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:108](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L108)
+[lib/k8s/apiProxy.ts:108](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L108)
 
 ## Functions
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:175](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L175)
+[lib/k8s/apiProxy.ts:175](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L175)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:220](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L220)
+[lib/k8s/apiProxy.ts:220](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L220)
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:625](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L625)
+[lib/k8s/apiProxy.ts:625](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L625)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:644](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L644)
+[lib/k8s/apiProxy.ts:644](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L644)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:351](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L351)
+[lib/k8s/apiProxy.ts:351](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L351)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:340](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L340)
+[lib/k8s/apiProxy.ts:340](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L340)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:362](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L362)
+[lib/k8s/apiProxy.ts:362](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L362)
 
 ___
 
@@ -239,7 +239,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:373](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L373)
+[lib/k8s/apiProxy.ts:373](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L373)
 
 ___
 
@@ -262,7 +262,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:27](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L27)
+[lib/k8s/apiProxy.ts:27](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L27)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:512](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L512)
+[lib/k8s/apiProxy.ts:512](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L512)
 
 ___
 
@@ -312,7 +312,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:378](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L378)
+[lib/k8s/apiProxy.ts:378](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L378)
 
 ___
 
@@ -334,7 +334,7 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:415](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L415)
+[lib/k8s/apiProxy.ts:415](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L415)
 
 ___
 
@@ -348,4 +348,4 @@ ___
 
 #### Defined in
 
-[lib/k8s/apiProxy.ts:673](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/apiProxy.ts#L673)
+[lib/k8s/apiProxy.ts:673](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/apiProxy.ts#L673)

--- a/docs/development/api/modules/lib_k8s_crd.md
+++ b/docs/development/api/modules/lib_k8s_crd.md
@@ -31,4 +31,4 @@ slug: "lib_k8s_crd"
 
 #### Defined in
 
-[lib/k8s/crd.ts:57](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/k8s/crd.ts#L57)
+[lib/k8s/crd.ts:57](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/k8s/crd.ts#L57)

--- a/docs/development/api/modules/lib_router.md
+++ b/docs/development/api/modules/lib_router.md
@@ -21,27 +21,14 @@ slug: "lib_router"
 | :------ | :------ |
 | `component` | () => `Element` |
 | `exact` | `boolean` |
+| `name` | `string` |
 | `noAuthRequired` | `boolean` |
 | `path` | `string` |
 | `sidebar` | ``null`` |
 
 #### Defined in
 
-[lib/router.tsx:430](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L430)
-
-___
-
-### ROUTES
-
-• **ROUTES**: `Object`
-
-#### Index signature
-
-▪ [routeName: `string`]: [`Route`](../interfaces/lib_router.Route.md)
-
-#### Defined in
-
-[lib/router.tsx:76](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L76)
+[lib/router.tsx:428](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L428)
 
 ## Functions
 
@@ -62,7 +49,21 @@ ___
 
 #### Defined in
 
-[lib/router.tsx:458](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L458)
+[lib/router.tsx:457](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L457)
+
+___
+
+### getDefaultRoutes
+
+▸ **getDefaultRoutes**(): `Object`
+
+#### Returns
+
+`Object`
+
+#### Defined in
+
+[lib/router.tsx:487](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L487)
 
 ___
 
@@ -82,7 +83,7 @@ ___
 
 #### Defined in
 
-[lib/router.tsx:438](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L438)
+[lib/router.tsx:437](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L437)
 
 ___
 
@@ -102,4 +103,4 @@ ___
 
 #### Defined in
 
-[lib/router.tsx:442](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/router.tsx#L442)
+[lib/router.tsx:441](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/router.tsx#L441)

--- a/docs/development/api/modules/lib_util.md
+++ b/docs/development/api/modules/lib_util.md
@@ -16,7 +16,7 @@ slug: "lib_util"
 
 #### Defined in
 
-[lib/util.ts:20](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L20)
+[lib/util.ts:20](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L20)
 
 ## Variables
 
@@ -26,7 +26,7 @@ slug: "lib_util"
 
 #### Defined in
 
-[lib/util.ts:18](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L18)
+[lib/util.ts:18](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L18)
 
 ## Functions
 
@@ -48,7 +48,7 @@ slug: "lib_util"
 
 #### Defined in
 
-[lib/util.ts:85](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L85)
+[lib/util.ts:85](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L85)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:153](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L153)
+[lib/util.ts:154](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L154)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:145](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L145)
+[lib/util.ts:146](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L146)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:34](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L34)
+[lib/util.ts:34](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L34)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:43](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L43)
+[lib/util.ts:43](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L43)
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:61](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L61)
+[lib/util.ts:61](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L61)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:51](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L51)
+[lib/util.ts:51](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L51)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:47](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L47)
+[lib/util.ts:47](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L47)
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:26](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L26)
+[lib/util.ts:26](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L26)
 
 ___
 
@@ -226,7 +226,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:22](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L22)
+[lib/util.ts:22](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L22)
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 #### Defined in
 
-[lib/util.ts:165](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L165)
+[lib/util.ts:166](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L166)
 
 ___
 
@@ -278,4 +278,4 @@ ___
 
 #### Defined in
 
-[lib/util.ts:140](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/lib/util.ts#L140)
+[lib/util.ts:141](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/lib/util.ts#L141)

--- a/docs/development/api/modules/plugin_registry.md
+++ b/docs/development/api/modules/plugin_registry.md
@@ -34,4 +34,4 @@ slug: "plugin_registry"
 
 #### Defined in
 
-[plugin/registry.tsx:20](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/plugin/registry.tsx#L20)
+[plugin/registry.tsx:20](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/plugin/registry.tsx#L20)

--- a/docs/development/api/modules/redux_reducers_config.md
+++ b/docs/development/api/modules/redux_reducers_config.md
@@ -17,7 +17,7 @@ slug: "redux_reducers_config"
 
 #### Defined in
 
-[redux/reducers/config.tsx:11](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/redux/reducers/config.tsx#L11)
+[redux/reducers/config.tsx:11](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/redux/reducers/config.tsx#L11)
 
 ## Functions
 
@@ -42,4 +42,4 @@ slug: "redux_reducers_config"
 
 #### Defined in
 
-[redux/reducers/config.tsx:21](https://github.com/kinvolk/headlamp/blob/490b989/frontend/src/redux/reducers/config.tsx#L21)
+[redux/reducers/config.tsx:21](https://github.com/kinvolk/headlamp/blob/2fb68817/frontend/src/redux/reducers/config.tsx#L21)

--- a/docs/development/plugins/functionality.md
+++ b/docs/development/plugins/functionality.md
@@ -18,6 +18,7 @@ The main ones are:
 * Headlamp: To register plugins
 * CommonComponents: React components commonly used in the Headlamp UI
 * Notification: This module contains two exported members one is Notification, a class which can be used to prepare notifications that are accepted by headlamp and the other one is setNotificationsInStore it is a dispatcher function which accepts a notification object prepared from the Notification class and when called it brings the notifications from plugin land to headlamp ecosystem so that headlamp can parse the notification and display it.
+* Router: To get or generate routes
 
 ### Shared Modules
 

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Redirect, Route, RouteProps, Switch } from 'react-router-dom';
 import { getToken } from '../../lib/auth';
 import { useClustersConf } from '../../lib/k8s';
-import { createRouteURL, getRoutePath, NotFoundRoute, ROUTES } from '../../lib/router';
+import { createRouteURL, getDefaultRoutes, getRoutePath, NotFoundRoute } from '../../lib/router';
 import { getCluster } from '../../lib/util';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { useSidebarItem } from '../Sidebar';
@@ -12,7 +12,7 @@ export default function RouteSwitcher() {
   const { t } = useTranslation('frequent');
 
   // The NotFoundRoute always has to be evaluated in the last place.
-  const defaultRoutes = Object.values(ROUTES).concat(NotFoundRoute);
+  const defaultRoutes = Object.values(getDefaultRoutes()).concat(NotFoundRoute);
   const routes = useTypedSelector(state => state.ui.routes);
 
   return (

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRouteMatch } from 'react-router-dom';
 import { testAuth } from '../../lib/k8s/apiProxy';
-import { getRoutePath, Route, ROUTES } from '../../lib/router';
+import { getDefaultRoutes, getRoutePath, Route } from '../../lib/router';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 
 const NOT_FOUND_ERROR_MESSAGES = ['Error: Api request error: Bad Gateway', 'Offline'];
@@ -136,5 +136,7 @@ export function PureAlertNotification({
 export default function AlertNotification() {
   const routes = useTypedSelector(state => state.ui.routes);
 
-  return <PureAlertNotification routes={routes} testAuth={testAuth} moreRoutes={ROUTES} />;
+  return (
+    <PureAlertNotification routes={routes} testAuth={testAuth} moreRoutes={getDefaultRoutes()} />
+  );
 }

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -5,7 +5,7 @@ import { makeKubeObject } from '../../lib/k8s/cluster';
 import { createRouteURL, RouteURLProps } from '../../lib/router';
 
 export interface LinkProps {
-  /** A key in the router.tsx ROUTES object. */
+  /** A key in the default routes object (given by router.tsx's getDefaultRoutes). */
   routeName: string;
   /** An object with corresponding params for the pattern to use. */
   params?: RouteURLProps;

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -71,9 +71,7 @@ export interface Route {
   component: () => JSX.Element;
 }
 
-// Note: Please update interface in plugins-pkg/types/lib/router.d.ts if you change Route.
-
-export const ROUTES: {
+const defaultRoutes: {
   [routeName: string]: Route;
 } = {
   cluster: {
@@ -437,7 +435,7 @@ export const NotFoundRoute = {
 };
 
 export function getRoute(routeName: string) {
-  return ROUTES[routeName];
+  return defaultRoutes[routeName];
 }
 
 export function getRoutePath(route: Route) {
@@ -480,8 +478,12 @@ export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
   // if fullParams is empty it means it is a request for generating choser
   // route
   if (_.isEmpty(fullParams)) {
-    return generatePath(ROUTES['chooser'].path);
+    return generatePath(defaultRoutes['chooser'].path);
   }
   const url = getRoutePath(route);
   return generatePath(url, fullParams);
+}
+
+export function getDefaultRoutes() {
+  return defaultRoutes;
 }

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -20,6 +20,7 @@ window.pluginLib = {
   Recharts: require('recharts'),
   ReactRouter: require('react-router-dom'),
   ReactRedux: require('react-redux'),
+  Router: require('../lib/router'),
   Utils: require('../lib/util'),
   Iconify: require('@iconify/react'),
   Lodash: require('lodash'),

--- a/plugins/headlamp-plugin/lib/index.ts
+++ b/plugins/headlamp-plugin/lib/index.ts
@@ -1,6 +1,6 @@
 import * as K8s from '../types/lib/k8s';
 import * as ApiProxy from '../types/lib/k8s/apiProxy';
-import * as Notification from '../types/lib/Notification';
+import * as Notification from '../types/lib/notification';
 import * as Router from '../types/lib/router';
 import * as Utils from '../types/lib/util';
 import { Headlamp, Plugin } from '../types/plugin/lib';

--- a/plugins/headlamp-plugin/lib/index.ts
+++ b/plugins/headlamp-plugin/lib/index.ts
@@ -1,6 +1,7 @@
 import * as K8s from '../types/lib/k8s';
 import * as ApiProxy from '../types/lib/k8s/apiProxy';
 import * as Notification from '../types/lib/Notification';
+import * as Router from '../types/lib/router';
 import * as Utils from '../types/lib/util';
 import { Headlamp, Plugin } from '../types/plugin/lib';
 import Registry from '../types/plugin/registry';
@@ -13,6 +14,7 @@ export {
   K8s as k8s,
   CommonComponents,
   Utils,
+  Router,
   Plugin,
   Registry,
   Headlamp,


### PR DESCRIPTION
We want all the route related methods to be used by plugin developers
thus exporting this in the pluginLib makes sense.


