### PR TITLE
Fix exporting circular chart

### DIFF
--- a/frontend/src/components/common/Resource/CircularChart.tsx
+++ b/frontend/src/components/common/Resource/CircularChart.tsx
@@ -22,7 +22,7 @@ export interface CircularChartProps extends Omit<PercentageCircleProps, 'data'> 
   tooltip?: string | null;
 }
 
-export default function CircularChart(props: CircularChartProps) {
+export function CircularChart(props: CircularChartProps) {
   const {
     items,
     itemsMetrics,
@@ -90,3 +90,5 @@ export default function CircularChart(props: CircularChartProps) {
     />
   );
 }
+
+export default CircularChart;

--- a/frontend/src/components/common/Resource/CircularChart.tsx
+++ b/frontend/src/components/common/Resource/CircularChart.tsx
@@ -30,6 +30,7 @@ export function CircularChart(props: CircularChartProps) {
     resourceUsedGetter,
     resourceAvailableGetter,
     title,
+    getLegend,
     ...others
   } = props;
   const { t } = useTranslation(['cluster']);
@@ -76,17 +77,17 @@ export function CircularChart(props: CircularChartProps) {
   return noMetrics ? (
     <HeaderLabel
       label={title || ''}
-      value={props.getLegend!(used, available)}
+      value={!!getLegend ? getLegend(used, available) : ''}
       tooltip={t('cluster|Install the metrics-server to get usage data.')}
     />
   ) : (
     <PercentageCircle
-      {...others}
       title={title}
       data={makeData()}
       total={available}
       label={getLabel()}
-      legend={props.getLegend!(used, available)}
+      legend={!!getLegend ? getLegend(used, available) : ''}
+      {...others}
     />
   );
 }


### PR DESCRIPTION
It was being exported only by default from its module, so it was not getting name-exported by common/index.tsx.