### PR TITLE
Add Code of Conduct directly to the repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Please refer to the [Kinvolk Code of Conduct](https://github.com/kinvolk/contribution/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ our [plugin development guide](https://kinvolk.github.io/headlamp/docs/latest/de
 
 ## Get involved
 
-Check out our [guidelines](https://kinvolk.github.io/headlamp/docs/latest/contributing/)
+Check out our [guidelines](https://kinvolk.github.io/headlamp/docs/latest/contributing/), including our [Code of Conduct](./CODE_OF_CONDUCT.md),
 and join the discussion on the
 [#headlamp](https://kubernetes.slack.com/messages/headlamp) channel
 in the Kubernetes Slack.


### PR DESCRIPTION
This is so Github finds it and sets the badge in the repo.
