### PR TITLE
Add basic test of container image on minikube

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,4 +1,9 @@
-name: Build Container
+
+# "Setup minikube as CI step in GitHub Actions"
+# https://minikube.sigs.k8s.io/docs/tutorials/setup_minikube_in_github_actions/
+# https://github.com/marketplace/actions/setup-minikube
+
+name: Build Container and test
 on:
   pull_request:
     paths:
@@ -6,16 +11,38 @@ on:
     - 'frontend/**'
     - Makefile
     - '.github/**'
-    - Dockerfile
 
 jobs:
   build:
-    name: Build Image
     runs-on: ubuntu-latest
+    name: build discover and deploy
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - name: Start cluster
+      uses: medyagh/setup-minikube@master
+      # now you can run kubectl to see the pods in the cluster
+    - name: Try the cluster!
+      run: kubectl get pods -A
     - name: Build image
       run: |
-        cd $GITHUB_WORKSPACE
-        make image
+        export SHELL=/bin/bash
+        eval $(minikube -p minikube docker-env)
+        DOCKER_IMAGE_VERSION=latest make image
+        echo -n "verifying images:"
+        docker images
+    - name: Deploy to cluster
+      run:
+        kubectl apply -f e2e-tests/kubernetes-headlamp-ci.yaml
+    - name: Test service URLs
+      run: |
+        minikube service list
+        minikube service headlamp -n kube-system --url
+        sleep 2
+        kubectl get deployments -n kube-system
+        minikube logs | tail -10
+        kubectl wait deployment -n kube-system headlamp --for condition=Available=True --timeout=10s
+        minikube service headlamp -n kube-system --url
+        echo -n "------------------opening the service------------------"
+        export SERVICE_URL=$(minikube service headlamp -n kube-system --url | tail -1)
+        echo -n $SERVICE_URL
+        curl -L $SERVICE_URL | grep -q "Headlamp: Kubernetes Web UI"

--- a/e2e-tests/kubernetes-headlamp-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-ci.yaml
@@ -1,0 +1,49 @@
+# For testing headlamp in CI.
+kind: Service
+apiVersion: v1
+metadata:
+  name: headlamp
+  namespace: kube-system
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 4466
+  selector:
+    k8s-app: headlamp
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: headlamp
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: headlamp
+  template:
+    metadata:
+      labels:
+        k8s-app: headlamp
+    spec:
+      containers:
+      - name: headlamp
+        imagePullPolicy: Never
+        image: ghcr.io/kinvolk/headlamp:latest
+        args:
+          - "-in-cluster"
+          - "-plugins-dir=/headlamp/plugins"
+        ports:
+        - containerPort: 4466
+      nodeSelector:
+        'kubernetes.io/os': linux
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: headlamp-admin
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: "headlamp-admin"
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
Runs minikube, and then checks the service URL is serving minikube.

## How to use

Look at the build container check.

## Testing done

- [x] It tests it on a github check. See "Test Service URLs" part of "Build container and test".
- [x] Ran it multiple times, and it doesn't fail. So hopefully not a flaky test!
