### PR TITLE
Center cluster chooser

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -197,7 +197,6 @@ export function PureTopBar({
   const { t } = useTranslation('frequent');
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
-  const isMedium = useMediaQuery(theme.breakpoints.down('sm'));
   const dispatch = useDispatch();
 
   const openSideBar = !!(isSidebarOpenUserSelected === undefined ? false : isSidebarOpen);
@@ -320,9 +319,9 @@ export function PureTopBar({
         aria-label={t('Appbar Tools')}
       >
         <Toolbar className={classes.toolbar}>
-          {isMedium && <HeadlampButton open={openSideBar} mobileOnly onToggleOpen={onToggleOpen} />}
+          {isSmall && <HeadlampButton open={openSideBar} mobileOnly onToggleOpen={onToggleOpen} />}
 
-          {!isMedium && (
+          {!isSmall && (
             <>
               <div className={clsx(classes.grow, classes.clusterTitle)}>
                 <ClusterTitle cluster={cluster} clusters={clusters} />
@@ -343,7 +342,7 @@ export function PureTopBar({
               </IconButton>
             </>
           )}
-          {isMedium && (
+          {isSmall && (
             <>
               <div className={classes.grow} />
               <IconButton
@@ -360,7 +359,7 @@ export function PureTopBar({
         </Toolbar>
       </AppBar>
       {renderUserMenu}
-      {isMedium && renderMobileMenu}
+      {isSmall && renderMobileMenu}
     </>
   );
 }

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -5,7 +5,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import clsx from 'clsx';
@@ -20,7 +20,7 @@ import { useCluster, useClustersConf } from '../../lib/k8s';
 import {
   HeaderActionType,
   setVersionDialogOpen,
-  setWhetherSidebarOpen,
+  setWhetherSidebarOpen
 } from '../../redux/actions/actions';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { ClusterTitle } from '../cluster/Chooser';
@@ -195,8 +195,9 @@ export function PureTopBar({
   onToggleOpen,
 }: PureTopBarProps) {
   const { t } = useTranslation('frequent');
-  const isSmall = useMediaQuery('(max-width:960px)');
-  const isMedium = useMediaQuery('(max-width:960px)');
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMedium = useMediaQuery(theme.breakpoints.down('sm'));
   const dispatch = useDispatch();
 
   const openSideBar =

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -20,7 +20,7 @@ import { useCluster, useClustersConf } from '../../lib/k8s';
 import {
   HeaderActionType,
   setVersionDialogOpen,
-  setWhetherSidebarOpen
+  setWhetherSidebarOpen,
 } from '../../redux/actions/actions';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { ClusterTitle } from '../cluster/Chooser';
@@ -200,10 +200,9 @@ export function PureTopBar({
   const isMedium = useMediaQuery(theme.breakpoints.down('sm'));
   const dispatch = useDispatch();
 
-  const openSideBar =
-    isMedium && !!(isSidebarOpenUserSelected === undefined ? false : isSidebarOpen);
+  const openSideBar = !!(isSidebarOpenUserSelected === undefined ? false : isSidebarOpen);
 
-  const classes = useStyles({ isSidebarOpen: openSideBar, isSmall });
+  const classes = useStyles({ isSidebarOpen, isSmall });
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [mobileMoreAnchorEl, setMobileMoreAnchorEl] = React.useState<null | HTMLElement>(null);
 


### PR DESCRIPTION
Before:
![Screenshot of topbar before changes](https://user-images.githubusercontent.com/1029635/181581506-34bfd6ee-7dc6-48fc-a114-3354280d80ac.png)


After:
![Screenshot of topbar after changes](https://user-images.githubusercontent.com/1029635/181581354-f1a26f94-278b-4d1e-a67e-867cd7003638.png)

Testing:
- [ ] Go to Headlamp, verify that the cluster button is always center, no matter whether the sidebar is open or closed
- [ ] Verify that the topbar behaves as expected in different resolutions