### PR TITLE
Improve terminal UX

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -25,7 +25,7 @@ const useStyle = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     '& .xterm ': {
-      height: '500px', // So the terminal doesn't stay shrunk when shrinking vertically and maximizing again.
+      height: '100vh', // So the terminal doesn't stay shrunk when shrinking vertically and maximizing again.
       '& .xterm-viewport': {
         width: 'initial !important', // BugFix: https://github.com/xtermjs/xterm.js/issues/3564#issuecomment-1004417440
       },

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -182,11 +182,15 @@ export default function Terminal(props: TerminalProps) {
   }
 
   function shellConnectFailed(xterm: XTerminal) {
+    const command = getCurrentShellCommand();
     if (isLastShell()) {
       xterm.clear();
-      xterm.write(t('Failed to connect…') + '\r\n');
+      if ((xterm as any).connected) {
+        xterm.write(t('Failed to run command "{{command}}"…', { command }) + '\r\n');
+      } else {
+        xterm.write(t('Failed to connect…') + '\r\n');
+      }
     } else {
-      const command = getCurrentShellCommand();
       xterm.write(t('Failed to run "{{ command }}"', { command }) + '\r\n');
       tryNextShell();
     }

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -1,11 +1,11 @@
 import 'xterm/css/xterm.css';
+import { Box } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import Dialog, { DialogProps } from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import FormControl from '@material-ui/core/FormControl';
-import Grid from '@material-ui/core/Grid';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
@@ -19,13 +19,35 @@ import Pod from '../../lib/k8s/pod';
 const decoder = new TextDecoder('utf-8');
 const encoder = new TextEncoder();
 
-const useStyle = makeStyles(() => ({
+const useStyle = makeStyles(theme => ({
   dialogContent: {
-    height: '80%',
-    minHeight: '80%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    '& .xterm ': {
+      height: '500px', // So the terminal doesn't stay shrunk when shrinking vertically and maximizing again.
+      '& .xterm-viewport': {
+        width: 'initial !important', // BugFix: https://github.com/xtermjs/xterm.js/issues/3564#issuecomment-1004417440
+      },
+    },
+    '& #xterm-container': {
+      overflow: 'hidden',
+      width: '100%',
+      '& .terminal.xterm': {
+        padding: 10,
+      },
+    },
   },
   containerFormControl: {
     minWidth: '11rem',
+  },
+  terminalBox: {
+    paddingTop: theme.spacing(1),
+    flex: 1,
+    width: '100%',
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column-reverse',
   },
 }));
 
@@ -57,7 +79,11 @@ export default function Terminal(props: TerminalProps) {
     xterm.open(containerRef);
 
     xterm.onData(data => {
-      send(data);
+      send(0, data);
+    });
+
+    xterm.onResize(size => {
+      send(4, `{"Width":${size.cols},"Height":${size.rows}}`);
     });
 
     // Allow copy/paste in terminal
@@ -79,22 +105,34 @@ export default function Terminal(props: TerminalProps) {
     fitAddon.fit();
   }
 
-  function send(data: string) {
+  function send(channel: number, data: string) {
     const socket = execRef.current.getSocket();
 
     // We should only send data if the socket is ready.
     if (!socket || socket.readyState !== 1) {
-      console.debug('Socket not ready...', socket);
+      console.debug('Could not send data to exec: Socket not ready...', socket);
       return;
     }
 
     const encoded = encoder.encode(data);
-    const buffer = new Uint8Array([0, ...encoded]);
+    const buffer = new Uint8Array([channel, ...encoded]);
 
     socket.send(buffer);
   }
 
+  // Channels:
+  // 0: stdin
+  // 1: stdout
+  // 2: stderr
+  // 3: server error
+  // 4: resize channel
   function onData(xterm: XTerminal, bytes: ArrayBuffer) {
+    // Only show data from stdout, stderr and server error channel.
+    const channel = new Int8Array(bytes.slice(0, 1))[0];
+    if (channel < 1 || channel > 3) {
+      return;
+    }
+
     // The first byte is discarded because it just identifies whether
     // this data is from stderr, stdout, or stdin.
     const data = bytes.slice(1);
@@ -102,6 +140,16 @@ export default function Terminal(props: TerminalProps) {
 
     if (bytes.byteLength < 2) {
       return;
+    }
+
+    // Send resize command to server once connection is establised.
+    if (!(xterm as any).connected && !!text) {
+      xterm.clear();
+      (async function () {
+        send(4, `{"Width":${xterm.cols},"Height":${xterm.rows}}`);
+      })();
+      (xterm as any).connected = true;
+      console.debug('Terminal is now connected');
     }
 
     xterm.write(text);
@@ -145,11 +193,18 @@ export default function Terminal(props: TerminalProps) {
         setupTerminal(terminalContainerRef, xtermRef.current, fitAddonRef.current);
       })();
 
+      const handler = () => {
+        fitAddonRef.current.fit();
+      };
+
+      window.addEventListener('resize', handler);
+
       return function cleanup() {
         xtermRef.current.dispose();
         if (execRef.current) {
           execRef.current.cancel();
         }
+        window.removeEventListener('resize', handler);
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -174,31 +229,33 @@ export default function Terminal(props: TerminalProps) {
     <Dialog maxWidth="lg" scroll="paper" fullWidth onClose={onClose} keepMounted {...other}>
       <DialogTitle>{t('Terminal: {{ itemName }}', { itemName: item.metadata.name })}</DialogTitle>
       <DialogContent className={classes.dialogContent}>
-        <Grid container direction="column" spacing={1}>
-          <Grid item>
-            <FormControl className={classes.containerFormControl}>
-              <InputLabel shrink id="container-name-chooser-label">
-                {t('glossary|Container')}
-              </InputLabel>
-              <Select
-                labelId="container-name-chooser-label"
-                id="container-name-chooser"
-                value={container !== null ? container : getDefaultContainer()}
-                onChange={handleContainerChange}
-              >
-                {item &&
-                  item.spec.containers.map(({ name }) => (
-                    <MenuItem value={name} key={name}>
-                      {name}
-                    </MenuItem>
-                  ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item>
-            <div id="xterm" ref={x => setTerminalContainerRef(x)} className="terminal" />
-          </Grid>
-        </Grid>
+        <Box>
+          <FormControl className={classes.containerFormControl}>
+            <InputLabel shrink id="container-name-chooser-label">
+              {t('glossary|Container')}
+            </InputLabel>
+            <Select
+              labelId="container-name-chooser-label"
+              id="container-name-chooser"
+              value={container !== null ? container : getDefaultContainer()}
+              onChange={handleContainerChange}
+            >
+              {item &&
+                item.spec.containers.map(({ name }) => (
+                  <MenuItem value={name} key={name}>
+                    {name}
+                  </MenuItem>
+                ))}
+            </Select>
+          </FormControl>
+        </Box>
+        <Box className={classes.terminalBox}>
+          <div
+            id="xterm-container"
+            ref={x => setTerminalContainerRef(x)}
+            style={{ flex: 1, display: 'flex', flexDirection: 'column-reverse' }}
+          />
+        </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} color="primary">

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -12,6 +12,9 @@ export interface KubePod extends KubeObjectInterface {
   spec: {
     containers: KubeContainer[];
     nodeName: string;
+    nodeSelector?: {
+      [key: string]: string;
+    };
   };
   status: {
     conditions: KubeCondition[];


### PR DESCRIPTION
This commit improves the terminal UX by:

- [X] Resizing the terminal automatically when a window resizes
- [X] Trying different shells instead of just one
- [X] Showing errors both for connect failure (404, etc.) and for command-not-found
- [X] Exiting the shell (Ctrl+D or `exit`) closes the terminal (and when opening it again, it'll show a new connection instead of keeping the previous contents)

## Testing done

1. Go to a pod where you can exec into
2. Press the terminal button
3. Type something like: ls -la
4. Shrink the browser window so the results from the previous command have to be wrapped
5. Verify that only the terminal console gets a scrollbar
6. With a terminal connected to the shell, type exit and verify that the terminal is closed; open it again and it'll be connected without an issue