### PR TITLE
plugins: Add useClusterURL, noAuthRequired to sidebar example

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -3,7 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { Redirect, Route, RouteProps, Switch } from 'react-router-dom';
 import { getToken } from '../../lib/auth';
 import { useClustersConf } from '../../lib/k8s';
-import { createRouteURL, getDefaultRoutes, getRoutePath, NotFoundRoute } from '../../lib/router';
+import {
+  createRouteURL,
+  getDefaultRoutes,
+  getRoutePath,
+  getRouteUseClusterURL,
+  NotFoundRoute,
+} from '../../lib/router';
 import { getCluster } from '../../lib/util';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { useSidebarItem } from '../Sidebar';
@@ -36,7 +42,7 @@ export default function RouteSwitcher() {
               path={getRoutePath(route)}
               sidebar={route.sidebar}
               requiresAuth={!route.noAuthRequired}
-              requiresCluster={!route.noCluster}
+              requiresCluster={getRouteUseClusterURL(route)}
               exact={!!route.exact}
               children={
                 <PageTitle title={t(route.name ? route.name : route.sidebar ? route.sidebar : '')}>

--- a/plugins/examples/sidebar/src/index.tsx
+++ b/plugins/examples/sidebar/src/index.tsx
@@ -3,6 +3,7 @@ import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import Typography from '@material-ui/core/Typography';
 
 // A top level item in the sidebar.
+// The sidebar link URL is: /c/mycluster/feedback
 registerSidebarEntry({
   parent: null,
   name: 'feedback',
@@ -12,6 +13,8 @@ registerSidebarEntry({
 });
 
 // A component to go along with the URL path.
+// This component rendered at URL: /c/mycluster/feedback
+//    (your URL might be /c/minikube/feedback if your cluster name is minikube)
 registerRoute({
   path: '/feedback',
   sidebar: 'feedback',
@@ -25,6 +28,7 @@ registerRoute({
 });
 
 // Another top level sidebar menu item.
+// The sidebar link URL is: /c/mycluster/feedback2
 registerSidebarEntry({
   parent: null,
   name: 'feedback2',
@@ -36,12 +40,14 @@ registerSidebarEntry({
 // Please see https://icon-sets.iconify.design/mdi/ for icons.
 
 // Here we have some sub menus.
+// The sidebar link URL is: /c/mycluster/feedback3
 registerSidebarEntry({
   parent: 'feedback2',
   name: 'feedback3',
   label: 'More Feedback',
   url: '/feedback3',
 });
+// The sidebar link URL is: /c/mycluster/feedback4
 registerSidebarEntry({
   parent: 'feedback2',
   name: 'feedback4',
@@ -50,6 +56,7 @@ registerSidebarEntry({
 });
 
 // Add components and routes for the three different side bar items.
+// This component rendered at URL: /c/mycluster/feedback2
 registerRoute({
   path: '/feedback2',
   sidebar: 'feedback2',
@@ -62,6 +69,7 @@ registerRoute({
   ),
 });
 
+// This component rendered at URL: /c/mycluster/feedback3
 registerRoute({
   path: '/feedback3',
   sidebar: 'feedback3',
@@ -74,6 +82,7 @@ registerRoute({
   ),
 });
 
+// This component rendered at URL: /c/mycluster/feedback4
 registerRoute({
   path: '/feedback4',
   sidebar: 'feedback4',
@@ -82,6 +91,31 @@ registerRoute({
   component: () => (
     <SectionBox title="Other Feedback" textAlign="center" paddingTop={2}>
       <Typography>Other feedback forms go here.</Typography>
+    </SectionBox>
+  ),
+});
+
+// The sidebar link URL is: /no-cluster-link
+registerSidebarEntry({
+  parent: null,
+  name: 'no-cluster-link',
+  label: 'No Cluster Link',
+  url: '/no-cluster-link',
+  icon: 'mdi:comment-quote',
+  useClusterURL: false, // Do not put "/c/mycluster/" in the URL
+});
+
+// This component rendered at URL: /no-cluster-link
+registerRoute({
+  path: '/no-cluster-link',
+  sidebar: null,
+  name: 'no-cluster-link',
+  exact: true,
+  useClusterURL: false, // This one does not have a "/c/mycluster/" in the URL
+  noAuthRequired: true, // No authentication is required to see the view
+  component: () => (
+    <SectionBox title="No Cluster Link" textAlign="center" paddingTop={2}>
+      <Typography>Your component here</Typography>
     </SectionBox>
   ),
 });


### PR DESCRIPTION
noCluster has been confusing to a few people. This is an attempt to improve things.

- [x] Add useClusterURL, noAuthRequired to sidebar example.
- [x] Deprecate Route.noCluster in favor of useClusterURL. Old plugins can still use noCluster.
- [x] Fix registerRoute to take a useClusterURL option (instead of noCluster option).
- [x] Add lots of comments to the sidebar example

Why useClusterURL and not noCluster?

- noCluster is confusing because it's a negatively named variable
- useClusterURL is used elsewhere (when registering sidebar entries)
- useClusterURL has URL in the name, so it's a bit more descriptive


## How to use

```bash
cd plugins/examples/sidebar
npm i
npm start
# Then go to Headlamp (make run-frontend).
```

Read sidebar example; does useClusterURL make sense?

Is /no-cluster-link not a 404?

## Testing done

Does useClusterURL option make more sense now?
