### PR TITLE
Set default namespace

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -153,6 +153,14 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       return this.jsonData!.kind;
     }
 
+    get isNamespaced() {
+      return this._class().isNamespaced;
+    }
+
+    static get isNamespaced() {
+      return this.apiEndpoint.isNamespaced;
+    }
+
     static apiList<U extends KubeObject>(
       onList: (arg: U[]) => void,
       onError?: (err: ApiError) => void,
@@ -288,7 +296,7 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
 
     delete() {
       const args: string[] = [this.getName()];
-      if (this._class().apiEndpoint.isNamespaced) {
+      if (this.isNamespaced) {
         args.unshift(this.getNamespace()!);
       }
 
@@ -329,7 +337,7 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       const patchMethod = this._class().apiEndpoint.patch;
       const args: Parameters<typeof patchMethod> = [body];
 
-      if (this._class().apiEndpoint.isNamespaced) {
+      if (this.isNamespaced) {
         args.push(this.getNamespace());
       }
 


### PR DESCRIPTION
fixes #711 .

How to test:
- [ ] Choose a namespaced resource config, like the [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/#configmaps-and-pods) without setting a namespace in its definition, and apply it from the + button in the UI: it should succeed