### PR TITLE
Add scaling UI

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -22,7 +22,7 @@ import {
   KubeContainer,
   KubeContainerStatus,
   KubeObject,
-  KubeObjectInterface,
+  KubeObjectInterface
 } from '../../../lib/k8s/cluster';
 import Pod, { KubePod } from '../../../lib/k8s/pod';
 import { createRouteURL, RouteURLProps } from '../../../lib/router';
@@ -41,6 +41,7 @@ import { useMetadataDisplayStyles } from '.';
 import DeleteButton from './DeleteButton';
 import EditButton from './EditButton';
 import { MetadataDictGrid, MetadataDisplay } from './MetadataDisplay';
+import ScaleButton from './ScaleButton';
 
 export interface ResourceLinkProps extends Omit<LinkProps, 'routeName' | 'params'> {
   name?: string;
@@ -103,7 +104,7 @@ export function MainInfoSection(props: MainInfoSectionProps) {
   let defaultActions: React.ReactNode[] | null = [];
 
   if (!noDefaultActions && resource) {
-    defaultActions = [<EditButton item={resource} />, <DeleteButton item={resource} />];
+    defaultActions = [<ScaleButton item={resource} />, <EditButton item={resource} />, <DeleteButton item={resource} />];
   }
 
   const propsHeaderActions = typeof actions === 'function' ? actions(resource) || [] : actions;

--- a/frontend/src/components/common/Resource/ScaleButton.tsx
+++ b/frontend/src/components/common/Resource/ScaleButton.tsx
@@ -1,0 +1,205 @@
+import { Icon } from '@iconify/react';
+import { DialogContentText } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog, { DialogProps } from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Fab from '@material-ui/core/Fab';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import MuiInput from '@material-ui/core/Input';
+import { makeStyles, styled } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
+import { KubeObject } from '../../../lib/k8s/cluster';
+import { CallbackActionOptions, clusterAction } from '../../../redux/actions/actions';
+
+interface ScaleButtonProps {
+  item: KubeObject;
+  options?: CallbackActionOptions;
+}
+
+export default function ScaleButton(props: ScaleButtonProps) {
+  const dispatch = useDispatch();
+  const { item, options = {} } = props;
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
+  const location = useLocation();
+  const { t } = useTranslation('resource');
+
+  async function updateFunc(numReplicas: number) {
+    try {
+      await item.scale(numReplicas);
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  const applyFunc = React.useCallback(updateFunc, [item]);
+
+  function handleSave(numReplicas: number) {
+    const cancelUrl = location.pathname;
+    const itemName = item.metadata.name;
+
+    setOpenDialog(false);
+
+    // setOpenDialog(false);
+    dispatch(
+      clusterAction(() => applyFunc(numReplicas), {
+        startMessage: t('Scaling {{ itemName }}…', { itemName }),
+        cancelledMessage: t('Cancelled scaling {{ itemName }}.', { itemName }),
+        successMessage: t('Scaled {{ itemName }}.', { itemName }),
+        errorMessage: t('Failed to scale {{ itemName }}.', { itemName }),
+        cancelUrl,
+        errorUrl: cancelUrl,
+        ...options,
+      })
+    );
+  }
+
+  function handleClose() {
+    setOpenDialog(false);
+  }
+
+  React.useEffect(() => {
+    if (item) {
+      item
+        .getAuthorization('update')
+        .then((result: any) => {
+          if (result.status.allowed) {
+            setVisible(true);
+          }
+        })
+        .catch((err: Error) => {
+          console.error(`Error while getting authorization for edit button in ${item}:`, err);
+          setVisible(false);
+        });
+    }
+  }, [item]);
+
+  if (!visible || !['Deployment', 'StatefulSet', 'ReplicaSet'].includes(item.kind)) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <Tooltip title={t('frequent|Scale') as string}>
+        <IconButton aria-label={t('frequent|scale')} onClick={() => setOpenDialog(true)}>
+          <Icon icon="mdi:overscan" />
+        </IconButton>
+      </Tooltip>
+      <ScaleDialog resource={item} open={openDialog} onClose={handleClose} onSave={handleSave} />
+    </React.Fragment>
+  );
+}
+
+interface ScaleDialogProps extends DialogProps {
+  resource: KubeObject;
+  onSave: (numReplicas: number) => void;
+  onClose: () => void;
+  errorMessage?: string;
+}
+
+const Input = styled(MuiInput)({
+  '& input[type=number]': {
+    MozAppearance: 'textfield',
+    textAlign: 'center',
+  },
+  '& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button': {
+    display: 'none',
+  },
+  width: '80px',
+});
+
+const useScaleDialogStyle = makeStyles(() => ({
+  dialogContent: {
+    paddingBottom: '20px', // Prevent the content from overflowing
+  },
+  replicasNumberInput: {
+    marginLeft: '6px',
+    marginRight: '6px',
+  },
+  replicasSwitcher: {
+    padding: '6px',
+    textAlign: 'center',
+  },
+}));
+
+function ScaleDialog(props: ScaleDialogProps) {
+  const { open, resource, onClose, onSave } = props;
+  const [numReplicas, setNumReplicas] = React.useState<number>(getNumReplicas());
+  const { t } = useTranslation(['frequent', 'resource']);
+  const classes = useScaleDialogStyle();
+  const desiredNumReplicasLabel = 'desired-number-replicas-label';
+
+  function getNumReplicas() {
+    if (!resource?.spec) {
+      return -1;
+    }
+
+    return parseInt(resource.spec.replicas);
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{t('Scale Replicas')}</DialogTitle>
+      <DialogContent className={classes.dialogContent}>
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <DialogContentText>
+              {t('resource|Current number of replicas: {{ numReplicas }}', {
+                numReplicas: getNumReplicas(),
+              })}
+            </DialogContentText>
+          </Grid>
+          <Grid item container alignItems="center" spacing={2}>
+            <Grid item sm="auto" xs={12}>
+              <DialogContentText id={desiredNumReplicasLabel}>
+                {t('resource|Desired number of replicas:')}
+              </DialogContentText>
+            </Grid>
+            <Grid item xs={12} sm spacing={1} className={classes.replicasSwitcher}>
+              <Fab
+                size="small"
+                color="primary"
+                onClick={() => setNumReplicas(numReplicas => numReplicas - 1)}
+              >
+                <Icon icon="mdi:minus" width="22px" />
+              </Fab>
+              <Input
+                type="number"
+                value={numReplicas}
+                className={classes.replicasNumberInput}
+                onChange={e => setNumReplicas(Number(e.target.value))}
+                aria-labelledby={desiredNumReplicasLabel}
+                inputProps={{
+                  min: 0,
+                  step: 1,
+                }}
+              />
+              <Fab
+                size="small"
+                color="primary"
+                onClick={() => setNumReplicas(numReplicas => numReplicas + 1)}
+              >
+                <Icon icon="mdi:plus" width="22px" />
+              </Fab>
+            </Grid>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          {t('frequent|Cancel')}
+        </Button>
+        <Button onClick={() => onSave(numReplicas)} color="primary">
+          {t('frequent|Apply')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -11,7 +11,7 @@ import { OpPatch } from 'json-patch';
 import helpers from '../../helpers';
 import { getToken, logout } from '../auth';
 import { getCluster } from '../util';
-import { KubeMetrics, KubeObjectInterface } from './cluster';
+import { KubeMetadata, KubeMetrics, KubeObjectInterface } from './cluster';
 
 const BASE_HTTP_URL = helpers.getAppUrl();
 const BASE_WS_URL = BASE_HTTP_URL.replace('http', 'ws');
@@ -272,6 +272,7 @@ function simpleApiFactoryWithNamespace(
 ) {
   const apiRoot = getApiRoot(group, version);
   const results: {
+    scale?: ReturnType<typeof apiScaleFactory>;
     [other: string]: any;
   } = {
     list: (namespace: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
@@ -339,7 +340,7 @@ function getApiRoot(group: string, version: string) {
 function apiScaleFactory(apiRoot: string, resource: string) {
   return {
     get: (namespace: string, name: string) => request(url(namespace, name)),
-    put: (body: KubeObjectInterface) =>
+    put: (body: { metadata: KubeMetadata; spec: { replicas: number } }) =>
       put(url(body.metadata.namespace as string, body.metadata.name), body),
   };
 
@@ -372,7 +373,7 @@ export function patch(url: string, json: any, autoLogoutOnAuthError = true, requ
 
 export function put(
   url: string,
-  json: KubeObjectInterface,
+  json: Partial<KubeObjectInterface>,
   autoLogoutOnAuthError = true,
   requestOptions = {}
 ) {

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -292,6 +292,28 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       return this.apiEndpoint.put(data);
     }
 
+    scale(numReplicas: number) {
+      const hasScaleApi = Object.keys(this._class().apiEndpoint).includes('scale');
+      if (!hasScaleApi) {
+        throw new Error(`This class has no scale API: ${this._class().className}`);
+      }
+
+      const spec = {
+        replicas: numReplicas,
+      };
+
+      type ApiEndpointWithScale = {
+        scale: {
+          put: (data: { metadata: KubeMetadata; spec: { replicas: number } }) => Promise<any>;
+        };
+      };
+
+      return (this._class().apiEndpoint as ApiEndpointWithScale).scale.put({
+        metadata: this.metadata,
+        spec,
+      });
+    }
+
     patch(body: OpPatch[]) {
       const patchMethod = this._class().apiEndpoint.patch;
       const args: Parameters<typeof patchMethod> = [body];


### PR DESCRIPTION
This PR adds a scaling button to the header actions of Deployments, StatefulSets, and ReplicaSets. Doing this it became clear that we really need to try to find an alternative to the current API proxy.

![Header actions screenshot](https://user-images.githubusercontent.com/1029635/176951531-dfd33424-c9a0-4c75-bbaf-cffdcf112532.png)

![Scaling dialog screenshot](https://user-images.githubusercontent.com/1029635/176951604-c6dda638-1ca7-490e-9c32-33a8ea0a5434.png)


fixes #530
