### PR TITLE
desktop: Add headlamp as the custom protocol

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,12 @@
     "afterSign": "mac/scripts/notarize.js",
     "asar": false,
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "protocols": {
+      "name": "headlamp-protocol",
+      "schemes": [
+        "headlamp"
+      ]
+    },
     "linux": {
       "target": [
         {


### PR DESCRIPTION
Adding this patch from #516 so we have it in the release now, in case users with a 0.10.0 need to use this in the future.