### PR TITLE
Fix ActionButton color and width problems

### DIFF
--- a/frontend/src/components/common/ActionButton/ActionButton.stories.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.stories.tsx
@@ -21,7 +21,7 @@ LargeAndColorful.args = {
   description: 'Some label',
   icon: 'mdi:pencil',
   width: '95',
-  color: '#adadad',
+  color: '#FF0000',
 };
 
 export const LongDescription = Template.bind({});
@@ -29,6 +29,4 @@ LongDescription.args = {
   description: 'Some label',
   longDescription: 'Although this is Some label, there is more to it than meets the eye.',
   icon: 'mdi:pencil',
-  width: '95',
-  color: '#adadad',
 };

--- a/frontend/src/components/common/ActionButton/ActionButton.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.tsx
@@ -40,15 +40,8 @@ export default function ActionButton({
 }: ActionButtonProps) {
   return (
     <Tooltip title={longDescription || description}>
-      <IconButton
-        aria-label={description}
-        onClick={onClick}
-        // @ts-ignore
-        color={color}
-        width={width}
-        edge={edge}
-      >
-        <Icon icon={icon} />
+      <IconButton aria-label={description} onClick={onClick} edge={edge}>
+        <Icon icon={icon} color={color} width={width} />
       </IconButton>
     </Tooltip>
   );

--- a/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.stories.storyshot
+++ b/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.stories.storyshot
@@ -33,7 +33,6 @@ exports[`Storyshots common/ActionButton Large And Colorful 1`] = `
     tabindex="0"
     title="Some label"
     type="button"
-    width="95"
   >
     <span
       class="MuiIconButton-label"
@@ -57,7 +56,6 @@ exports[`Storyshots common/ActionButton Long Description 1`] = `
     tabindex="0"
     title="Although this is Some label, there is more to it than meets the eye."
     type="button"
-    width="95"
   >
     <span
       class="MuiIconButton-label"


### PR DESCRIPTION
This fixes the Create resource button being invisible.

## How to use

Open Headlamp see the Create + icon is visible.

## Testing done

`npm run storybook` also shows the ActionButtons with different colors / widths.
