### PR TITLE
frontend: Do not default page rows to 5

### DIFF
--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -117,7 +117,7 @@ export default function SimpleTable(props: SimpleTableProps) {
   const [displayData, setDisplayData] = React.useState(data);
   const rowsPerPageOptions = props.rowsPerPage || [15, 25, 50];
   const [rowsPerPage, setRowsPerPage] = React.useState(
-    helpers.getTablesRowsPerPage() || rowsPerPageOptions[0]
+    helpers.getTablesRowsPerPage(rowsPerPageOptions[0])
   );
   const classes = useTableStyle();
   const [isIncreasingOrder, setIsIncreasingOrder] = React.useState(

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -154,8 +154,13 @@ function getRecentClusters() {
 
 const tablesRowsPerPageKey = 'tables_rows_per_page';
 
-function getTablesRowsPerPage() {
-  return parseInt(localStorage.getItem(tablesRowsPerPageKey) || '5');
+function getTablesRowsPerPage(defaultRowsPerPage: number = 5) {
+  const perPageStr = localStorage.getItem(tablesRowsPerPageKey);
+  if (!perPageStr) {
+    return defaultRowsPerPage;
+  }
+
+  return parseInt(perPageStr);
 }
 
 function setTablesRowsPerPage(perPage: number) {


### PR DESCRIPTION
Due to a mistake, the default page rows was being set as 5.

Testing:
- [ ] Cleanup Headlamp browser storage; then start it and navigate to pods: Notice that the rows in the pods table should be 15 and not 5