### PR TITLE
app: Kill Headlamp server process synchronously

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,4 +1,4 @@
-import { ChildProcessWithoutNullStreams, exec, spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams, execSync, spawn } from 'child_process';
 import { app, BrowserWindow, ipcMain, Menu, MenuItem, screen, shell } from 'electron';
 import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import log from 'electron-log';
@@ -97,7 +97,7 @@ function quitServerProcess() {
     process.kill(-serverProcess.pid);
   } else if (process.platform === 'win32' && serverProcess) {
     // Otherwise on Windows the process will stick around.
-    exec('taskkill /pid ' + serverProcess.pid + ' /T /F');
+    execSync('taskkill /pid ' + serverProcess.pid + ' /T /F');
   }
 
   serverProcess.stdin.destroy();


### PR DESCRIPTION
When the app is quitting, if we try to kill the Headlamp server
process asynchronously, there's a race condition which may end up in
the electron process being quit before the server kill instruction is
actually done. The result was that the Headlamp server would be left
running in Windows most of the times.

Testing done:
1. Launch the app, verify there's a headlamp-server process running
2. Quit the app: verify there's no headlamp-server process running