### PR TITLE
Add better a11y error reporting, fix storybook, fix reported a11y issues

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -56,3 +56,7 @@ jobs:
     - name: Build docs
       run: |
         make docs
+
+    - name: Build storybook
+      run: |
+        make frontend-build-storybook

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ frontend: frontend-install
 frontend-build:
 	cd frontend && npm run build
 
+.PHONY: frontend-build-storybook
+frontend-build-storybook:
+	cd frontend && npm run build-storybook
+
 run-backend:
 	./backend/headlamp-server -dev
 

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -50,3 +50,19 @@ From within the [Headlamp](https://github.com/kinvolk/headlamp/) repo run:
 ```bash
 make storybook
 ```
+
+
+## Accessibility (a11y)
+
+### Developer console warnings and errors
+
+axe-core is used to detect some a11y issues at runtime when running
+Headlamp in developer mode. This detects more issues than testing
+components via eslint or via unit tests.
+
+Any issues found are reported in the developer console.
+
+To disable the alert message during development, use the following:
+```bash
+REACT_APP_SKIP_A11Y=true make run-frontend
+```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.0.3",
-        "@iconify/icons-mdi": "^1.1.34",
-        "@iconify/react": "^3.1.3",
+        "@iconify/icons-mdi": "^1.2.9",
+        "@iconify/react": "^3.2.1",
         "@kinvolk/eslint-config": "^0.5.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/lab": "^4.0.0-alpha.60",
@@ -2351,17 +2351,25 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
     "node_modules/@iconify/icons-mdi": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@iconify/icons-mdi/-/icons-mdi-1.1.34.tgz",
-      "integrity": "sha512-vZHthXWcClQi/o1sAx6DxwFx3FYPYUMXl+Ebk9YuyLA+E7PrIwi7NPlYbkM5M4vIZ3tt9wreCSu23nhlXK+uDg=="
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@iconify/icons-mdi/-/icons-mdi-1.2.9.tgz",
+      "integrity": "sha512-MemyfTF9RcUELwbklu8DjeAYR0ew6JZEU2A/fxD7bSBnYJ8UXqGBxNMGyd9nxf9rQVy4dON8nnUjaezLCwxgUg==",
+      "dependencies": {
+        "@iconify/types": "^1.1.0"
+      }
     },
     "node_modules/@iconify/react": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-3.2.0.tgz",
-      "integrity": "sha512-nHmPeBGn4KKS8DwDjGrZ9SLpoMmZ+dKZ53s2msBftg6srESMWBUOMW/XBMRjnUjzwQQchguVEhhh59LSSAia/g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-yKzixjC9ct9RC/aSGo1OGxkG2rpfhlr/urRz6k2YZlIBzn92PBTlqtSx8o8dFYEorr3eUFSCBZFzBy1yw5jsAA==",
       "funding": {
         "url": "http://github.com/sponsors/cyberalien"
       }
+    },
+    "node_modules/@iconify/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -34208,14 +34216,22 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
     "@iconify/icons-mdi": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@iconify/icons-mdi/-/icons-mdi-1.1.34.tgz",
-      "integrity": "sha512-vZHthXWcClQi/o1sAx6DxwFx3FYPYUMXl+Ebk9YuyLA+E7PrIwi7NPlYbkM5M4vIZ3tt9wreCSu23nhlXK+uDg=="
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@iconify/icons-mdi/-/icons-mdi-1.2.9.tgz",
+      "integrity": "sha512-MemyfTF9RcUELwbklu8DjeAYR0ew6JZEU2A/fxD7bSBnYJ8UXqGBxNMGyd9nxf9rQVy4dON8nnUjaezLCwxgUg==",
+      "requires": {
+        "@iconify/types": "^1.1.0"
+      }
     },
     "@iconify/react": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-3.2.0.tgz",
-      "integrity": "sha512-nHmPeBGn4KKS8DwDjGrZ9SLpoMmZ+dKZ53s2msBftg6srESMWBUOMW/XBMRjnUjzwQQchguVEhhh59LSSAia/g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-yKzixjC9ct9RC/aSGo1OGxkG2rpfhlr/urRz6k2YZlIBzn92PBTlqtSx8o8dFYEorr3eUFSCBZFzBy1yw5jsAA=="
+    },
+    "@iconify/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "productName": "Headlamp",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
-    "@iconify/icons-mdi": "^1.1.34",
-    "@iconify/react": "^3.1.3",
+    "@iconify/icons-mdi": "^1.2.9",
+    "@iconify/react": "^3.2.1",
     "@kinvolk/eslint-config": "^0.5.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/frontend/src/components/404/index.tsx
+++ b/frontend/src/components/404/index.tsx
@@ -1,34 +1,51 @@
-import { Dialog, Grid, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import headlampBrokenImage from '../../assets/headlamp-404.svg';
 
+const useStyles = makeStyles(() => ({
+  root: {
+    textAlign: 'center',
+  },
+  h1: {
+    fontSize: '2.125rem',
+    lineHeight: 1.2,
+    fontWeight: 400,
+  },
+  h2: {
+    fontSize: '1.25rem',
+    lineHeight: 3.6,
+    fontWeight: 500,
+  },
+  img: {
+    width: '100%',
+  },
+}));
+
 export default function NotFoundComponent() {
   const { t } = useTranslation('frequent');
+  const classes = useStyles();
   return (
-    <Dialog fullScreen open style={{ overflow: 'hidden' }}>
-      <Grid
-        justifyContent="center"
-        direction="column"
-        alignItems="center"
-        container
-        spacing={2}
-        style={{ minHeight: '100vh' }}
-      >
-        <Grid item>
-          <img src={headlampBrokenImage} alt="" />
-        </Grid>
-        <Grid item>
-          <Typography variant="h4">{t(`Whoops! This page doesn't exist`)}</Typography>
-        </Grid>
-        <Grid item>
-          <Typography variant="h6">
-            <Trans t={t}>
-              Head back <Link to="/">home</Link>.
-            </Trans>
-          </Typography>
-        </Grid>
+    <Grid
+      container
+      spacing={0}
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+      className={classes.root}
+    >
+      <Grid item xs={12}>
+        <img src={headlampBrokenImage} alt="" className={classes.img} />
+        <Typography variant="h1" className={classes.h1}>
+          {t(`Whoops! This page doesn't exist`)}
+        </Typography>
+        <Typography variant="h2" className={classes.h2}>
+          <Trans t={t}>
+            Head back <Link to="/">home</Link>.
+          </Trans>
+        </Typography>
       </Grid>
-    </Dialog>
+    </Grid>
   );
 }

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Redirect, Route, RouteProps, Switch } from 'react-router-dom';
 import { getToken } from '../../lib/auth';
 import { useClustersConf } from '../../lib/k8s';
@@ -8,6 +9,8 @@ import { useTypedSelector } from '../../redux/reducers/reducers';
 import { useSidebarItem } from '../Sidebar';
 
 export default function RouteSwitcher() {
+  const { t } = useTranslation('frequent');
+
   // The NotFoundRoute always has to be evaluated in the last place.
   const defaultRoutes = Object.values(ROUTES).concat(NotFoundRoute);
   const routes = useTypedSelector(state => state.ui.routes);
@@ -21,7 +24,7 @@ export default function RouteSwitcher() {
             <Route
               path={route.path}
               component={() => (
-                <PageTitle title={route.name ? route.name : route.sidebar}>
+                <PageTitle title={t(route.name ? route.name : route.sidebar)}>
                   <route.component />
                 </PageTitle>
               )}

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -247,9 +247,7 @@ export function PureTopBar({
                 <ClusterTitle cluster={cluster} clusters={clusters} />
               </div>
               {Object.values(appBarActions).map((action, i) => (
-                <MenuItem>
-                  <React.Fragment key={i}>{action()}</React.Fragment>
-                </MenuItem>
+                <React.Fragment key={i}>{action()}</React.Fragment>
               ))}
               <LocaleSelect />
               <ThemeChangeButton />

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -1,10 +1,9 @@
-import { Link } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
+import Link from '@material-ui/core/Link';
 import Snackbar from '@material-ui/core/Snackbar';
 import TextField from '@material-ui/core/TextField';
 import React from 'react';
@@ -15,6 +14,7 @@ import { useClustersConf } from '../../lib/k8s';
 import { ApiError, testAuth } from '../../lib/k8s/apiProxy';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import { ClusterDialog } from '../cluster/Chooser';
+import { DialogTitle } from '../common/Dialog';
 
 export default function AuthToken() {
   const history = useHistory();
@@ -101,7 +101,7 @@ export function PureAuthToken({
   }
 
   return (
-    <Box>
+    <Box component="main">
       <ClusterDialog useCover onClose={onClose} aria-labelledby="authtoken-dialog-title">
         <DialogTitle id="authtoken-dialog-title">{title}</DialogTitle>
         <DialogContent>

--- a/frontend/src/components/account/__snapshots__/AuthToken.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.stories.storyshot
@@ -4,7 +4,7 @@ exports[`Storyshots AuthToken Show Actions 1`] = `
 <div
   id="root"
 >
-  <div
+  <main
     class="MuiBox-root MuiBox-root"
   />
 </div>
@@ -14,7 +14,7 @@ exports[`Storyshots AuthToken Show Error 1`] = `
 <div
   id="root"
 >
-  <div
+  <main
     class="MuiBox-root MuiBox-root"
   >
     <div
@@ -38,6 +38,6 @@ exports[`Storyshots AuthToken Show Error 1`] = `
         </div>
       </div>
     </div>
-  </div>
+  </main>
 </div>
 `;

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -1,5 +1,5 @@
 import { InlineIcon } from '@iconify/react';
-import { Box, Button, DialogTitle, withStyles } from '@material-ui/core';
+import { Box, Button, withStyles } from '@material-ui/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -12,6 +12,7 @@ import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import { setConfig } from '../../redux/actions/actions';
 import { ClusterDialog } from '../cluster/Chooser';
 import { Loader } from '../common';
+import { DialogTitle } from '../common/Dialog';
 import Empty from '../common/EmptyContent';
 import OauthPopup from '../oidcauth/OauthPopup';
 
@@ -220,13 +221,6 @@ export function PureAuthChooser({
 }: PureAuthChooserProps) {
   const { t } = useTranslation('auth');
 
-  const focusedRef = React.useCallback(node => {
-    if (node !== null) {
-      node.setAttribute('tabindex', '-1');
-      node.focus();
-    }
-  }, []);
-
   function onClose() {
     // Do nothing because we're not supposed to close on backdrop click or escape.
   }
@@ -234,15 +228,15 @@ export function PureAuthChooser({
   return (
     <ClusterDialog useCover onClose={onClose} aria-labelledby="authchooser-dialog-title">
       {testingAuth ? (
-        <Box textAlign="center">
-          <DialogTitle ref={focusedRef} id="authchooser-dialog-title">
+        <Box component="main" textAlign="center">
+          <DialogTitle id="authchooser-dialog-title" focusTitle>
             {testingTitle}
           </DialogTitle>
           <Loader title={t('Testing auth')} />
         </Box>
       ) : (
-        <Box display="flex" flexDirection="column" alignItems="center">
-          <DialogTitle ref={focusedRef} id="authchooser-dialog-title">
+        <Box component="main" display="flex" flexDirection="column" alignItems="center">
+          <DialogTitle id="authchooser-dialog-title" focusTitle>
             {title}
           </DialogTitle>
           {!error ? (

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@iconify/react';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Card from '@material-ui/core/Card';
@@ -6,7 +7,6 @@ import CardContent from '@material-ui/core/CardContent';
 import Dialog, { DialogProps } from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import SvgIcon from '@material-ui/core/SvgIcon';
@@ -22,6 +22,7 @@ import { useCluster, useClustersConf } from '../../lib/k8s';
 import { Cluster } from '../../lib/k8s/cluster';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import { ReactComponent as LogoLight } from '../../resources/logo-light.svg';
+import { DialogTitle } from '../common/Dialog';
 import Loader from '../common/Loader';
 
 const useClusterTitleStyle = makeStyles(theme => ({
@@ -261,45 +262,52 @@ function Chooser(props: ClusterDialogProps) {
   }
 
   const clusterList = Object.values(clusters || {});
+  if (!show) {
+    return null;
+  }
 
   return (
-    <ClusterDialog
-      open={show}
-      onClose={onClose || handleClose}
-      aria-labelledby="chooser-dialog-title"
-      aria-busy={clusterList.length === 0 && clusters === null}
-      {...otherProps}
-    >
-      <DialogTitle id="chooser-dialog-title">{t('Choose a cluster')}</DialogTitle>
+    <Box component="main">
+      <ClusterDialog
+        open={show}
+        onClose={onClose || handleClose}
+        aria-labelledby="chooser-dialog-title"
+        aria-busy={clusterList.length === 0 && clusters === null}
+        {...otherProps}
+      >
+        <DialogTitle id="chooser-dialog-title" focusTitle>
+          {t('Choose a cluster')}
+        </DialogTitle>
 
-      {clusterList.length === 0 ? (
-        <React.Fragment>
-          {clusters === null ? (
-            <>
-              <DialogContentText>{t('Wait while fetching clusters…')}</DialogContentText>
-              <Loader title={t('Loading cluster information')} />
-            </>
-          ) : (
-            <>
-              <DialogContentText>
-                {t('There seems to be no clusters configured…')}
-              </DialogContentText>
-              <DialogContentText>
-                {t('Please make sure you have at least one cluster configured.')}
-              </DialogContentText>
-              {helpers.isElectron() && (
+        {clusterList.length === 0 ? (
+          <React.Fragment>
+            {clusters === null ? (
+              <>
+                <DialogContentText>{t('Wait while fetching clusters…')}</DialogContentText>
+                <Loader title={t('Loading cluster information')} />
+              </>
+            ) : (
+              <>
                 <DialogContentText>
-                  {t('Or try running Headlamp with a different kube config.')}
+                  {t('There seems to be no clusters configured…')}
                 </DialogContentText>
-              )}
-            </>
-          )}
-        </React.Fragment>
-      ) : (
-        <ClusterList clusters={clusterList} onButtonClick={handleButtonClick} />
-      )}
-      {children}
-    </ClusterDialog>
+                <DialogContentText>
+                  {t('Please make sure you have at least one cluster configured.')}
+                </DialogContentText>
+                {helpers.isElectron() && (
+                  <DialogContentText>
+                    {t('Or try running Headlamp with a different kube config.')}
+                  </DialogContentText>
+                )}
+              </>
+            )}
+          </React.Fragment>
+        ) : (
+          <ClusterList clusters={clusterList} onButtonClick={handleButtonClick} />
+        )}
+        {children}
+      </ClusterDialog>
+    </Box>
   );
 }
 

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -1,11 +1,53 @@
+import { Typography } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import Dialog, { DialogProps } from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
+import MuiDialogTitle, { DialogTitleProps } from '@material-ui/core/DialogTitle';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
+export interface OurDialogTitleProps extends DialogTitleProps {
+  /** true if you want the title focused in the dialog */
+  focusTitle?: boolean;
+}
+
+/**
+ * This is like Material-ui DialogTitle but fixes some a11y issues.
+ *
+ * First, it needs a h1 because other page content is aria-diable=true'd
+ *
+ * Additionally, it also focuses the title text as that is where
+ * reading can begin.
+ */
+export function DialogTitle(props: OurDialogTitleProps) {
+  const { children, focusTitle, ...other } = props;
+  const focusedRef = React.useCallback(node => {
+    if (node !== null) {
+      if (focusTitle) {
+        node.setAttribute('tabindex', '-1');
+        node.focus();
+      }
+    }
+  }, []);
+
+  return (
+    <MuiDialogTitle {...other}>
+      <Typography
+        ref={focusedRef}
+        variant="h1"
+        style={{
+          fontSize: '1.25rem',
+          fontWeight: 500,
+          lineHeight: 1.6,
+        }}
+      >
+        {children}
+      </Typography>
+    </MuiDialogTitle>
+  );
+}
 
 export interface ConfirmDialogProps extends DialogProps {
   title: string;

--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.stories.storyshot
@@ -13,14 +13,15 @@ exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Name
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -32,14 +33,15 @@ exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Namespace
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -51,14 +53,15 @@ exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Creation
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -70,14 +73,15 @@ exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Labels
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
@@ -135,14 +139,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Name
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -154,14 +159,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Namespace
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -173,14 +179,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Creation
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -192,14 +199,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Labels
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
@@ -242,14 +250,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Some extra label 1
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -261,14 +270,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Some extra label 2
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -280,14 +290,15 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Some extra label 3
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -314,14 +325,15 @@ exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Name
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -333,14 +345,15 @@ exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Namespace
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -352,14 +365,15 @@ exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Creation
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <span
             class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -371,14 +385,15 @@ exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Labels
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
@@ -421,14 +436,15 @@ exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
       <tr
         class="MuiTableRow-root"
       >
-        <td
+        <th
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+          role="cell"
+          scope="row"
         >
           Controlled by
-        </td>
+        </th>
         <td
           class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-          scope="row"
         >
           <a
             class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -407,8 +407,10 @@ export function NameValueTable(props: NameValueTableProps) {
           if (hide) return null;
           return (
             <TableRow key={i}>
-              <TableCell className={classes.metadataNameCell}>{name}</TableCell>
-              <TableCell scope="row" className={classes.metadataCell}>
+              <TableCell component="th" scope="row" className={classes.metadataNameCell}>
+                {name}
+              </TableCell>
+              <TableCell className={classes.metadataCell}>
                 <Value value={value} />
               </TableCell>
             </TableRow>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -166,14 +166,15 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   <tr
                     class="MuiTableRow-root"
                   >
-                    <td
+                    <th
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                      role="cell"
+                      scope="row"
                     >
                       Name
-                    </td>
+                    </th>
                     <td
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-                      scope="row"
                     >
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -185,14 +186,15 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   <tr
                     class="MuiTableRow-root"
                   >
-                    <td
+                    <th
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                      role="cell"
+                      scope="row"
                     >
                       Namespace
-                    </td>
+                    </th>
                     <td
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-                      scope="row"
                     >
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -204,14 +206,15 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   <tr
                     class="MuiTableRow-root"
                   >
-                    <td
+                    <th
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                      role="cell"
+                      scope="row"
                     >
                       Creation
-                    </td>
+                    </th>
                     <td
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-                      scope="row"
                     >
                       <span
                         class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
@@ -223,14 +226,15 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   <tr
                     class="MuiTableRow-root"
                   >
-                    <td
+                    <th
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
+                      role="cell"
+                      scope="row"
                     >
                       Test Col
-                    </td>
+                    </th>
                     <td
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-                      scope="row"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"

--- a/frontend/src/i18n/ThemeProviderNexti18n.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.tsx
@@ -21,9 +21,12 @@ function getLocale(locale: string): typeof enUS {
  *  Because Material UI is localized as well.
  */
 const ThemeProviderNexti18n: React.FunctionComponent<{ theme: Theme }> = props => {
-  const { i18n, ready: isI18nReady } = useTranslation(['sidebar', 'frequent', 'glossary', 'auth'], {
-    useSuspense: false,
-  });
+  const { i18n, ready: isI18nReady } = useTranslation(
+    ['sidebar', 'frequent', 'glossary', 'auth', 'resource'],
+    {
+      useSuspense: false,
+    }
+  );
   const [lang, setLang] = useState(i18n.language);
 
   function changeLang(lng: string) {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,7 +7,26 @@ ReactDOM.render(<App />, document.getElementById('root'));
 
 if (process.env.NODE_ENV !== 'production') {
   const axe = require('@axe-core/react');
-  axe(React, ReactDOM, 500);
+  const axeCore = require('axe-core');
+
+  if (process.env.REACT_APP_SKIP_A11Y !== 'true') {
+    axe(React, ReactDOM, 500, undefined, undefined, (results: typeof axeCore.AxeResults) => {
+      if (results.violations.length > 0) {
+        console.error('axe results', results);
+        alert(
+          'Accessibility issues found. See developer console. ' +
+            '`REACT_APP_SKIP_A11Y=true make run-frontend` to disable alert.'
+        );
+      }
+    }).then(() => {
+      // Show the logs at end of other console logs (and after the alert).
+      // So they are easier to read.
+      axe(React, ReactDOM, 500, { disableDeduplicate: true });
+    });
+  } else {
+    // Only show the logs.
+    axe(React, ReactDOM, 500);
+  }
 }
 
 // If you want your app to work offline and load faster, you can change

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -430,6 +430,7 @@ export const ROUTES: {
 export const NotFoundRoute = {
   path: '*',
   exact: true,
+  name: `Whoops! This page doesn't exist`,
   component: () => <NotFoundComponent />,
   sidebar: null,
   noAuthRequired: true,


### PR DESCRIPTION
- Issues are logged _last_ in the console. To make them easier to read whilst the console is noisy.
- If any issues remain, an alert() is done to warn developers when Headlamp is run in development mode. 

Hopefully these measures will help prevent more issues escaping review, since the console log was quite noisy and can be forgotten.


Additionally:
- Started a section in the documentation on a11y tools.
- fixes a number of the reported a11y issues
- storybook was broken because of an iconify issue (added test of storybook to CI)
- apart from a11y messages in the console, it removes a few more lines from the dev console related to i18n


## How to use

During development
- "axe react" a11y messages should be printed at the end of the development console now (rather than somewhere in the middle).
- an alert message is shown if any a11y issues are reported

To disable the alert message during development, use the following:
```bash
REACT_APP_SKIP_A11Y=true make run-frontend
```

You can either introduce an a11y issue, or checkout the first commit to see the behaviour (because it will report issues).

## Testing done

- [x] go to each route, load the page and no alert and no a11y issues reported
- [x] with REACT_APP_SKIP_A11Y=true no alert is shown
- [x] storybook builds and runs
