### PR TITLE
Add install docs for brew package manager

### DIFF
--- a/docs/installation/desktop/mac-installation.md
+++ b/docs/installation/desktop/mac-installation.md
@@ -4,6 +4,16 @@ linktitle: Mac OS
 weight: 20
 ---
 
+## Install via brew Package Manager
+
+If you are using the [Homebrew package manager](https://brew.sh/), you can install the latest release like so:
+
+```sh
+brew install --cask headlamp
+```
+
+## Install via GitHub Releases
+
 For Mac OS we provide a _.dmg_ file, so you need to download it from the [releases page](https://github.com/kinvolk/headlamp/releases)
 and than follow the below steps :
 


### PR DESCRIPTION
# Add Headlamp to Homebrew casks

This documentation change relates to adding the app to Homebrew/homebrew-cask: https://github.com/Homebrew/homebrew-cask/pull/127319

[ describe the change in 1 - 3 paragraphs ]

## How to use

- Proofread the docs
- Merge after Headlamp was merged to Homebrew/homebrew-cask

## Testing done

- [x] Markdown linter