### PR TITLE
frontend ReleaseNotes: Fix query for latest release

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -30,8 +30,9 @@ export default function ReleaseNotes() {
               owner: 'kinvolk',
               repo: 'headlamp',
             });
+            // Get the latest release that is not headlamp-plugin or headlamp-helm.
             const latestRelease = response.data.find(
-              release => !release.name?.startsWith('headlamp-helm')
+              release => !release.name?.startsWith('headlamp-')
             );
             if (
               latestRelease &&


### PR DESCRIPTION
It was breaking because it did not consider headlamp-plugin releases.

## How to use

Use the app.

## Testing done

In the app, check the console for a ReleaseNotes related error that isn't there anymore.