### PR TITLE
github: Fix golang version to one version

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -32,7 +32,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
     - name: App linux
       run: |
         make app-linux
@@ -49,7 +49,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
     - name: Dependencies
       uses: crazy-max/ghaction-chocolatey@v1
       with:
@@ -69,7 +69,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
     - name: Dependencies
       run: brew install make
     - name: App Mac


### PR DESCRIPTION
This way we are testing with a particular version, rather than using the latest version even if it hasn't been tested.