### PR TITLE
frontend: Catch and log Plugin initialize() errors

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -81,10 +81,15 @@ export async function initializePlugins() {
 
   // Initialize every plugin in the order they were loaded.
   return new Promise(resolve => {
-    for (const plugin of Object.values(window.plugins)) {
-      // @todo: what should happen if this fails?
-      // @todo: The return code is not checked? What is it for?
-      plugin.initialize(new Registry());
+    for (const pluginName of Object.keys(window.plugins)) {
+      const plugin = window.plugins[pluginName];
+      try {
+        // @todo: what should happen if this fails?
+        // @todo: The return code is not checked? What is it for?
+        plugin.initialize(new Registry());
+      } catch (e) {
+        console.error(`Plugin initialize() error in ${pluginName}:`, e);
+      }
     }
     resolve(undefined);
   });


### PR DESCRIPTION
So that plugins that use initialize() will not crash the system if they have an error in them.

## Testing done

Introduce an error into a plugin that uses the Plugin `initialize()` method of registration (like plugin/examples/app-menus) and it should not stop other plugins running.
