### PR TITLE
frontend: Fix unexpected undefined value in OwnedPodsSection

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -652,7 +652,7 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
       return [];
     }
     return pods.filter(item =>
-      resourceTemplateLabel.every(elem => Object.values(item.metadata.labels).includes(elem))
+      resourceTemplateLabel.every(elem => Object.values(item.metadata.labels || {}).includes(elem))
     );
   }
 


### PR DESCRIPTION
Just hit an error when apparently the labels of a pod are null/undefined but they are not expected to be so in the OwnedPodsSection.