### PR TITLE
Build: Create gh action to create PR

### DIFF
--- a/.github/workflows/pr-to-update-homebrew.yml
+++ b/.github/workflows/pr-to-update-homebrew.yml
@@ -1,0 +1,86 @@
+name: PR to update homebrew
+
+# This action will run after a tag starting with "v" is published
+on:
+  push:
+    tags:
+    - 'v*'
+  workflow_dispatch:
+
+env:
+  LATEST_HEADLAMP_TAG: latest
+jobs:
+  create_pr_to_upgrade_homebrew:
+    name: Create PR to upgrade homebrew
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout headlamp repo 
+        uses: actions/checkout@v2 
+        with:
+          path: headlamp
+          fetch-depth: 0
+      - name: Configure Git 
+        run: | 
+          user=${{github.actor}}
+          if [ -z $user ]; then
+            user=yolossn
+          fi
+          git config --global user.name "$user"
+          git config --global user.email "$user@users.noreply.github.com"
+      - name: Get headlamp latest tag 
+        run: |
+          cd headlamp 
+          latestTag=$(git tag --list --sort=version:refname 'v*' | tail -1)
+          echo "LATEST_HEADLAMP_TAG=$latestTag" >> $GITHUB_ENV
+          echo $latestTag
+      - name: Sync homebrew-cask fork from upstream
+        run: |
+          gh repo sync kinvolk/homebrew-cask
+        env:
+          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+      - name: Check out homebrew-cask repo 
+        uses: actions/checkout@v2 
+        with: 
+          repository: kinvolk/homebrew-cask
+          path: homebrew-cask
+          token: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+      - name: Update headlamp version in homebrew-cask
+        run: |
+          user=${{github.actor}}
+          if [ -z $user ]; then
+            user=yolossn
+          fi
+          cd homebrew-cask
+          HEADLAMP_VERSION=${LATEST_HEADLAMP_TAG:1}
+          wget "https://github.com/kinvolk/headlamp/releases/download/$LATEST_HEADLAMP_TAG/checksums.txt"
+          ARM_SHA=$(cat checksums.txt | grep .arm64.dmg | awk -F" " '{print $1}')
+          INTEL_SHA=$(cat checksums.txt | grep .x64.dmg | awk -F" " '{print $1}')
+          git checkout -b "update_headlamp_$HEADLAMP_VERSION"
+          sed -i "s/version\ .*/version \"$HEADLAMP_VERSION\"/g" ./Casks/headlamp.rb
+          if [ $ARM_SHA ]; then
+            echo "replacing ARM SHA"
+            sed -i "s/sha256 arm:\   \".*/sha256 arm:\   \"$ARM_SHA\",/g" ./Casks/headlamp.rb
+          fi
+          if [ $INTEL_SHA ]; then
+            echo "replacing Intel SHA"
+            sed -i "s/  intel:\ \".*/  intel:\ \"$INTEL_SHA\"/g" ./Casks/headlamp.rb
+          fi
+          git diff
+          rm ./checksums.txt
+          git add ./Casks/headlamp.rb
+          git status 
+          git commit --signoff -m "Update Headlamp version to $HEADLAMP_VERSION"
+          git status 
+          git log -1 
+          git push origin "update_headlamp_$HEADLAMP_VERSION" -f
+          gh pr create \
+          --title "Upgrade Headlamp version to $HEADLAMP_VERSION" \
+          --repo "Homebrew/homebrew-cask" \
+          --head "kinvolk:update_headlamp_$HEADLAMP_VERSION" \
+          --base "master"  \
+          --assignee "$user" \
+          --body "Upgrade Headlamp version to $HEADLAMP_VERSION
+            cc: @$user" \
+        env:
+          LATEST_HEADLAMP_TAG: ${{ env.LATEST_HEADLAMP_TAG }}
+          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}

--- a/.github/workflows/pr-to-update-minikube.yml
+++ b/.github/workflows/pr-to-update-minikube.yml
@@ -1,0 +1,79 @@
+name: PR to update minikube
+
+# This action will run after the "Publish container" is succesfully completed
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+on:
+  workflow_run:
+    workflows: ["Publish container"]
+    types:
+      - completed
+  workflow_dispatch:
+
+env:
+  LATEST_HEADLAMP_TAG: latest
+jobs:
+  create_pr_to_upgrade_minikube:
+    name: Create PR to upgrade minikube
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout headlamp repo 
+        uses: actions/checkout@v2 
+        with:
+          path: headlamp
+          fetch-depth: 0
+      - name: Configure Git 
+        run: | 
+          user=${{github.actor}}
+          if [ -z $user ]; then
+            user=yolossn
+          fi
+          git config --global user.name "$user"
+          git config --global user.email "$user@users.noreply.github.com"
+      - name: Get headlamp latest tag 
+        run: |
+          cd headlamp 
+          latestTag=$(git tag --list --sort=version:refname 'v*' | tail -1)
+          echo "LATEST_HEADLAMP_TAG=$latestTag" >> $GITHUB_ENV
+          echo $latestTag
+      - name: Sync minikube fork from upstream
+        run: |
+          gh repo sync kinvolk/minikube
+        env:
+          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+      - name: Check out minikube repo 
+        uses: actions/checkout@v2 
+        with: 
+          repository: kinvolk/minikube
+          path: minikube
+          token: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+      - name: Update headlamp version in minikube 
+        run: |
+          user=${{github.actor}}
+          if [ -z $user ]; then
+            user=yolossn
+          fi
+          HEADLAMP_VERSION=${LATEST_HEADLAMP_TAG:1}
+          LATEST_HEADLAMP_SHA=$(gh api \
+          "/orgs/kinvolk/packages/container/headlamp/versions" --jq "map(select(.metadata.container.tags[] | contains(\"$LATEST_HEADLAMP_TAG\"))) | .[].name")
+          echo $LATEST_HEADLAMP_SHA
+          cd minikube    
+          git checkout -b "update_headlamp_$HEADLAMP_VERSION" 
+          sed -i "s/kinvolk\/headlamp:v.*/kinvolk\/headlamp:$LATEST_HEADLAMP_TAG@$LATEST_HEADLAMP_SHA\",/g" ./pkg/minikube/assets/addons.go
+          git diff
+          git add ./pkg/minikube/assets/addons.go
+          git status 
+          git commit --signoff -m "Update Headlamp container version to $HEADLAMP_VERSION"
+          git status 
+          git log -1 
+          git push origin "update_headlamp_$HEADLAMP_VERSION" -f
+          gh pr create \
+          --title "Upgrade Headlamp version to $HEADLAMP_VERSION" \
+          --repo "kubernetes/minikube" \
+          --head "kinvolk:update_headlamp_$HEADLAMP_VERSION" \
+          --base "master"  \
+          --assignee "$user" \
+          --body "Upgrade Headlamp version to $HEADLAMP_VERSION
+            cc: @$user" \
+        env:
+          LATEST_HEADLAMP_TAG: ${{ env.LATEST_HEADLAMP_TAG }}
+          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}


### PR DESCRIPTION
This patch creates a PR to update homebrew and minikube versions. The GitHub action will get triggered once the [Publish Container](https://github.com/kinvolk/headlamp/blob/main/.github/workflows/container-publish.yml) workflow completes, this ensures that the container used in minikube is the latest one. Refer to the following example PRs created by the workflow
https://github.com/yolossn/minikube/pull/4
https://github.com/yolossn/homebrew-cask/pull/5

To Dos

- [x] Create a fork of [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask)
- [x] Create a GH token with the following access and add to secrets under the key `KINVOLK_REPOS_TOKEN`
- [x] Right now the PRs are in draft and assigned to the github actor who initiated the action, have to make decide if the PRs should be left in draft or not and add compulsory assignees.

<img width="771" alt="image" src="https://user-images.githubusercontent.com/22731013/189591793-9038b2cc-8bbe-4bb6-913b-3b19f4831492.png">


