### PR TITLE
Fix plugin imports again

### DIFF
--- a/plugins/headlamp-plugin/config/plugins-tsconfig.json
+++ b/plugins/headlamp-plugin/config/plugins-tsconfig.json
@@ -27,5 +27,5 @@
     "rootDirs": ["node_modules/@kinvolk/headlamp-plugin/"],
     "skipLibCheck": true
   },
-  "include": ["./src/**/*"]
+  "include": ["./../../../../src/**/*"]
 }

--- a/plugins/headlamp-plugin/config/plugins-tsconfig.json
+++ b/plugins/headlamp-plugin/config/plugins-tsconfig.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
     "moduleResolution": "node",
-    "baseUrl": ".",
+    "baseUrl": "../../../../",
     "paths": {
       "*": [
         "node_modules/*.js",
@@ -15,12 +15,13 @@
       "@iconify/react": [
         "node_modules/@kinvolk/headlamp-plugin/node_modules/@iconify/react/src/icon.js"
       ],
-      "@kinvolk/headlamp-plugin/lib/K8s": [
-        "node_modules/@kinvolk/headlamp-plugin/types/src/lib/k8s/index.d.ts"
+      "@kinvolk/headlamp-plugin/lib/K8s/*": [
+        "node_modules/@kinvolk/headlamp-plugin/types/lib/k8s/*/index.d.ts",
+        "node_modules/@kinvolk/headlamp-plugin/types/lib/k8s/*.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/CommonComponents/*": [
-        "node_modules/@kinvolk/headlamp-plugin/types/src/components/common/*/index.d.ts",
-        "node_modules/@kinvolk/headlamp-plugin/types/src/components/common/*.d.ts"
+        "node_modules/@kinvolk/headlamp-plugin/types/components/common/*/index.d.ts",
+        "node_modules/@kinvolk/headlamp-plugin/types/components/common/*.d.ts"
       ]
     },
     "rootDirs": ["node_modules/@kinvolk/headlamp-plugin/"],


### PR DESCRIPTION
This is another attempt at making the plugins' imports easy.

#### Test

1. Do the following in VSCode (and use the values/types).
```typescript
import { KubeObjectInterface } from '@kinvolk/headlamp-plugin/lib/K8s/cluster';
import { makeCustomResourceClass } from '@kinvolk/headlamp-plugin/lib/K8s/crd';
```
2. Set your plugin's tsconfig as the following:
```json
{
  "extends": "./node_modules/@kinvolk/headlamp-plugin/config/plugins-tsconfig.json"
}
```
3. Click + hover the module part of the import to see that it's resolved. (And also, no errors should be reported/underlined by VSCode)
4. Change an import to a non-existing module to check if there's an error reported by VSCode.
5. Run `npm run tsc` in the plugin to see that there are no complaints about the imports.

If there are VSCode complaints, in a .ts file, press Ctrl+Shift+p and choose `Typescript: Restart TS Server`
(I noticed that VSCode sometimes is picking rules that are no longer accurate, so the TS restart should fix that)