### PR TITLE
frontend: Make the namespaces filter values occupy just one line

### DIFF
--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -26,7 +26,8 @@ export function PureNamespacesAutocomplete({
   filter,
 }: PureNamespacesAutocompleteProps) {
   const theme = useTheme();
-  const { t } = useTranslation('glossary');
+  const { t } = useTranslation(['glossary', 'frequent']);
+  const maxNamespacesChars = 12;
 
   return (
     <Autocomplete
@@ -52,10 +53,33 @@ export function PureNamespacesAutocomplete({
         </React.Fragment>
       )}
       renderTags={(tags: string[]) => {
-        const joinedTags = tags.join(', ');
+        if (tags.length === 0) {
+          return <Typography variant="body2">{t('frequent|All namespaces')}</Typography>;
+        }
+
+        let namespacesToShow = tags[0];
+        const joiner = ', ';
+        const joinerLength = joiner.length;
+        let joinnedNamespaces = 1;
+
+        tags.slice(1).forEach(tag => {
+          if (namespacesToShow.length + tag.length + joinerLength <= maxNamespacesChars) {
+            namespacesToShow += joiner + tag;
+            joinnedNamespaces++;
+          }
+        });
+
         return (
-          <Typography>
-            {joinedTags.length > 15 ? joinedTags : joinedTags.slice(0, 15) + '…'}
+          <Typography style={{ overflowWrap: 'anywhere' }}>
+            {namespacesToShow.length > maxNamespacesChars
+              ? namespacesToShow.slice(0, maxNamespacesChars) + '…'
+              : namespacesToShow}
+            {tags.length > joinnedNamespaces && (
+              <>
+                <span>,&nbsp;</span>
+                <b>{`+${tags.length - joinnedNamespaces}`}</b>
+              </>
+            )}
           </Typography>
         );
       }}


### PR DESCRIPTION
When multiple namespaces were selected, the input could show several
lines and that made the header for the contents very large vertically,
which didn't look good.

This patch changes how the namespaces are shown, so that only up to
a certain number of chars are visible for the namespace name and after
that it shows how many other namespaces are selected.

Here are examples:
Long name namespace selected + another one:
![Screenshot of a long name namespace selected + another one](https://user-images.githubusercontent.com/1029635/179489734-ebb323d8-6263-4497-8643-8bb5702f522c.png)

A single and short namespace selected:
![Screenshot of a single and short namespace selected](https://user-images.githubusercontent.com/1029635/179490031-b412f5b1-b0ed-4ec5-9390-f0aba2bf5294.png)

If two namespaces' names fit the char limit (12 chars), then they may be displayed with the `+N` part.

fixes #593