### PR TITLE
frontend: Fix #582 crash in notification with non latin chars

### DIFF
--- a/frontend/src/lib/notification.tsx
+++ b/frontend/src/lib/notification.tsx
@@ -17,7 +17,7 @@ export class Notification {
       this.date = date;
     }
     // generate the id based on the message and the date attached to a notification
-    this.id = btoa(`${this.date},${this.message}`);
+    this.id = btoa(unescape(encodeURIComponent(`${this.date},${this.message}`)));
   }
 }
 


### PR DESCRIPTION
# Headlamp crashing in Notification component

From issue #582

```ts
> btoa(unescape(encodeURIComponent(`✓`)));
'4pyT'
> btoa(`✓`);
VM224:1 Uncaught DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
```
