### PR TITLE
app github: Build windows app without bash

### DIFF
--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -27,8 +27,8 @@ jobs:
       with:
         args: install make
     - name: App Windows
+      shell: pwsh
       run: |
-        npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
         make app-win
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/app/package.json
+++ b/app/package.json
@@ -8,15 +8,15 @@
   "scripts": {
     "compile-electron": "babel electron --out-dir electron/ --extensions .ts",
     "start": "cd ../ && make backend && make run-backend  & cd ../frontend/ && export BROWSER=none && npm start",
-    "prod-deps": "mkdirp prod_deps && cd ./prod_deps && cp ../package.json ../package-lock.json . && npm i --only=prod && rm -rf ./node_modules/.bin",
-    "copy-icons": "mkdirp build/icons && cp ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
+    "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
+    "copy-icons": "mkdirp build/icons && copyfiles -f ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && npm run prod-deps && electron-builder --dir --publish never",
     "package": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && electron-builder build --publish never",
     "dev": "npm run compile-electron && cross-env ELECTRON_DEV=1 electron .",
     "dev-only-app": "npm run compile-electron && cross-env ELECTRON_DEV=1 ELECTRON_START_URL=http://localhost:3000 EXTERNAL_SERVER=true electron .",
     "i18n": "npx --no-install i18next ./electron/main.ts -c ./electron/i18next-parser.config.js",
     "test": "jest",
-    "copy-plugins": "rm -rf build/.plugins && mkdirp build/.plugins && copyfiles ../.plugins build/.plugins"
+    "copy-plugins": "npx --no-install rimraf build/.plugins && mkdirp build/.plugins && copyfiles ../.plugins build/.plugins"
   },
   "build": {
     "appId": "com.kinvolk.headlamp",


### PR DESCRIPTION
## Bash, but also... not bash.

Before we were building the app on windows using bash.

- [x] We should support building the app on windows without bash. However, bugs keep creeping in because we only test making it with bash on CI.

## Testing done

This now works on windows with cmd (and make installed):
```bash
make app-win

# Also...
cd app
npm run copy-icons
npm run prod-deps
npm run copy-plugins
```
