### PR TITLE
Export resource chart and lib

### DIFF
--- a/frontend/src/components/cluster/Charts.tsx
+++ b/frontend/src/components/cluster/Charts.tsx
@@ -1,9 +1,8 @@
 import '../../i18n/config';
 import { useTheme } from '@material-ui/core/styles';
 import _ from 'lodash';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { KubeObject } from '../../lib/k8s/cluster';
+import { KubeMetrics, KubeObject } from '../../lib/k8s/cluster';
 import Pod from '../../lib/k8s/pod';
 import { parseCpu, parseRam, TO_GB, TO_ONE_CPU } from '../../lib/units';
 import { HeaderLabel } from '../common';
@@ -11,7 +10,7 @@ import { PercentageCircle, PercentageCircleProps } from '../common/Chart';
 
 interface ResourceCircularChartProps extends Omit<PercentageCircleProps, 'data'> {
   items: KubeObject[] | null;
-  itemsMetrics: any;
+  itemsMetrics: KubeMetrics[] | null;
   noMetrics?: boolean;
   resourceUsedGetter?: (node: KubeObject) => number;
   resourceAvailableGetter?: (node: KubeObject) => number;
@@ -33,7 +32,7 @@ export function ResourceCircularChart(props: ResourceCircularChartProps) {
 
   const [used, available] = getResourceUsage();
 
-  function filterMetrics(items: KubeObject[], metrics: any[]) {
+  function filterMetrics(items: KubeObject[], metrics: KubeMetrics[] | null) {
     if (!items || !metrics) return [];
 
     const names = items.map(({ metadata }) => metadata.name);

--- a/frontend/src/components/cluster/Charts.tsx
+++ b/frontend/src/components/cluster/Charts.tsx
@@ -1,91 +1,13 @@
 import '../../i18n/config';
 import { useTheme } from '@material-ui/core/styles';
-import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { KubeMetrics, KubeObject } from '../../lib/k8s/cluster';
+import { KubeObject } from '../../lib/k8s/cluster';
 import Pod from '../../lib/k8s/pod';
 import { parseCpu, parseRam, TO_GB, TO_ONE_CPU } from '../../lib/units';
-import { HeaderLabel } from '../common';
-import { PercentageCircle, PercentageCircleProps } from '../common/Chart';
-
-interface ResourceCircularChartProps extends Omit<PercentageCircleProps, 'data'> {
-  items: KubeObject[] | null;
-  itemsMetrics: KubeMetrics[] | null;
-  noMetrics?: boolean;
-  resourceUsedGetter?: (node: KubeObject) => number;
-  resourceAvailableGetter?: (node: KubeObject) => number;
-  getLegend?: (used: number, available: number) => string;
-  tooltip?: string | null;
-}
-
-export function ResourceCircularChart(props: ResourceCircularChartProps) {
-  const {
-    items,
-    itemsMetrics,
-    noMetrics = false,
-    resourceUsedGetter,
-    resourceAvailableGetter,
-    title,
-    ...others
-  } = props;
-  const { t } = useTranslation(['cluster']);
-
-  const [used, available] = getResourceUsage();
-
-  function filterMetrics(items: KubeObject[], metrics: KubeMetrics[] | null) {
-    if (!items || !metrics) return [];
-
-    const names = items.map(({ metadata }) => metadata.name);
-    return metrics.filter(item => names.includes(item.metadata.name));
-  }
-
-  function getLabel() {
-    if (available === 0) {
-      return '…';
-    }
-    return `${((used / available) * 100).toFixed(1)} %`;
-  }
-
-  function getResourceUsage() {
-    if (!items) return [-1, -1];
-
-    const nodeMetrics = filterMetrics(items, itemsMetrics);
-    const usedValue = _.sumBy(nodeMetrics, resourceUsedGetter);
-    const availableValue = _.sumBy(items, resourceAvailableGetter);
-
-    return [usedValue, availableValue];
-  }
-
-  function makeData() {
-    if (used === -1) {
-      return [];
-    }
-
-    return [
-      {
-        name: 'used',
-        value: used,
-      },
-    ];
-  }
-
-  return noMetrics ? (
-    <HeaderLabel
-      label={title || ''}
-      value={props.getLegend!(used, available)}
-      tooltip={t('cluster|Install the metrics-server to get usage data.')}
-    />
-  ) : (
-    <PercentageCircle
-      {...others}
-      title={title}
-      data={makeData()}
-      total={available}
-      label={getLabel()}
-      legend={props.getLegend!(used, available)}
-    />
-  );
-}
+import { PercentageCircle } from '../common/Chart';
+import ResourceCircularChart, {
+  CircularChartProps as ResourceCircularChartProps,
+} from '../common/Resource/CircularChart';
 
 export function MemoryCircularChart(props: ResourceCircularChartProps) {
   const { noMetrics } = props;

--- a/frontend/src/components/common/Resource/CircularChart.tsx
+++ b/frontend/src/components/common/Resource/CircularChart.tsx
@@ -1,0 +1,92 @@
+import '../../i18n/config';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { KubeMetrics, KubeObject } from '../../../lib/k8s/cluster';
+import { PercentageCircle, PercentageCircleProps } from '../Chart';
+import { HeaderLabel } from '../Label';
+
+export interface CircularChartProps extends Omit<PercentageCircleProps, 'data'> {
+  /** Items to display in the chart (should have a corresponding value in @param itemsMetrics) */
+  items: KubeObject[] | null;
+  /** Metrics to display in the chart (for items in @param items) */
+  itemsMetrics: KubeMetrics[] | null;
+  /** Whether no metrics are available. If true, then instead of a chart, a message will be displayed */
+  noMetrics?: boolean;
+  /** Function to get the "used" value for the metrics in question */
+  resourceUsedGetter?: (node: KubeObject) => number;
+  /** Function to get the "available" value for the metrics in question */
+  resourceAvailableGetter?: (node: KubeObject) => number;
+  /** Function to create a legend for the data */
+  getLegend?: (used: number, available: number) => string;
+  /** Tooltip to display when hovering over the chart */
+  tooltip?: string | null;
+}
+
+export default function CircularChart(props: CircularChartProps) {
+  const {
+    items,
+    itemsMetrics,
+    noMetrics = false,
+    resourceUsedGetter,
+    resourceAvailableGetter,
+    title,
+    ...others
+  } = props;
+  const { t } = useTranslation(['cluster']);
+
+  const [used, available] = getResourceUsage();
+
+  function filterMetrics(items: KubeObject[], metrics: KubeMetrics[] | null) {
+    if (!items || !metrics) return [];
+
+    const names = items.map(({ metadata }) => metadata.name);
+    return metrics.filter(item => names.includes(item.metadata.name));
+  }
+
+  function getLabel() {
+    if (available === 0) {
+      return '…';
+    }
+    return `${((used / available) * 100).toFixed(1)} %`;
+  }
+
+  function getResourceUsage() {
+    if (!items) return [-1, -1];
+
+    const nodeMetrics = filterMetrics(items, itemsMetrics);
+    const usedValue = _.sumBy(nodeMetrics, resourceUsedGetter);
+    const availableValue = _.sumBy(items, resourceAvailableGetter);
+
+    return [usedValue, availableValue];
+  }
+
+  function makeData() {
+    if (used === -1) {
+      return [];
+    }
+
+    return [
+      {
+        name: 'used',
+        value: used,
+      },
+    ];
+  }
+
+  return noMetrics ? (
+    <HeaderLabel
+      label={title || ''}
+      value={props.getLegend!(used, available)}
+      tooltip={t('cluster|Install the metrics-server to get usage data.')}
+    />
+  ) : (
+    <PercentageCircle
+      {...others}
+      title={title}
+      data={makeData()}
+      total={available}
+      label={getLabel()}
+      legend={props.getLegend!(used, available)}
+    />
+  );
+}

--- a/frontend/src/components/common/Resource/CircularChart.tsx
+++ b/frontend/src/components/common/Resource/CircularChart.tsx
@@ -1,4 +1,4 @@
-import '../../i18n/config';
+import '../../../i18n/config';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { KubeMetrics, KubeObject } from '../../../lib/k8s/cluster';

--- a/frontend/src/components/common/Resource/index.tsx
+++ b/frontend/src/components/common/Resource/index.tsx
@@ -1,2 +1,3 @@
+export * from './CircularChart';
 export * from './MetadataDisplay';
 export * from './Resource';

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useErrorState } from '../util';
 import { useConnectApi } from '.';
-import { apiFactory, metrics } from './apiProxy';
+import { ApiError, apiFactory, metrics } from './apiProxy';
 import { KubeCondition, KubeMetrics, KubeObjectInterface, makeKubeObject } from './cluster';
 
 export interface KubeNode extends KubeObjectInterface {
@@ -47,7 +47,7 @@ class Node extends makeKubeObject<KubeNode>('node') {
     return this.jsonData!.spec;
   }
 
-  static useMetrics() {
+  static useMetrics(): [KubeMetrics[] | null, ApiError | null] {
     const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
     const [error, setError] = useErrorState(setNodeMetrics);
 

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -179,3 +179,7 @@ export function useErrorState(dependentSetter?: (...args: any) => void) {
   // Adding "as any" here because it was getting difficult to validate the setter type.
   return [error, setError as any];
 }
+
+// Make units available from here
+export * as auth from './auth';
+export * as units from './units';


### PR DESCRIPTION
# Export ResourceCircularChart and lib

This PR is about exporting the ResourceCircularChart, used to create the cluster's overview charts, and also to export the Headlamp's lib/* modules.

- [X] Export ResourceCircularCart
- [X] Export units and auth modules

## Testing done

In a plugin (with the new version of headlamp-plugin), add:
```typescript
import { auth, units } from '@kinvolk/headlamp-plugin/lib/Utils';

console.log('VERIFY', units, auth)
```

Look for the logs to see if they show valid modules.

PS. We need to really integrate testing in plugins imports.