### PR TITLE
headlamp-plugin upgrade improvements - check and audit after upgrade, fail better, README

### DIFF
--- a/plugins/headlamp-plugin/README.md
+++ b/plugins/headlamp-plugin/README.md
@@ -16,6 +16,10 @@ headlamp-plugin build <package>   Build the plugin, or folder of
                                   plugins. <package> defaults to
                                   current working directory.
 headlamp-plugin start             Watch for changes and build the plugin
+headlamp-plugin upgrade <package> Upgrade the plugin to latest headlamp-plugin.
+                                  Audits, formats, lints and type checks.
+                                  <package> defaults to current working
+                                  directory. Can also be a folder of packages.
 headlamp-plugin extract           Copies folders of packages from plug
 <pluginPackages> <outputPlugins>  inPackages/packageName/dist/main.js
                                   to outputPlugins/packageName/main.js

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -664,7 +664,7 @@ yargs(process.argv.slice(2))
         });
     },
     argv => {
-      process.exitCode = lint(argv.package);
+      process.exitCode = lint(argv.package, argv.fix);
     }
   )
   .command(


### PR DESCRIPTION
headlamp-plugin upgrade improvements - check after upgrade, fail better, README.

- Check after upgrade: run lint, tsc, and such after upgrading.
- Run npm audit --fix after upgrading.
- Add the upgrade command to the README.md
- Turn on the type checker so it type checks headlamp-plugin.js

## How to use

Run `node ./plugins/headlamp-plugin/bin/headlamp-plugin.js upgrade plugins/examples/pod-counter` or on another package.

## Testing done

Ran on some existing plugins, and there's a test in CI for the upgrade command already.
