### PR TITLE
Add name for cluster chooser route

### DIFF
--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -84,6 +84,7 @@ const defaultRoutes: {
   chooser: {
     path: '/',
     exact: true,
+    name: 'Choose a cluster',
     sidebar: null,
     noCluster: true,
     noAuthRequired: true,


### PR DESCRIPTION
Add name for cluster chooser route

## How to use

Go to / with a cluster chooser.

## Testing done

See the page has a `<title>Choose a cluster</title>`