### PR TITLE
Fix (again) + help quitting server

### DIFF
--- a/app/electron/locales/en/app.json
+++ b/app/electron/locales/en/app.json
@@ -28,5 +28,10 @@
   "Minimize": "Minimize",
   "Bring All to Front": "Bring All to Front",
   "Documentation": "Documentation",
-  "Open an Issue": "Open an Issue"
+  "Open an Issue": "Open an Issue",
+  "Another process is running": "Another process is running",
+  "Looks like another process is already running. Continue by terminating that process automatically, or quit?": "Looks like another process is already running. Continue by terminating that process automatically, or quit?",
+  "Continue": "Continue",
+  "Failed to quit the other running process": "Failed to quit the other running process",
+  "Could not quit the other running process, PIDs: {{ process_list }}. Please stop that process and relaunch the app.": "Could not quit the other running process, PIDs: {{ process_list }}. Please stop that process and relaunch the app."
 }

--- a/app/electron/locales/es/app.json
+++ b/app/electron/locales/es/app.json
@@ -28,5 +28,10 @@
   "Minimize": "Minimizar",
   "Bring All to Front": "Traer todo al frente",
   "Documentation": "Documentación",
-  "Open an Issue": "Abrir un incidente"
+  "Open an Issue": "Abrir un incidente",
+  "Another process is running": "Un otro proceso está corriendo",
+  "Looks like another process is already running. Continue by terminating that process automatically, or quit?": "Parece que ya hay un otro proceso corriendo. Continuar y terminar el proceso automaticamente ou salir?",
+  "Continue": "Continuar",
+  "Failed to quit the other running process": "Fallo al quitar el otro proceso en ejecución",
+  "Could not quit the other running process, PIDs: {{ process_list }}. Please stop that process and relaunch the app.": "No se ha podido terminar el otro proceso, PIDs:  {{ process_list }}. Por favor, termine el otro proceso y vuelva a lanzar la aplicación."
 }

--- a/app/electron/locales/pt/app.json
+++ b/app/electron/locales/pt/app.json
@@ -28,5 +28,10 @@
   "Minimize": "Minimizar",
   "Bring All to Front": "Passar tudo para a frente",
   "Documentation": "Documentação",
-  "Open an Issue": "Abrir um incidente"
+  "Open an Issue": "Abrir um incidente",
+  "Another process is running": "Há outro processo em execução",
+  "Looks like another process is already running. Continue by terminating that process automatically, or quit?": "Parece que há outro processo em execução. Continuar com a eliminação automática desse processo ou sair?",
+  "Continue": "Continuar",
+  "Failed to quit the other running process": "Falha ao eliminar o outro processo em execução",
+  "Could not quit the other running process, PIDs: {{ process_list }}. Please stop that process and relaunch the app.": "Não foi possível eliminar o outro processo em execução. PIDs: {{ process_list }}. Por favor pare esse processo e reinicie o programa."
 }

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,7 +1,7 @@
-import { ChildProcessWithoutNullStreams, execSync, spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { app, BrowserWindow, ipcMain, Menu, MenuItem, screen, shell } from 'electron';
-import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import log from 'electron-log';
+import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import fs from 'fs';
 import { i18n as I18n } from 'i18next';
 import open from 'open';
@@ -91,14 +91,6 @@ function quitServerProcess() {
 
   intentionalQuit = true;
   log.info('stopping server process...');
-  if (process.platform !== 'win32') {
-    // Negative pid because it should kill the whole group of processes:
-    //    https://azimi.me/2014/12/31/kill-child_process-node-js.html
-    process.kill(-serverProcess.pid);
-  } else if (process.platform === 'win32' && serverProcess) {
-    // Otherwise on Windows the process will stick around.
-    execSync('taskkill /pid ' + serverProcess.pid + ' /T /F');
-  }
 
   serverProcess.stdin.destroy();
   // @todo: should we try and end the process a bit more gracefully?

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -363,7 +363,6 @@ function startElecron() {
         preload: `${__dirname}/preload.js`,
       },
     });
-    mainWindow.loadURL(startUrl);
 
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
       // allow all urls starting with app startUrl to open in electron
@@ -466,6 +465,9 @@ function startElecron() {
       serverProcess = startServer();
       attachServerEventHandlers(serverProcess);
     }
+
+    // Finally load the frontend
+    mainWindow.loadURL(startUrl);
   }
 
   if (disableGPU) {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,7 +1,8 @@
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
-import { app, BrowserWindow, ipcMain, Menu, MenuItem, screen, shell } from 'electron';
-import log from 'electron-log';
+import { ChildProcessWithoutNullStreams, execSync, spawn } from 'child_process';
+import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItem, screen, shell } from 'electron';
 import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
+import log from 'electron-log';
+import find_process from 'find-process';
 import fs from 'fs';
 import { i18n as I18n } from 'i18next';
 import open from 'open';
@@ -299,6 +300,24 @@ function setMenu(i18n: I18n) {
   Menu.setApplicationMenu(menu);
 }
 
+async function getRunningHeadlampPIDs() {
+  const processes = await find_process('name', 'headlamp-server.*');
+  if (processes.length === 0) {
+    return null;
+  }
+
+  return processes.map(pInfo => pInfo.pid);
+}
+
+function killProcess(pid: number) {
+  if (process.platform === 'win32') {
+    // Otherwise on Windows the process will stick around.
+    execSync('taskkill /pid ' + pid + ' /T /F');
+  } else {
+    process.kill(pid, 'SIGHUP');
+  }
+}
+
 function startElecron() {
   log.transports.file.level = 'info';
   log.info('App starting...');
@@ -315,7 +334,7 @@ function startElecron() {
 
   setMenu(i18n);
 
-  function createWindow() {
+  async function createWindow() {
     let frontendPath = '';
     if (isDev) {
       frontendPath = path.resolve('..', 'frontend', 'build', 'index.html');
@@ -375,6 +394,75 @@ function startElecron() {
     });
 
     if (!useExternalServer) {
+      const runningHeadlamp = await getRunningHeadlampPIDs();
+      let shouldWaitForKill = true;
+
+      if (!!runningHeadlamp) {
+        const resp = dialog.showMessageBoxSync(mainWindow, {
+          // Avoiding mentioning Headlamp here because it may run under a different name depending on branding (plugins).
+          title: i18n.t('Another process is running'),
+          message: i18n.t(
+            'Looks like another process is already running. Continue by terminating that process automatically, or quit?'
+          ),
+          type: 'question',
+          buttons: [i18n.t('Continue'), i18n.t('Quit')],
+        });
+
+        if (resp === 0) {
+          runningHeadlamp.forEach(pid => {
+            try {
+              killProcess(pid);
+            } catch (e) {
+              console.log(`Failed to quit headlamp-servere:`, e.message);
+              shouldWaitForKill = false;
+            }
+          });
+        } else {
+          mainWindow.close();
+          return;
+        }
+      }
+
+      // If we reach here, then we attempted to kill headlamp-server. Let's make sure it's killed
+      // before starting our own, or else we may end up in a race condition (failing to start the
+      // new one before the existing one is fully killed).
+      if (!!runningHeadlamp && shouldWaitForKill) {
+        let stillRunning = true;
+        let timeWaited = 0;
+        const maxWaitTime = 3000; // ms
+        // @todo: Use an iterative back-off strategy for the wait (so we can start by waiting for shorter times).
+        for (let tries = 1; timeWaited < maxWaitTime && stillRunning; tries++) {
+          console.debug(
+            `Checking if Headlamp is still running after we asked it to be killed; ${tries} ${timeWaited}/${maxWaitTime}ms wait.`
+          );
+
+          // Wait (10 * powers of 2) ms with a max of 250 ms
+          const waitTime = Math.min(10 * tries ** 2, 250); // ms
+          await new Promise(f => setTimeout(f, waitTime));
+
+          timeWaited += waitTime;
+
+          stillRunning = !!(await getRunningHeadlampPIDs());
+          console.debug(stillRunning ? 'Still running...' : 'No longer running!');
+        }
+      }
+
+      // If we couldn't kill the process, warn the user and quit.
+      const processes = await getRunningHeadlampPIDs();
+      if (!!processes) {
+        dialog.showMessageBoxSync({
+          type: 'warning',
+          title: i18n.t('Failed to quit the other running process'),
+          message: i18n.t(
+            `Could not quit the other running process, PIDs: {{ process_list }}. Please stop that process and relaunch the app.`,
+            { process_list: processes }
+          ),
+        });
+
+        mainWindow.close();
+        return;
+      }
+
       serverProcess = startServer();
       attachServerEventHandlers(serverProcess);
     }

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -39,12 +39,6 @@ function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
     ? path.resolve('../backend/headlamp-server')
     : path.join(process.resourcesPath, './headlamp-server');
 
-  const options = { shell: true, detached: false };
-  if (process.platform !== 'win32' && !isDev) {
-    // This makes the child processes a separate group, for easier killing.
-    options.detached = true;
-  }
-
   let serverArgs = [];
   if (!!args.kubeconfig) {
     serverArgs = serverArgs.concat(['--kubeconfig', args.kubeconfig]);
@@ -62,6 +56,12 @@ function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
 
   serverArgs = serverArgs.concat(flags);
   console.log('arguments passed to backend server', serverArgs);
+
+  // We run detached but not in shell, otherwise it's hard to make sure the
+  // server process gets killed. When changing these options, please make sure
+  // to test quitting the app in the different platforms and making sure the
+  // server process has been correctly quit.
+  const options = { detached: true };
 
   return spawn(serverFilePath, serverArgs, options);
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
         "electron-log": "^4.4.1",
+        "find-process": "^1.4.7",
         "i18next": "^20.6.1",
         "i18next-node-fs-backend": "^2.1.3",
         "mkdirp": "^1.0.4",
@@ -3630,7 +3631,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4150,7 +4150,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5152,6 +5151,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-process": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "debug": "^4.1.1"
+      },
+      "bin": {
+        "find-process": "bin/find-process.js"
+      }
+    },
+    "node_modules/find-process/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5566,7 +5586,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7504,8 +7523,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8865,7 +8883,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12548,7 +12565,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12958,7 +12974,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -13748,6 +13763,23 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-process": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -14087,8 +14119,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -15573,8 +15604,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -16666,7 +16696,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -133,6 +133,7 @@
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "electron-log": "^4.4.1",
+    "find-process": "^1.4.7",
     "i18next": "^20.6.1",
     "i18next-node-fs-backend": "^2.1.3",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
I reflected more on the discussion about whether we should ask users to terminate running Headlamp server processes and remembered that any users of current Headlamp versions on Windows will hit this problem until they update to the new version.
So I started fixing this, working from Linux, and noticed that Linux was also leaving its headlamp-server processes running after the app quit. It also had an issue (we were killing the PID using its negative version, for killing a process group, but on Linux the process doesn't run detached, so there was an uncaught exception...)

Therefore, I worked again on making sure that we can start and finish the headlamp-server process from within the app without resorting to killing it by PID (since we do have a subprocess wrapper for it). This was not working because we were:
1. Running detached only on windows (so the negative kill in Linux was broken)
2. Running with a shell on non-windows, so killing the process would just kill the `sh -c` command (parent) and not the actual `headlamp-server`

Here is the dialog asking the user whether to kill ongoing processes:
![confirmation dialog for quitting other headlamp servers](https://user-images.githubusercontent.com/1029635/172730431-872fbf27-6384-45d5-8ba4-999c0db873ff.png)

## Testing
I have tested running on both Linux and Windows. Not yet on Mac. It'd be also nice if someone tried it on Ubuntu as I believe it used to behave differently from Fedora.

- [x] Test on Ubuntu
- [X] Test on Windows
- [x] Test on Mac

Test 1:
1. Run `make run-backend` to have a running process
3. Launch the Headlamp app (or `cd app && npm run dev`) -> There should be a dialog asking to kill the process or quit
4. Try the "kill" option, the app should start after that
5. Repeat 2 and try the "quit" option, the app should quit

Test 2:
1. Run the app and quit it at slightly different times
2. Do this 10 times. There should be no dialogs or dangling headlamp-server processes

Test 3 (cannot kill):
1. Modify the app code where it checks whether the headlamp-server has been successfully killed (look for attempts and change it to 0)
2. Run the app -> The dialog should now say that it couldn't kill the process, and upon accepting it, it should quit the app.

Test 4:
1. Run headlamp-server as root
2. Then run the Headlamp app as a user -> It should show a dialog saying it couldn't kill the processes

![cannot kill dialog](https://user-images.githubusercontent.com/1029635/172879149-92b83216-8d5b-4085-b1b3-30c286d835e4.png)
