### PR TITLE
frontend Terminal: Use xterm.js windowsMode on Windows

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -238,12 +238,15 @@ export default function Terminal(props: TerminalProps) {
         xtermRef.current.xterm.dispose();
         execRef.current?.cancel();
       }
+
+      const isWindows = ['Windows', 'Win16', 'Win32', 'WinCE'].indexOf(navigator?.platform) >= 0;
       xtermRef.current = {
         xterm: new XTerminal({
           cursorBlink: true,
           cursorStyle: 'underline',
           scrollback: 10000,
           rows: 30, // initial rows before fit
+          windowsMode: isWindows,
         }),
         connected: false,
       };


### PR DESCRIPTION
Hopefully fixes the white space additions for long lines that wrap.

Closes #697

## How to use

See #697 on how to reproduce.

## Testing done

I tested this on a windows container, and it fixes it:

1) paste this into terminal
``` bash
echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > a
type a
```
2) copy the result of "type a".
3) paste somewhere and see it is pasted as one long line.
