### PR TITLE
Wait for plugins to load before showing views

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -10,6 +10,6 @@ test('renders without crashing', async () => {
   );
 
   await waitFor(() => {
-    expect(getByText(/Wait while fetching clusters/i)).toBeInTheDocument();
+    expect(getByText(/Skip to main content/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -3,6 +3,7 @@ import Container from '@material-ui/core/Container';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Link from '@material-ui/core/Link';
 import { makeStyles } from '@material-ui/core/styles';
+import { useTypedSelector } from '../../redux/reducers/reducers';
 import ActionsNotifier from '../common/ActionsNotifier';
 import AlertNotification from '../common/AlertNotification';
 import Sidebar, { NavigationTabs } from '../Sidebar';
@@ -44,6 +45,7 @@ export interface LayoutProps {}
 
 export default function Layout({}: LayoutProps) {
   const classes = useStyle();
+  const arePluginsLoaded = useTypedSelector(state => state.ui.pluginsLoaded);
 
   return (
     <>
@@ -60,7 +62,7 @@ export default function Layout({}: LayoutProps) {
             <div className={classes.toolbar} />
             <Container maxWidth="lg">
               <NavigationTabs />
-              <RouteSwitcher />
+              {arePluginsLoaded && <RouteSwitcher />}
             </Container>
           </Box>
         </main>


### PR DESCRIPTION
Fixes #454

The plugins can change a route, so waiting for the plugin to load stops flash-of-route-that-has-changed problem.

## How to use

Change a route with a plugin, and then the default view should not be shown before the plugin is loaded.

## Testing done

Use the following plugin that overrides "namespaces" and go to http://localhost:3000/c/minikube/namespaces

There should be "Namespaces is overridden." text.

```tsx
import { registerRoute } from '@kinvolk/headlamp-plugin/lib';
import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
import Typography from '@material-ui/core/Typography';

// A component to go along with the URL path.
registerRoute({
  path: '/namespaces',
  sidebar: 'namespaces',
  name: 'namespaces',
  exact: true,
  component: () => (
    <SectionBox title="Feedback" textAlign="center" paddingTop={2}>
      <Typography>Namespaces is overridden.</Typography>
    </SectionBox>
  ),
});
```


Here's another one to show the 404 page doesn't flash. Go to http://localhost:3000/woof
```tsx
import { registerRoute } from '@kinvolk/headlamp-plugin/lib';
import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
import Typography from '@material-ui/core/Typography';

// go to http://localhost:3000/woof
registerRoute({
  path: '/woof',
  exact: true,
  sidebar: null,
  noCluster: true,
  noAuthRequired: true,
  component: () => (
    <SectionBox title="Feedback" textAlign="center" paddingTop={2}>
      <Typography>There should be no 404 page flashed.</Typography>
    </SectionBox>
  ),
});
```