### PR TITLE
Add checks for exported common components

### DIFF
--- a/frontend/src/components/common/index.test.ts
+++ b/frontend/src/components/common/index.test.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import * as AllComps from '.';
+
+const avoidCheck = [
+  '.stories',
+  '.test',
+  'index',
+  '__snapshots__',
+  // Not exported on purpose
+  'ReleaseNotes',
+  'ActionsNotifier',
+  'AlertNotification',
+  'ConfirmButton',
+  'NamespacesAutocomplete',
+];
+
+const checkExports = [
+  'ActionButton',
+  'Chart',
+  'ConfirmDialog',
+  'Dialog',
+  'EmptyContent',
+  'Label',
+  'Link',
+  'Loader',
+  'LogViewer',
+  'Resource',
+  'SectionBox',
+  'SectionFilterHeader',
+  'SectionHeader',
+  'SimpleTable',
+  'Tabs',
+  'Terminal',
+  'Tooltip',
+];
+
+function getFilesToVerify() {
+  const filesToVerify: string[] = [];
+  fs.readdirSync(__dirname).forEach(file => {
+    const fileNoSuffix = file.replace(/\.[^/.]+$/, '');
+    if (!avoidCheck.find(suffix => fileNoSuffix.endsWith(suffix))) {
+      filesToVerify.push(fileNoSuffix);
+    }
+  });
+
+  return filesToVerify;
+}
+
+const filesToVerify = getFilesToVerify();
+
+describe('Import tests', () => {
+  test('Left out imports', () => {
+    filesToVerify.forEach((file: string) => {
+      expect(checkExports).toContain(file);
+    });
+  });
+
+  // Not important, but just for the sake of keeping this file clean.
+  test('Left over imports', () => {
+    checkExports.forEach((file: string) => {
+      expect(filesToVerify).toContain(file);
+    });
+  });
+
+  test('Check imports', () => {
+    filesToVerify.forEach((file: string) => {
+      const r = require(`./${file}`);
+
+      // Check that all components are exported.
+      for (const key in r) {
+        if (key === 'default') {
+          // If default, then we try to import by file name.
+          expect(AllComps).toHaveProperty(file);
+        } else {
+          expect(AllComps).toHaveProperty(key);
+        }
+      }
+    });
+  });
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,5 +1,6 @@
 export * from './ActionButton';
 export { default as ActionButton } from './ActionButton';
+export * from './Chart';
 export * from './Dialog';
 export * from './EmptyContent';
 export { default as EmptyContent } from './EmptyContent';


### PR DESCRIPTION
This new test allows us to check whether we have modules in `common/` that cannot be imported from `common/index.tsx`. It may require more complexity for adding whatever corner cases I may have forgotten, but it's a good start IMO.

By running it I have noticed that Charts.tsx was not being exported and started exporting it.
