### PR TITLE
frontend: Fix Plugin class based plugins not loading

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -75,8 +75,6 @@ function loadDevPlugins() {
  * Load external, then local plugins. Then initialize() them in order with a Registry.
  */
 export async function initializePlugins() {
-  window.plugins = {};
-
   await loadDevPlugins();
 
   // Initialize every plugin in the order they were loaded.


### PR DESCRIPTION
Fix Plugin class based plugins not loading. Such as app-menus.

## How to use

Use with app-menus.

## Testing done

app-menus example works again.
