### PR TITLE
frontend: Only alert about a11y issues once per session

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,7 @@ import * as serviceWorker from './serviceWorker';
 ReactDOM.render(<App />, document.getElementById('root'));
 
 if (process.env.NODE_ENV !== 'production') {
+  let alreadyWarned = false;
   let axe = require('@axe-core/react');
   if (axe.default) {
     axe = axe.default; //changed to esm module sometimes?
@@ -16,10 +17,13 @@ if (process.env.NODE_ENV !== 'production') {
     axe(React, ReactDOM, 500, undefined, undefined, (results: typeof axeCore.AxeResults) => {
       if (results.violations.length > 0) {
         console.error('axe results', results);
-        alert(
-          'Accessibility issues found. See developer console. ' +
-            '`REACT_APP_SKIP_A11Y=true make run-frontend` to disable alert.'
-        );
+        if (!alreadyWarned) {
+          alreadyWarned = true;
+          alert(
+            'Accessibility issues found. See developer console. ' +
+              '`REACT_APP_SKIP_A11Y=true make run-frontend` to disable alert.'
+          );
+        }
       }
     }).then(() => {
       // Show the logs at end of other console logs (and after the alert).


### PR DESCRIPTION
If there are multiple a11y issues reported by axe, then the UI
becomes unusable with the alert notifications that need to be
acknowledged.
This may lead developers to just run all the time with the skipped
a11y alerts.

So this patch tries to prevent that by allowing only a one-time alert
per session (i.e. if the user refreshes, they should see it again).

fixes #554 