### PR TITLE
frontend headlamp-plugin: Add material ui labs

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -21,6 +21,7 @@ window.pluginLib = {
   CommonComponents: require('../components/common'),
   MuiCore: require('@material-ui/core'),
   MuiStyles: require('@material-ui/styles'),
+  MuiLab: require('@material-ui/lab'),
   React: require('react'),
   ReactJSX: require('react/jsx-runtime'),
   ReactDOM: require('react-dom'),

--- a/plugins/headlamp-plugin/config/webpack.config.js
+++ b/plugins/headlamp-plugin/config/webpack.config.js
@@ -1,5 +1,6 @@
 const externalModules = {
   '@material-ui/core': 'pluginLib.MuiCore',
+  '@material-ui/lab': 'pluginLib.MuiLab',
   '@material-ui/styles': 'pluginLib.MuiStyles',
   react: 'pluginLib.React',
   'react/jsx-runtime': 'pluginLib.ReactJSX',


### PR DESCRIPTION
Add Material UI labs


## How to use

```bash
cd plugins/headlamp-plugin
npm run build && npm run pack

# install headlamp-plugin local in your plugin
cd your-plugin
npm install ../path-to/plugins/headlamp-plugin/*.tgz
```

## Testing done

tried to use ToggleButton in a plugin


```tsx
import { K8s, registerAppBarAction } from '@kinvolk/headlamp-plugin/lib';
import { Typography } from '@material-ui/core';
import ToggleButton from '@material-ui/lab/ToggleButton';
import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
import { makeStyles } from '@material-ui/styles';
import React from 'react';

export default function ToggleButtons() {
  const [alignment, setAlignment] = React.useState('left');

  const handleAlignment = (event, newAlignment) => {
    setAlignment(newAlignment);
  };

  return (
    <ToggleButtonGroup
      value={alignment}
      exclusive
      onChange={handleAlignment}
      aria-label="text alignment"
    >
      <ToggleButton value="left" aria-label="left aligned">
        FormatAlignLeftIcon
      </ToggleButton>
      <ToggleButton value="center" aria-label="centered">
        FormatAlignCenterIcon
      </ToggleButton>
      <ToggleButton value="right" aria-label="right aligned">
        FormatAlignRightIcon
      </ToggleButton>
      <ToggleButton value="justify" aria-label="justified" disabled>
        FormatAlignJustifyIcon
      </ToggleButton>
    </ToggleButtonGroup>
  );
}

const useStyle = makeStyles(() => ({
  pods: {
    fontStyle: 'italic',
  },
}));

function PodCounter() {
  const classes = useStyle();
  const [pods, error] = K8s.ResourceClasses.Pod.useList();
  const msg = pods === null ? 'Loading…' : pods.length.toString();

  return (
    <>
      <ToggleButtons />
      <Typography color="textPrimary" className={classes.pods}>
        {!error ? `# Pods: ${msg}` : 'Uh, pods!?'}
      </Typography>
    </>
  );
}

registerAppBarAction(PodCounter);
```


