### PR TITLE
github: Fix golang version to be 1.17 rather than latest

### DIFF
--- a/.github/workflows/app-artifacts-linux.yml
+++ b/.github/workflows/app-artifacts-linux.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: 16.x
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
     - name: App linux
       run: |
         make app-linux

--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: 16.x
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
     - name: Dependencies
       run: brew install make
     - name: App Mac

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: 16.x
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
     - name: Dependencies
       uses: crazy-max/ghaction-chocolatey@v1
       with:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15.4'
+        go-version: 1.17
       id: go
 
     - name: Check out code


### PR DESCRIPTION
There's an incompatibility with some libraries in the latest version.