### PR TITLE
app: Do not create a one-click installer for Windows

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,13 @@
         "headlamp"
       ]
     },
+    "nsis": {
+      "deleteAppDataOnUninstall": true,
+      "runAfterFinish": true,
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "linux": {
       "target": [
         {


### PR DESCRIPTION
We want to provide Windows users with installation options.
