### PR TITLE
backend: Handle CA file not found error without panic

### DIFF
--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -92,7 +92,7 @@ func pathRelativeToBase(base string, dest string) string {
 	return path.Join(base, dest)
 }
 
-func (c *Cluster) getCAData() []byte {
+func (c *Cluster) getCAData() ([]byte, error) {
 	if c.config.CertificateAuthority != "" {
 		// paths inside the config are relative to the config.
 		configDir := filepath.Dir(c.config.LocationOfOrigin)
@@ -100,17 +100,19 @@ func (c *Cluster) getCAData() []byte {
 
 		pemBytes, err := ioutil.ReadFile(caPath)
 		if err == nil {
-			return pemBytes
+			return pemBytes, nil
 		}
 
-		log.Fatal("Failed to add certificate:", err)
+		log.Println("Failed to add certificate:", err)
+
+		return nil, fmt.Errorf("failed to add certificate for cluster %q: %w", c.Name, err)
 	}
 
 	if caData := c.config.CertificateAuthorityData; len(caData) > 0 {
-		return caData
+		return caData, nil
 	}
 
-	return nil
+	return nil, fmt.Errorf("no certificate authority data found for cluster %s", c.Name)
 }
 
 func (c *Cluster) shouldVerifyTLS() bool {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -260,7 +260,8 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 			context := &contexts[i]
 			proxy, err := config.createProxyForContext(*context)
 			if err != nil {
-				log.Fatalf("Error setting up proxy for context %s: %s", context.Name, err)
+				log.Printf("Error setting up proxy for context %s: %s\n", context.Name, err)
+				continue
 			}
 
 			fmt.Printf("\tlocalhost:%s%s%s/{api...} -> %s\n", config.port, config.baseURL, "/clusters/"+context.Name,
@@ -485,9 +486,12 @@ func (c *HeadlampConfig) createProxyForContext(context Context) (*httputil.Rever
 
 	shouldVerifyTLS := !c.insecure || cluster.shouldVerifyTLS()
 	if shouldVerifyTLS {
-		if certificate := cluster.getCAData(); certificate != nil {
-			rootCAs.AppendCertsFromPEM(certificate)
+		certificate, err := cluster.getCAData()
+		if err != nil {
+			return nil, err
 		}
+
+		rootCAs.AppendCertsFromPEM(certificate)
 	}
 
 	var certs []tls.Certificate


### PR DESCRIPTION
this patch makes sure that headlamp still works for
other clusters when one of the cluster certificate
authority is misconfigured.

Signed-off-by: Santhosh Nagaraj S <santhosh@kinvolk.io>
