### PR TITLE
Fix logo getting trimmed

### DIFF
--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -9,7 +9,6 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import SvgIcon from '@material-ui/core/SvgIcon';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -89,12 +88,6 @@ const useStyles = makeStyles(theme => ({
   },
   chooserDialogCover: {
     background: theme.palette.common.black,
-  },
-  logo: {
-    height: '28px',
-    width: '100%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
   },
   chooserTitle: {
     background: theme.palette.common.black,
@@ -274,7 +267,7 @@ export function ClusterDialog(props: ClusterDialogProps) {
       {...otherProps}
     >
       <DialogTitle className={classes.chooserTitle} disableTypography>
-        <SvgIcon className={classes.logo} component={LogoLight} viewBox="0 0 175 32" />
+        <LogoLight />
       </DialogTitle>
       <DialogContent className={classes.chooserDialog}>{children}</DialogContent>
     </Dialog>

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -27,7 +27,7 @@ export interface OurDialogTitleProps extends DialogTitleProps {
  * reading can begin.
  */
 export function DialogTitle(props: OurDialogTitleProps) {
-  const { children, focusTitle, buttons, ...other } = props;
+  const { children, focusTitle, buttons, disableTypography, ...other } = props;
 
   const focusedRef = React.useCallback(node => {
     if (node !== null) {
@@ -42,17 +42,21 @@ export function DialogTitle(props: OurDialogTitleProps) {
     <MuiDialogTitle style={{ display: 'flex' }} disableTypography {...other}>
       <Grid container justifyContent="space-between" alignItems="center">
         <Grid item>
-          <Typography
-            ref={focusedRef}
-            variant="h1"
-            style={{
-              fontSize: '1.25rem',
-              fontWeight: 500,
-              lineHeight: 1.6,
-            }}
-          >
-            {children}
-          </Typography>
+          {disableTypography ? (
+            children
+          ) : (
+            <Typography
+              ref={focusedRef}
+              variant="h1"
+              style={{
+                fontSize: '1.25rem',
+                fontWeight: 500,
+                lineHeight: 1.6,
+              }}
+            >
+              {children}
+            </Typography>
+          )}
         </Grid>
         <Grid item>{buttons && buttons.length > 0 && <Box>{buttons}</Box>}</Grid>
       </Grid>


### PR DESCRIPTION
This fixes #622 .
The problem was that the logo component was added to an SvgIcon which is something that is intended to be used with icons, not with generic images. Adding the component directly, fixed it.

Not sure if there are any a11y implications, but that's not an important part of the dialog for understand what it is, so I guess it's fine.

I have also added a patch to drop the typography from DialogTitle components when the respective attribute is present.