### PR TITLE
kubernetes-headlamp.yaml: Add Secret section for new k8s

### DIFF
--- a/kubernetes-headlamp.yaml
+++ b/kubernetes-headlamp.yaml
@@ -42,3 +42,12 @@ spec:
           timeoutSeconds: 30
       nodeSelector:
         'kubernetes.io/os': linux
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: headlamp-admin
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: "headlamp-admin"
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
This adds a Secret section to our sample yaml snippet.

Kubernetes 1.24+
- https://kinvolk.github.io/headlamp/docs/latest/installation/#create-a-service-account-token
- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#no-really-you-must-read-this-before-you-upgrade

The relevant section from the CHANGELOG above is:
> The LegacyServiceAccountTokenNoAutoGeneration feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every ServiceAccount. Use the [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this [guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets). https://github.com/kubernetes/kubernetes/pull/108309 

Thanks @aceeric 

closes #687

## How to use

Use new k8s 1.24+

Follow quickstart guide: https://kinvolk.github.io/headlamp/docs/latest/installation/#create-a-service-account-token

```bash
kubectl apply -f kubernetes-headlamp.yaml
sleep 20
kubectl -n kube-system get secrets | grep headlamp-admin
```

## Testing done

See above.