### PR TITLE
Width cosmetic fixes

### DIFF
--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -14,7 +14,7 @@ const useStyle = makeStyles(theme => ({
   content: {
     flexGrow: 1,
     marginLeft: 'initial',
-    [theme.breakpoints.between('sm', 'md')]: {
+    [theme.breakpoints.only('sm')]: {
       marginLeft: drawerWidthClosed,
     },
   },

--- a/frontend/src/components/Sidebar/HeadlampButton.tsx
+++ b/frontend/src/components/Sidebar/HeadlampButton.tsx
@@ -42,9 +42,16 @@ export interface HeadlampButtonProps {
   mobileOnly?: boolean;
   /** Called when sidebar toggles between open and closed. */
   onToggleOpen: () => void;
+  /** Whether the button is to be disabled or not. */
+  disabled?: boolean;
 }
 
-export default function HeadlampButton({ open, onToggleOpen, mobileOnly }: HeadlampButtonProps) {
+export default function HeadlampButton({
+  open,
+  onToggleOpen,
+  mobileOnly,
+  disabled = false,
+}: HeadlampButtonProps) {
   const isSmall = useMediaQuery('(max-width:600px)');
   const classes = useStyle({ isSidebarOpen: open, isSmall: isSmall });
   const { t } = useTranslation('sidebar');
@@ -61,6 +68,7 @@ export default function HeadlampButton({ open, onToggleOpen, mobileOnly }: Headl
         onClick={onToggleOpen}
         className={classes.button}
         aria-label={open ? t('Shrink sidebar') : t('Expand sidebar')}
+        disabled={disabled}
       >
         <ErrorBoundary>
           {

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -1,6 +1,6 @@
 import { Divider } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router';
@@ -50,10 +50,13 @@ export default function NavigationTabs() {
   const history = useHistory();
   const classes = useStyle();
   const sidebar = useTypedSelector(state => state.ui.sidebar);
-  const isMobile = useMediaQuery('(max-width:600px)');
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
+  const isSmallSideBar = useMediaQuery(theme.breakpoints.only('sm'));
   const { t } = useTranslation();
 
-  if (sidebar.isSidebarOpen || isMobile) {
+  // Always show the navigation tabs when the sidebar is the small version
+  if (!isSmallSideBar && (sidebar.isSidebarOpen || isMobile)) {
     return null;
   }
 

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -158,7 +158,11 @@ export function PureSidebar({
 
   const contents = (
     <>
-      <HeadlampButton open={largeSideBarOpen} onToggleOpen={onToggleOpen} />
+      <HeadlampButton
+        open={largeSideBarOpen}
+        onToggleOpen={onToggleOpen}
+        disabled={smallSideOnly}
+      />
       <Grid
         className={classes.sidebarGrid}
         container

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -501,9 +501,6 @@ const useContainerInfoStyles = makeStyles((theme: Theme) => ({
     paddingTop: theme.spacing(1),
     fontSize: '.95rem',
   },
-  preventOverflow: {
-    overflowWrap: 'anywhere',
-  },
 }));
 
 export interface ContainerInfoProps {
@@ -594,7 +591,7 @@ export function ContainerInfo(props: ContainerInfoProps) {
         name: t('Image'),
         value: (
           <>
-            <Typography className={classes.preventOverflow}>{container.image}</Typography>
+            <Typography>{container.image}</Typography>
             {status && (
               <Typography className={classes.imageID}>
                 <Typography component="span" style={{ fontWeight: 'bold' }}>

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles(theme => ({
   }),
   sectionTitle: ({ headerStyle }: HeaderStyleProps) => ({
     ...theme.palette.headerStyle[headerStyle || 'normal'],
+    whiteSpace: 'pre-wrap',
   }),
 }));
 

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -347,6 +347,7 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     verticalAlign: 'top',
     fontSize: '1rem',
+    overflowWrap: 'anywhere',
   },
   metadataNameCell: {
     fontSize: '1rem',


### PR DESCRIPTION
These changes do:
* Remove an extra left margin when on sm
* Prevent the image ID from expanding the details views horizontally
* Remove the now unneeded overflow-wrap from the image name
* Add the navigation tabs when the sidebar is the narrow static version (width=sm)
* Wrap section titles so they fit better on small screens

Testing:
- [ ] Go to a pod's details view: verify that the image and image ID have not forced the page width to go beyond normal
- [ ] Enter inspect mode (Ctrl+Shift+I), click on the mobile sizes button and redeuce the page's width: There should not be a sudden extra margin when the width is between `sm` and `md`
- [ ] Verify that in the narrow sidebar above, you can see the navigation tabs
- [ ] Verify the sidebar works as expected in all other resolutions