### PR TITLE
Allow to build without checking for updates

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,4 +1,5 @@
 import { ChildProcessWithoutNullStreams, execSync, spawn } from 'child_process';
+import dotenv from 'dotenv';
 import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItem, screen, shell } from 'electron';
 import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import log from 'electron-log';
@@ -11,6 +12,8 @@ import url from 'url';
 import yargs from 'yargs';
 import i18n from './i18next.config';
 import windowSize from './windowSize';
+
+dotenv.config({ path: path.join(process.resourcesPath, '.env') });
 
 const args = yargs
   .command('$0 [kubeconfig]', '', yargs => {
@@ -34,6 +37,7 @@ const defaultPort = 4466;
 
 const isDev = process.env.ELECTRON_DEV || false;
 const useExternalServer = process.env.EXTERNAL_SERVER || false;
+const shouldCheckForUpdates = process.env.HEADLAMP_CHECK_FOR_UPDATES !== 'false';
 
 function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
   const serverFilePath = isDev
@@ -364,6 +368,8 @@ function startElecron() {
     appVersion = app.getVersion();
   }
 
+  console.log('Check for updates: ', shouldCheckForUpdates);
+
   setMenu(i18n);
 
   async function createWindow() {
@@ -469,6 +475,7 @@ function startElecron() {
 
     ipcMain.on('appConfig', () => {
       mainWindow?.webContents.send('appConfig', {
+        checkForUpdates: shouldCheckForUpdates,
         appVersion,
       });
     });

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -467,9 +467,10 @@ function startElecron() {
       setMenu(i18n);
     });
 
-    // Send the app version when requested.
-    ipcMain.on('appVersion', () => {
-      mainWindow?.webContents.send('appVersion', appVersion);
+    ipcMain.on('appConfig', () => {
+      mainWindow?.webContents.send('appConfig', {
+        appVersion,
+      });
     });
 
     ipcMain.on('setMenu', (event: IpcMainEvent, menus: any) => {

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -4,13 +4,13 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('desktopApi', {
   send: (channel, data) => {
     // allowed channels
-    const validChannels = ['setMenu', 'locale', 'appVersion'];
+    const validChannels = ['setMenu', 'locale', 'appConfig'];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);
     }
   },
   receive: (channel, func) => {
-    const validChannels = ['currentMenu', 'setMenu', 'locale', 'appVersion'];
+    const validChannels = ['currentMenu', 'setMenu', 'locale', 'appConfig'];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`
       ipcRenderer.on(channel, ({}, ...args) => func(...args));

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,6 +12,7 @@
         "@types/semver": "^7.3.8",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
+        "dotenv": "^16.0.1",
         "electron-log": "^4.4.1",
         "find-process": "^1.4.7",
         "i18next": "^20.6.1",
@@ -4511,12 +4512,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
-      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
-      "dev": true,
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -8250,6 +8250,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/read-config-file/node_modules/dotenv": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/read-config-file/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -13330,10 +13339,9 @@
       }
     },
     "dotenv": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
-      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
-      "dev": true
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -16268,6 +16276,12 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "dotenv": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+          "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
           "dev": true
         },
         "js-yaml": {

--- a/app/package.json
+++ b/app/package.json
@@ -145,6 +145,7 @@
     "@types/semver": "^7.3.8",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.0.1",
     "electron-log": "^4.4.1",
     "find-process": "^1.4.7",
     "i18next": "^20.6.1",

--- a/app/scripts/after-pack.js
+++ b/app/scripts/after-pack.js
@@ -14,7 +14,16 @@ exports.default = async context => {
 
   try {
     fse.copySync('./prod_deps/node_modules', dest);
-  } catch(err) {
+  } catch (err) {
     console.error('Failed to copy node_modules after pack:', err);
+  }
+
+  if (fse.existsSync('.env')) {
+    console.info('Copying .env file to app resources directory!');
+    try {
+      fse.copySync('./.env', path.join(context.appOutDir, 'resources', '.env'));
+    } catch (err) {
+      console.error('Failed to copy .env after pack:', err);
+    }
   }
 };

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -12,7 +12,9 @@ export default function ReleaseNotes() {
 
   React.useEffect(() => {
     if (desktopApi) {
-      desktopApi.receive('appVersion', (currentBuildAppVersion: string) => {
+      desktopApi.receive('appConfig', (config: { appVersion: string }) => {
+        const { appVersion: currentBuildAppVersion } = config;
+
         const octokit = new Octokit();
 
         async function fetchRelease() {
@@ -81,7 +83,7 @@ export default function ReleaseNotes() {
   }, []);
 
   React.useEffect(() => {
-    desktopApi?.send('appVersion');
+    desktopApi?.send('appConfig');
   }, []);
 
   return (

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -12,73 +12,80 @@ export default function ReleaseNotes() {
 
   React.useEffect(() => {
     if (desktopApi) {
-      desktopApi.receive('appConfig', (config: { appVersion: string }) => {
-        const { appVersion: currentBuildAppVersion } = config;
-
-        const octokit = new Octokit();
-
-        async function fetchRelease() {
-          const githubReleaseURL = `GET /repos/{owner}/{repo}/releases`;
-          // get me all the releases -> default decreasing order of releases
-          const response = await octokit.request(githubReleaseURL, {
-            owner: 'kinvolk',
-            repo: 'headlamp',
-          });
-          const latestRelease = response.data.find(
-            release => !release.name?.startsWith('headlamp-helm')
-          );
-          if (
-            latestRelease &&
-            semver.gt(latestRelease.name as string, currentBuildAppVersion) &&
-            !process.env.FLATPAK_ID
-          ) {
-            setReleaseDownloadURL(latestRelease.html_url);
+      desktopApi.receive(
+        'appConfig',
+        (config: { appVersion: string; checkForUpdates: boolean }) => {
+          const { appVersion: currentBuildAppVersion, checkForUpdates = true } = config;
+          if (!checkForUpdates) {
+            console.debug("Skipping update check because config's checkForUpdates is false");
+            return;
           }
 
-          // check if there is already a version in store if it exists don't store the current version
-          // this check will help us later in determining whether we are on the latest release or not.
-          const storedAppVersion = helpers.getAppVersion();
-          let releaseNotes = '';
-          if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
-            // get the release notes for the version with which the app was built with
+          const octokit = new Octokit();
 
-            const githubReleaseURL = `GET /repos/{owner}/{repo}/releases/tags/v${currentBuildAppVersion}`;
-            try {
-              const response = await octokit.request(githubReleaseURL, {
-                owner: 'kinvolk',
-                repo: 'headlamp',
-              });
+          async function fetchRelease() {
+            const githubReleaseURL = `GET /repos/{owner}/{repo}/releases`;
+            // get me all the releases -> default decreasing order of releases
+            const response = await octokit.request(githubReleaseURL, {
+              owner: 'kinvolk',
+              repo: 'headlamp',
+            });
+            const latestRelease = response.data.find(
+              release => !release.name?.startsWith('headlamp-helm')
+            );
+            if (
+              latestRelease &&
+              semver.gt(latestRelease.name as string, currentBuildAppVersion) &&
+              !process.env.FLATPAK_ID
+            ) {
+              setReleaseDownloadURL(latestRelease.html_url);
+            }
 
-              const [notes] = response.data.body.split('<!-- end-release-notes -->');
-              if (!!notes) {
-                releaseNotes = notes;
+            // check if there is already a version in store if it exists don't store the current version
+            // this check will help us later in determining whether we are on the latest release or not.
+            const storedAppVersion = helpers.getAppVersion();
+            let releaseNotes = '';
+            if (storedAppVersion && semver.lt(storedAppVersion as string, currentBuildAppVersion)) {
+              // get the release notes for the version with which the app was built with
+
+              const githubReleaseURL = `GET /repos/{owner}/{repo}/releases/tags/v${currentBuildAppVersion}`;
+              try {
+                const response = await octokit.request(githubReleaseURL, {
+                  owner: 'kinvolk',
+                  repo: 'headlamp',
+                });
+
+                const [notes] = response.data.body.split('<!-- end-release-notes -->');
+                if (!!notes) {
+                  releaseNotes = notes;
+                }
+              } catch (err) {
+                console.error(
+                  `Error getting release notes for version ${currentBuildAppVersion}:`,
+                  err
+                );
               }
-            } catch (err) {
-              console.error(
-                `Error getting release notes for version ${currentBuildAppVersion}:`,
-                err
-              );
+            }
+
+            // set the store version to the current so that we don't show release notes on
+            // every start of app
+            helpers.setAppVersion(currentBuildAppVersion);
+
+            // Calling this after setting the version above, so the release notes have the right version
+            // set when they show it.
+            if (!!releaseNotes) {
+              setReleaseNotes(releaseNotes);
             }
           }
 
-          // set the store version to the current so that we don't show release notes on
-          // every start of app
-          helpers.setAppVersion(currentBuildAppVersion);
-
-          // Calling this after setting the version above, so the release notes have the right version
-          // set when they show it.
-          if (!!releaseNotes) {
-            setReleaseNotes(releaseNotes);
+          const isUpdateCheckingDisabled = JSON.parse(
+            localStorage.getItem('disable_update_check') || 'false'
+          );
+          if (!isUpdateCheckingDisabled) {
+            fetchRelease();
           }
         }
-
-        const isUpdateCheckingDisabled = JSON.parse(
-          localStorage.getItem('disable_update_check') || 'false'
-        );
-        if (!isUpdateCheckingDisabled) {
-          fetchRelease();
-        }
-      });
+      );
     }
   }, []);
 


### PR DESCRIPTION
This is a proposal for adding a way to build Headlamp's app without having it check for updates.

@illume , I am open to a better alternative to having the options in app/package.json.

Testing:
- [ ] Run `make run-backend` and `make run-frontend`, then go to the app folder and run `HEADLAMP_APP_VERSION=0.1.0 npm run dev-only-app`: It should check for updates and show the small popup notification on the lower right saying a new version is available
- [ ] Change the `checkForUpdates` setting to `false` in app/package.json and run the same command as above again: the updat check shouldn't happen this time