### PR TITLE
frontend: Do not duplicate children in dynamic sidebar items

### DIFF
--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { SidebarEntry } from '../../redux/reducers/ui';
 import store from '../../redux/stores/store';
 
@@ -124,7 +125,8 @@ function prepareRoutes(t: (arg: string) => string) {
   // @todo: Find a better way to avoid modifying the objects in LIST_ITEMS.
   const routes: SidebarEntry[] = JSON.parse(JSON.stringify(LIST_ITEMS));
 
-  for (const item of Object.values(items)) {
+  for (const i of Object.values(items)) {
+    const item = _.cloneDeep(i);
     const parent = item.parent ? routes.find(({ name }) => name === item.parent) : null;
     let placement = routes;
     if (parent) {


### PR DESCRIPTION
When items were set up in the sidebar from a plugin, the object they
were using was the one set up in redux. This meant that any children
of that sidebar entry would be appended to the object's "subList" in
redux and hence that list would grow with multiple equal entries
every time the sidebar was rendered.

This patch prevents that by deep cloning the object before using it.
