### PR TITLE
frontend: Make the rows-per-page setting persist among views

### DIFF
--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -10,6 +10,7 @@ import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import helpers from '../../helpers';
 import Empty from './EmptyContent';
 import { ValueLabel } from './Label';
 import Loader from './Loader';
@@ -114,8 +115,10 @@ export default function SimpleTable(props: SimpleTableProps) {
   const [page, setPage] = React.useState(0);
   const [currentData, setCurrentData] = React.useState(data);
   const [displayData, setDisplayData] = React.useState(data);
-  const rowsPerPageOptions = props.rowsPerPage || [5, 10, 50];
-  const [rowsPerPage, setRowsPerPage] = React.useState(rowsPerPageOptions[0]);
+  const rowsPerPageOptions = props.rowsPerPage || [15, 25, 50];
+  const [rowsPerPage, setRowsPerPage] = React.useState(
+    helpers.getTablesRowsPerPage() || rowsPerPageOptions[0]
+  );
   const classes = useTableStyle();
   const [isIncreasingOrder, setIsIncreasingOrder] = React.useState(
     !defaultSortingColumn || defaultSortingColumn > 0
@@ -133,7 +136,9 @@ export default function SimpleTable(props: SimpleTableProps) {
   function handleChangeRowsPerPage(
     event: React.ChangeEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLInputElement>
   ) {
-    setRowsPerPage(+event.target.value);
+    const numRows = +event.target.value;
+    helpers.setTablesRowsPerPage(numRows);
+    setRowsPerPage(numRows);
     setPage(0);
   }
 

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -152,6 +152,16 @@ function getRecentClusters() {
   return JSON.parse(currentClustersStr) as string[];
 }
 
+const tablesRowsPerPageKey = 'tables_rows_per_page';
+
+function getTablesRowsPerPage() {
+  return parseInt(localStorage.getItem(tablesRowsPerPageKey) || '5');
+}
+
+function setTablesRowsPerPage(perPage: number) {
+  localStorage.setItem(tablesRowsPerPageKey, perPage.toString());
+}
+
 const exportFunctions = {
   getBaseUrl,
   isDevMode,
@@ -161,6 +171,8 @@ const exportFunctions = {
   setAppVersion,
   setRecentCluster,
   getRecentClusters,
+  getTablesRowsPerPage,
+  setTablesRowsPerPage,
 };
 
 export default exportFunctions;


### PR DESCRIPTION
This patch makes the chosen rows per page persistent across the use of the SimpleTable component. Based on what's requested in #522 .

Testing:
1. Go to the pods' list, verify that the usual 15 items per page are set by default
2. Choose a different number of rows per page
3. Go to a different view and verify that it's the previously chosen value that is used now by default