### PR TITLE
frontend: Show containers' ports in UI

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -588,6 +588,10 @@ export function ContainerInfo(props: ContainerInfoProps) {
         hide: !status,
       },
       {
+        name: t('Image Pull Policy'),
+        value: container.imagePullPolicy,
+      },
+      {
         name: t('Image'),
         value: (
           <>

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -36,7 +36,7 @@ import { PodListProps, PodListRenderer } from '../../pod/List';
 import { LightTooltip } from '..';
 import Empty from '../EmptyContent';
 import ErrorBoundary from '../ErrorBoundary';
-import { DateLabel, HoverInfoLabel, StatusLabel, StatusLabelProps } from '../Label';
+import { DateLabel, HoverInfoLabel, StatusLabel, StatusLabelProps, ValueLabel } from '../Label';
 import Link, { LinkProps } from '../Link';
 import { useMetadataDisplayStyles } from '.';
 import DeleteButton from './DeleteButton';
@@ -624,6 +624,20 @@ export function ContainerInfo(props: ContainerInfoProps) {
         name: t('Liveness Probes'),
         value: <LivenessProbes liveness={container.livenessProbe} />,
         hide: _.isEmpty(container.livenessProbe),
+      },
+      {
+        name: t('Ports'),
+        value: (
+          <Grid container>
+            {container.ports?.map(({ containerPort, protocol }, index) => (
+              <Grid item xs={12} key={`port_line_${index}`}>
+                <ValueLabel>{`${protocol}:`}</ValueLabel>
+                <ValueLabel>{containerPort}</ValueLabel>
+              </Grid>
+            ))}
+          </Grid>
+        ),
+        hide: _.isEmpty(container.ports),
       },
     ];
   }

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -596,7 +596,7 @@ export function ContainerInfo(props: ContainerInfoProps) {
         value: (
           <>
             <Typography>{container.image}</Typography>
-            {status && (
+            {status?.imageID && (
               <Typography className={classes.imageID}>
                 <Typography component="span" style={{ fontWeight: 'bold' }}>
                   ID:


### PR DESCRIPTION
We should show the ports used by a container in the pod's container details.
![Screenshot showing ports in a container](https://user-images.githubusercontent.com/1029635/180818007-96e24ffd-e4cb-4126-b308-d79b667a9a87.png)


Testing:
Go to a pod that has a container which declares ports and verify they're shown in the UI.