### PR TITLE
frontend plugins: Add hideAppBar option to routes

### DIFF
--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -41,6 +41,7 @@ export default function TopBar({}: TopBarProps) {
   const isSidebarOpenUserSelected = useTypedSelector(
     state => state.ui.sidebar.isSidebarOpenUserSelected
   );
+  const hideAppBar = useTypedSelector(state => state.ui.hideAppBar);
 
   const clustersConfig = useClustersConf();
   const cluster = useCluster();
@@ -57,6 +58,9 @@ export default function TopBar({}: TopBarProps) {
     history.push('/');
   }
 
+  if (hideAppBar) {
+    return null;
+  }
   return (
     <PureTopBar
       appBarActions={appBarActions}

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -76,6 +76,8 @@ export interface Route {
   sidebar: string | null;
   /** Shown component for this route. */
   component: () => JSX.Element;
+  /** Hide the appbar at the top. */
+  hideAppBar?: boolean;
 }
 
 const defaultRoutes: {

--- a/frontend/src/redux/actions/actions.tsx
+++ b/frontend/src/redux/actions/actions.tsx
@@ -31,6 +31,7 @@ export const UI_PLUGINS_LOADED = 'UI_PLUGINS_LOADED';
 export const UI_VERSION_DIALOG_OPEN = 'UI_VERSION_DIALOG_OPEN';
 export const UI_BRANDING_SET_APP_LOGO = 'UI_BRANDING_SET_APP_LOGO';
 export const UI_SET_CLUSTER_CHOOSER_BUTTON = 'UI_SET_CLUSTER_CHOOSER_BUTTON';
+export const UI_HIDE_APP_BAR = 'UI_HIDE_APP_BAR';
 
 export interface BrandingProps {
   logo: AppLogoType;
@@ -112,6 +113,10 @@ export function setSidebarSelected(selected: SidebarType['selected']) {
 export function setWhetherSidebarOpen(isSidebarOpen: boolean) {
   localStorage.setItem('sidebar', JSON.stringify({ shrink: !isSidebarOpen }));
   return { type: UI_SIDEBAR_SET_EXPANDED, isSidebarOpen, isSidebarOpenUserSelected: isSidebarOpen };
+}
+
+export function setHideAppBar(hideAppBar: boolean | undefined) {
+  return { type: UI_HIDE_APP_BAR, hideAppBar };
 }
 
 export function setSidebarVisible(isVisible: SidebarType['isVisible']) {

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -11,6 +11,7 @@ import {
   UI_APP_BAR_SET_ACTION,
   UI_BRANDING_SET_APP_LOGO,
   UI_DETAILS_VIEW_SET_HEADER_ACTION,
+  UI_HIDE_APP_BAR,
   UI_INITIALIZE_PLUGIN_VIEWS,
   UI_PLUGINS_LOADED,
   UI_ROUTER_SET_ROUTE,
@@ -64,6 +65,7 @@ export interface UIState {
   isVersionDialogOpen: boolean;
   notifications: Notification[];
   clusterChooserButtonComponent?: ClusterChooserType;
+  hideAppBar?: boolean;
 }
 
 function setInitialSidebarOpen() {
@@ -121,6 +123,7 @@ export const INITIAL_STATE: UIState = {
     logo: null,
   },
   notifications: [],
+  hideAppBar: false,
 };
 
 function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
@@ -164,6 +167,10 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
         isSidebarOpen: action.isSidebarOpen,
         isSidebarOpenUserSelected: action.isSidebarOpenUserSelected,
       };
+      break;
+    }
+    case UI_HIDE_APP_BAR: {
+      newFilters.hideAppBar = action.hideAppBar;
       break;
     }
     case UI_ROUTER_SET_ROUTE: {

--- a/plugins/examples/sidebar/src/index.tsx
+++ b/plugins/examples/sidebar/src/index.tsx
@@ -98,6 +98,7 @@ registerRoute({
       <Typography>Other feedback forms go here.</Typography>
     </SectionBox>
   ),
+  hideAppBar: true, // hide the top AppBar with this.
 });
 
 // The sidebar link URL is: /no-cluster-link
@@ -111,6 +112,7 @@ registerSidebarEntry({
 });
 
 // This component rendered at URL: /no-cluster-link
+// The AppBar at the top of the screen will not be shown for this route.
 registerRoute({
   path: '/no-cluster-link',
   sidebar: null,
@@ -123,6 +125,7 @@ registerRoute({
       <Typography>Your component here</Typography>
     </SectionBox>
   ),
+  hideAppBar: true, // hide the top AppBar with this.
 });
 
 // Remove "Workloads" top level sidebar menu item


### PR DESCRIPTION
So plugins can hide the app bar at the top.

Closes #681

## How to use

See bottom of plugins/examples/sidebar

Add "hideAppBar: true" to the route options in registerRoute.

```bash
cd plugins/headlamp-plugin
npm run build && npm run pack
cd ../examples/sidebar
npm i ../../headlamp-plugin/*.tgz
npm start
# run headlamp a select "no cluster link" and "other feedback" links
```
http://localhost:3000/c/minikube/feedback4
http://localhost:3000/no-cluster-link

## Testing done

- [x] hide the app bar on a route with authorization (Other feedback link)
- [x] hide the app bar on a route without auth (No cluster link)
