### PR TITLE
plugins/headlamp-plugin: Add upgrade command

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -7,6 +7,7 @@ on:
     - 'Makefile'
     - '.github/**'
     - 'app/**'
+    - 'plugins/**'
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
     - Makefile
     - '.github/**'
     - 'app/**'
+    - 'plugins/**'
 
 jobs:
   build:


### PR DESCRIPTION
An upgrade command for upgrading plugins (and folders of plugins).

For https://github.com/kinvolk/headlamp/issues/426

- [x] Check if headlamp-plugin is outdated when starting `npm start`
- [x] When package is upgraded, make sure the version is also updated (For example `^0.5.0` should be `^0.5.1`)
- [x] Upgrade @kinvolk/headlamp-plugin if it is outdated. On one folder or many.
- [x] Add extra config inside package.json (like the new eslint/prettier config)
- [x] Add extra required config files (like a previous version did with a tsconfig file)
- [x] Add tests

## How to use

### Testing this PR before it's released:

```bash
node plugins/headlamp-plugin/bin/headlamp-plugin.js upgrade plugins/examples
```

### When it's released

#### Upgrade multiple folders

```bash
npx @kinvolk/headlamp-plugin upgrade plugins/examples
```

#### Upgrade current folder

```bash
cd plugins/examples/sidebar
npx @kinvolk/headlamp-plugin upgrade
```


## Testing done

- [x] run it against our plugins/examples/
- [x] Add a few tests to test-headlamp-plugin.sh
