### PR TITLE
Headless app fix

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -74,7 +74,7 @@ function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
     serverArgs = serverArgs.concat(['-plugins-dir', bundledPlugins]);
   }
 
-  serverArgs.concat(flags);
+  serverArgs = serverArgs.concat(flags);
   console.log('arguments passed to backend server', serverArgs);
 
   return spawn(serverFilePath, serverArgs, options);

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -353,10 +353,12 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	})
 
 	// Serve the frontend if needed
-	spa := spaHandler{staticPath: config.staticDir, indexPath: "index.html", baseURL: config.baseURL}
-	r.PathPrefix("/").Handler(spa)
+	if config.staticDir != "" {
+		spa := spaHandler{staticPath: config.staticDir, indexPath: "index.html", baseURL: config.baseURL}
+		r.PathPrefix("/").Handler(spa)
 
-	http.Handle("/", r)
+		http.Handle("/", r)
+	}
 
 	var handler http.Handler
 


### PR DESCRIPTION
- backend: Fix serving the static frontend only if needed
- app: Fix passing static dir arg for headless mode

## How to use

```bash
make app-linux
cd app/dist/linux-unpacked
./headlamp --headless
```

## Testing done

- `--headless` mode with app works
- `make run-frontend` / `make run-backend` still works
