### PR TITLE
Update: nodeSelector

### DIFF
--- a/kubernetes-headlamp.yaml
+++ b/kubernetes-headlamp.yaml
@@ -41,4 +41,4 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
       nodeSelector:
-        'beta.kubernetes.io/os': linux
+        'kubernetes.io/os': linux


### PR DESCRIPTION
The other has been deprecated since kubernetes v1.14

# update node selector

Updates the node selector to get rid off this warning:

```
service/headlamp created
Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
deployment.apps/headlamp created
```