### PR TITLE
plugins: Add registerRouteFilter and registerSidebarEntryFilter

### DIFF
--- a/docs/development/plugins/functionality.md
+++ b/docs/development/plugins/functionality.md
@@ -128,15 +128,19 @@ Set a cluster dynamically, rather than have the backend read it from configurati
 Show a component (in Headlamps main area) at a given URL with
 [registerRoute](../api/modules/plugin_registry.md#registerRoute).
 
-- Example plugin shows [How To Register a Route](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/sidebar)
+- Example plugin shows [How To Register a Route](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/sidebar), and how to remove a route.
 - API reference for [registerRoute](../api/modules/plugin_registry.md#registerRoute)
+- API reference for [registerRouteFilter](../api/modules/plugin_registry.md#registerRouteFilter)
+
 
 ### Sidebar Item
 
 Add sidebar items (menu on the left) with
-[registerSidebarItem](../api/modules/plugin_registry.md#registerSidebarItem).
+[registerSidebarEntry](../api/modules/plugin_registry.md#registerSidebarEntry).
+Remove sidebar items with [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registerSidebarEntryFilter).
 
-![screenshot of the logo being changed](./images/sidebar.png)
+![screenshot of the sidebar being changed](./images/sidebar.png)
 
-- Example plugin shows [How To add items to the sidebar](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/sidebar)
-- API reference for [registerSidebarItem](../api/modules/plugin_registry.md#registerSidebarItem)
+- Example plugin shows [How To add items to the sidebar](https://github.com/kinvolk/headlamp/tree/main/plugins/examples/sidebar), and also how to remove sidebar items.
+- API reference for [registerSidebarEntry](../api/modules/plugin_registry.md#registerSidebarEntry)
+- API reference for [registerSidebarEntryFilter](../api/modules/plugin_registry.md#registerSidebarEntryFilter)

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -20,38 +20,46 @@ export default function RouteSwitcher() {
   // The NotFoundRoute always has to be evaluated in the last place.
   const defaultRoutes = Object.values(getDefaultRoutes()).concat(NotFoundRoute);
   const routes = useTypedSelector(state => state.ui.routes);
+  const routeFilters = useTypedSelector(state => state.ui.routeFilters);
+  const filteredRoutes = Object.values(routes)
+    .concat(defaultRoutes)
+    .filter(
+      route =>
+        !(
+          routeFilters.length > 0 &&
+          routeFilters.filter(f => f(route)).length !== routeFilters.length
+        )
+    );
 
   return (
     <Switch>
-      {Object.values(routes)
-        .concat(defaultRoutes)
-        .map((route, index) =>
-          route.name === 'OidcAuth' ? (
-            <Route
-              path={route.path}
-              component={() => (
-                <PageTitle title={t(route.name ? route.name : route.sidebar ? route.sidebar : '')}>
-                  <route.component />
-                </PageTitle>
-              )}
-              key={index}
-            />
-          ) : (
-            <AuthRoute
-              key={index}
-              path={getRoutePath(route)}
-              sidebar={route.sidebar}
-              requiresAuth={!route.noAuthRequired}
-              requiresCluster={getRouteUseClusterURL(route)}
-              exact={!!route.exact}
-              children={
-                <PageTitle title={t(route.name ? route.name : route.sidebar ? route.sidebar : '')}>
-                  <route.component />
-                </PageTitle>
-              }
-            />
-          )
-        )}
+      {filteredRoutes.map((route, index) =>
+        route.name === 'OidcAuth' ? (
+          <Route
+            path={route.path}
+            component={() => (
+              <PageTitle title={t(route.name ? route.name : route.sidebar ? route.sidebar : '')}>
+                <route.component />
+              </PageTitle>
+            )}
+            key={index}
+          />
+        ) : (
+          <AuthRoute
+            key={index}
+            path={getRoutePath(route)}
+            sidebar={route.sidebar}
+            requiresAuth={!route.noAuthRequired}
+            requiresCluster={getRouteUseClusterURL(route)}
+            exact={!!route.exact}
+            children={
+              <PageTitle title={t(route.name ? route.name : route.sidebar ? route.sidebar : '')}>
+                <route.component />
+              </PageTitle>
+            }
+          />
+        )
+      )}
     </Switch>
   );
 }

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -71,12 +71,16 @@ export default function Sidebar() {
   const isSidebarOpenUserSelected = useTypedSelector(
     state => state.ui.sidebar.isSidebarOpenUserSelected
   );
+  const arePluginsLoaded = useTypedSelector(state => state.ui.pluginsLoaded);
 
   const namespaces = useTypedSelector(state => state.filter.namespaces);
   const dispatch = useDispatch();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const { t, i18n } = useTranslation(['glossary', 'frequent']);
-  const items = React.useMemo(() => prepareRoutes(t), [sidebar.entries, i18n.language]);
+  const items = React.useMemo(
+    () => prepareRoutes(t),
+    [sidebar.entries, i18n.language, arePluginsLoaded]
+  );
   const search = namespaces.size !== 0 ? `?namespace=${[...namespaces].join('+')}` : '';
 
   // Use the location to make sure the sidebar is changed, as it depends on the cluster

--- a/frontend/src/components/Sidebar/prepareRoutes.ts
+++ b/frontend/src/components/Sidebar/prepareRoutes.ts
@@ -122,6 +122,7 @@ function prepareRoutes(t: (arg: string) => string) {
   ];
 
   const items = store.getState().ui.sidebar.entries;
+  const filters = store.getState().ui.sidebar.filters;
   // @todo: Find a better way to avoid modifying the objects in LIST_ITEMS.
   const routes: SidebarItemProps[] = JSON.parse(JSON.stringify(LIST_ITEMS));
 
@@ -139,8 +140,24 @@ function prepareRoutes(t: (arg: string) => string) {
 
     placement.push(item);
   }
+  // Filter the routes, if we have any filters.
+  const filteredRoutes = [];
+  for (const route of routes) {
+    const routeFiltered =
+      filters.length > 0 && filters.filter(f => f(route)).length !== filters.length;
+    if (routeFiltered) {
+      continue;
+    }
 
-  return routes;
+    const newSubList = route.subList?.filter(
+      subRoute =>
+        !(filters.length > 0 && filters.filter(f => f(subRoute)).length !== filters.length)
+    );
+    route.subList = newSubList;
+
+    filteredRoutes.push(route);
+  }
+  return filteredRoutes;
 }
 
 export default prepareRoutes;

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -12,7 +12,9 @@ import Registry, {
   registerDetailsViewHeaderAction,
   registerDetailsViewSection,
   registerRoute,
+  registerRouteFilter,
   registerSidebarEntry,
+  registerSidebarEntryFilter,
 } from './registry';
 
 window.pluginLib = {
@@ -42,7 +44,9 @@ window.pluginLib = {
   registerDetailsViewHeaderAction,
   registerDetailsViewSection,
   registerRoute,
+  registerRouteFilter,
   registerSidebarEntry,
+  registerSidebarEntryFilter,
 };
 
 // @todo: should window.plugins be private?

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -14,7 +14,9 @@ import {
   setDetailsView,
   setDetailsViewHeaderAction,
   setRoute,
+  setRouteFilter,
   setSidebarItem,
+  setSidebarItemFilter,
 } from '../redux/actions/actions';
 import store from '../redux/stores/store';
 
@@ -184,6 +186,42 @@ export function registerSidebarEntry({
       icon,
     })
   );
+}
+
+/**
+ * Remove sidebar menu items.
+ *
+ * @param filterFunc - a function for filtering sidebar entries.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { registerSidebarEntryFilter } from '@kinvolk/headlamp-plugin/lib';
+ *
+ * registerSidebarEntryFilter(entry => (entry.name === 'workloads' ? null : entry));
+ * ```
+ */
+export function registerSidebarEntryFilter(
+  filterFunc: (entry: SidebarEntryProps) => SidebarEntryProps | null
+) {
+  store.dispatch(setSidebarItemFilter(filterFunc));
+}
+
+/**
+ * Remove routes.
+ *
+ * @param filterFunc - a function for filtering routes.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { registerRouteFilter } from '@kinvolk/headlamp-plugin/lib';
+ *
+ * registerRouteFilter(route => (route.path === '/workloads' ? null : route));
+ * ```
+ */
+export function registerRouteFilter(filterFunc: (entry: Route) => Route | null) {
+  store.dispatch(setRouteFilter(filterFunc));
 }
 
 /**

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -18,8 +18,10 @@ export const CONFIG_NEW = 'CONFIG_NEW';
 export const UI_SIDEBAR_SET_SELECTED = 'UI_SIDEBAR_SET_SELECTED';
 export const UI_SIDEBAR_SET_VISIBLE = 'UI_SIDEBAR_SET_VISIBLE';
 export const UI_SIDEBAR_SET_ITEM = 'UI_SIDEBAR_SET_ITEM';
+export const UI_SIDEBAR_SET_ITEM_FILTER = 'UI_SIDEBAR_SET_ITEM_FILTER';
 export const UI_SIDEBAR_SET_EXPANDED = 'UI_SIDEBAR_SET_EXPANDED';
 export const UI_ROUTER_SET_ROUTE = 'UI_ROUTER_SET_ROUTE';
+export const UI_ROUTER_SET_ROUTE_FILTER = 'UI_ROUTER_SET_ROUTE_FILTER';
 export const UI_DETAILS_VIEW_SET_HEADER_ACTION = 'UI_DETAILS_VIEW_SET_HEADER_ACTION';
 export const UI_SET_DETAILS_VIEW = 'UI_SET_DETAILS_VIEW';
 export const UI_APP_BAR_SET_ACTION = 'UI_APP_BAR_SET_ACTION';
@@ -124,8 +126,18 @@ export function setSidebarItem(item: SidebarEntryProps) {
   return { type: UI_SIDEBAR_SET_ITEM, item };
 }
 
+export function setSidebarItemFilter(
+  filterFunc: (entry: SidebarEntryProps) => SidebarEntryProps | null
+) {
+  return { type: UI_SIDEBAR_SET_ITEM_FILTER, filterFunc };
+}
+
 export function setRoute(routeSpec: Route) {
   return { type: UI_ROUTER_SET_ROUTE, route: routeSpec };
+}
+
+export function setRouteFilter(filterFunc: (entry: Route) => Route | null) {
+  return { type: UI_ROUTER_SET_ROUTE_FILTER, filterFunc };
 }
 
 export function setDetailsViewHeaderAction(actionFunc: HeaderActionType) {

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -14,17 +14,22 @@ import {
   UI_INITIALIZE_PLUGIN_VIEWS,
   UI_PLUGINS_LOADED,
   UI_ROUTER_SET_ROUTE,
+  UI_ROUTER_SET_ROUTE_FILTER,
   UI_SET_CLUSTER_CHOOSER_BUTTON,
   UI_SET_DETAILS_VIEW,
   UI_SET_NOTIFICATIONS,
   UI_SIDEBAR_SET_EXPANDED,
   UI_SIDEBAR_SET_ITEM,
+  UI_SIDEBAR_SET_ITEM_FILTER,
   UI_SIDEBAR_SET_SELECTED,
   UI_SIDEBAR_SET_VISIBLE,
   UI_THEME_SET,
   UI_UPDATE_NOTIFICATION,
   UI_VERSION_DIALOG_OPEN,
 } from '../actions/actions';
+
+type SidebarEntryFilterFuncType = (entry: SidebarEntryProps) => SidebarEntryProps | null;
+type RouteFilterFuncType = (entry: Route) => Route | null;
 
 export interface UIState {
   sidebar: {
@@ -36,10 +41,12 @@ export interface UIState {
     entries: {
       [propName: string]: SidebarEntryProps;
     };
+    filters: SidebarEntryFilterFuncType[];
   };
   routes: {
     [path: string]: Route;
   };
+  routeFilters: RouteFilterFuncType[];
   views: {
     details: {
       headerActions: HeaderActionType[];
@@ -90,10 +97,12 @@ export const INITIAL_STATE: UIState = {
     selected: null,
     isVisible: false,
     entries: {},
+    filters: [],
   },
   routes: {
-    // path -> component
+    // path -> Route
   },
+  routeFilters: [],
   views: {
     details: {
       headerActions: [],
@@ -135,10 +144,17 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
     case UI_SIDEBAR_SET_ITEM: {
       const entries = { ...newFilters.sidebar.entries };
       entries[action.item.name] = action.item;
-
       newFilters.sidebar = {
         ...newFilters.sidebar,
         entries,
+      };
+      break;
+    }
+    case UI_SIDEBAR_SET_ITEM_FILTER: {
+      const filters = [...newFilters.sidebar.filters, action.filterFunc];
+      newFilters.sidebar = {
+        ...newFilters.sidebar,
+        filters,
       };
       break;
     }
@@ -154,6 +170,11 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       const routes = { ...newFilters.routes };
       routes[action.route.path] = action.route;
       newFilters.routes = routes;
+      break;
+    }
+    case UI_ROUTER_SET_ROUTE_FILTER: {
+      const routeFilters = [...newFilters.routeFilters, action.filterFunc];
+      newFilters.routeFilters = routeFilters;
       break;
     }
     case UI_DETAILS_VIEW_SET_HEADER_ACTION: {

--- a/plugins/examples/sidebar/README.md
+++ b/plugins/examples/sidebar/README.md
@@ -2,7 +2,7 @@
 
 This example plugin places two items with the title "Feedback" in the
 sidebar; one as a top-level entry, and the other is placed under the
-cluster item.
+cluster item. It also removes the Namespaces sidebar item and route.
 
 ![screenshot of the side bar being changed](../../../docs/development/plugins/images/sidebar.png)
 
@@ -19,5 +19,7 @@ The main code for the plugin is in [src/index.tsx](src/index.tsx).
 
 See the API documentation for:
 
-- [registerSidebarItem](https://kinvolk.github.io/headlamp/docs/latest/development/api/classes/plugin_registry.registry/#registersidebaritem)
+- [registerSidebarEntry](https://kinvolk.github.io/headlamp/docs/latest/development/api/classes/plugin_registry.registry/#registersidebarentry)
+- [registerSidebarEntryFilter](https://kinvolk.github.io/headlamp/docs/latest/development/api/classes/plugin_registry.registry/#registersidebarentryfilter)
 - [registerRoute](https://kinvolk.github.io/headlamp/docs/latest/development/api/classes/plugin_registry.registry/#registerroute)
+- [registerRouteFilter](https://kinvolk.github.io/headlamp/docs/latest/development/api/classes/plugin_registry.registry/#registerroutefilter)

--- a/plugins/examples/sidebar/src/index.tsx
+++ b/plugins/examples/sidebar/src/index.tsx
@@ -1,4 +1,9 @@
-import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
+import {
+  registerRoute,
+  registerRouteFilter,
+  registerSidebarEntry,
+  registerSidebarEntryFilter,
+} from '@kinvolk/headlamp-plugin/lib';
 import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import Typography from '@material-ui/core/Typography';
 
@@ -119,3 +124,13 @@ registerRoute({
     </SectionBox>
   ),
 });
+
+// Remove "Workloads" top level sidebar menu item
+registerSidebarEntryFilter(entry => (entry.name === 'workloads' ? null : entry));
+// Remove "/workloads" route
+registerRouteFilter(route => (route.path === '/workloads' ? null : route));
+
+// Remove "Namespaces" second level sidebar menu item
+registerSidebarEntryFilter(entry => (entry.name === 'namespaces' ? null : entry));
+// Remove "/namespaces" route
+registerRouteFilter(route => (route.path === '/namespaces' ? null : route));

--- a/plugins/headlamp-plugin/lib/index.ts
+++ b/plugins/headlamp-plugin/lib/index.ts
@@ -14,7 +14,9 @@ import Registry, {
   registerDetailsViewHeaderAction,
   registerDetailsViewSection,
   registerRoute,
+  registerRouteFilter,
   registerSidebarEntry,
+  registerSidebarEntryFilter,
 } from '../types/plugin/registry';
 import * as CommonComponents from './CommonComponents';
 
@@ -39,5 +41,7 @@ export {
   registerDetailsViewHeaderAction,
   registerDetailsViewSection,
   registerRoute,
+  registerRouteFilter,
   registerSidebarEntry,
+  registerSidebarEntryFilter,
 };


### PR DESCRIPTION
Add registerRouteFilter and registerSidebarEntryFilter,
which allows plugins to remove routes, and sidebar menu items.

```tsx
import { registerRouteFilter, registerSidebarEntryFilter } from '@kinvolk/headlamp-plugin/lib';

// Remove workloads top level sidebar item
registerSidebarEntryFilter(entry => (entry.name === 'workloads' ? null : entry));
// Remove workloads route
registerRouteFilter(route => (route.path === '/workloads' ? null : route));
```

Closes #445

## How to use

See plugins/examples/sidebar

```bash
cd plugins/headlamp-plugin
npm run build && npm run pack
cd ../examples/sidebar
npm i ../../headlamp-plugin/*.tgz
npm start
# run headlamp to see the Workloads+Namespaces routes and sidebar items gone.
```

## Testing done

- [x] top level sidebar item is removed
- [x] second level sidebar item removed
- [x] route removed
- [x] works with no filters active.
