### PR TITLE
Fix new version checks

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -407,7 +407,6 @@ function startElecron() {
     });
 
     mainWindow.webContents.on('dom-ready', () => {
-      mainWindow?.webContents.send('appVersion', appVersion);
       mainWindow?.webContents.send('currentMenu', getDefaultAppMenu(i18n));
     });
 
@@ -466,6 +465,11 @@ function startElecron() {
 
     i18n.on('languageChanged', () => {
       setMenu(i18n);
+    });
+
+    // Send the app version when requested.
+    ipcMain.on('appVersion', () => {
+      mainWindow?.webContents.send('appVersion', appVersion);
     });
 
     ipcMain.on('setMenu', (event: IpcMainEvent, menus: any) => {

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -32,10 +32,9 @@ export default function ReleaseNotes() {
           ) {
             setReleaseDownloadURL(latestRelease.html_url);
           }
-          /*
-    check if there is already a version in store if it exists don't store the current version
-    this check will help us later in determining whether we are on the latest release or not
-    */
+
+          // check if there is already a version in store if it exists don't store the current version
+          // this check will help us later in determining whether we are on the latest release or not.
           const storedAppVersion = helpers.getAppVersion();
           let releaseNotes = '';
           if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
@@ -70,6 +69,7 @@ export default function ReleaseNotes() {
             setReleaseNotes(releaseNotes);
           }
         }
+
         const isUpdateCheckingDisabled = JSON.parse(
           localStorage.getItem('disable_update_check') || 'false'
         );

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -80,6 +80,10 @@ export default function ReleaseNotes() {
     }
   }, []);
 
+  React.useEffect(() => {
+    desktopApi?.send('appVersion');
+  }, []);
+
   return (
     <>
       {releaseDownloadURL && <UpdatePopup releaseDownloadURL={releaseDownloadURL} />}


### PR DESCRIPTION
Today I ran into the issue as described in #512 . Indeed the appVersion is sent only when the DOM is ready, but the component that acts on the received appVersion was not ready yet.

To fix this, this PR changes how the appVersion is sent. Now it's sent only when requested, guaranteeing that the component is in fact ready.