### PR TITLE
Fix simple table data type

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -410,7 +410,7 @@ export function ConditionsTable(props: ConditionsTableProps) {
 
   return (
     <SimpleTable
-      data={(resource && resource.status && resource.status.conditions) || {}}
+      data={(resource && resource.status && resource.status.conditions) || []}
       columns={getColumns()}
     />
   );

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -64,10 +64,12 @@ interface SimpleTableGetterColumn extends SimpleTableColumn {
 
 export interface SimpleTableProps {
   columns: (SimpleTableGetterColumn | SimpleTableDatumColumn)[];
-  data: {
-    [dataProp: string]: any;
-    [dataProp: number]: any;
-  } | null;
+  data:
+    | {
+        [dataProp: string]: any;
+        [dataProp: number]: any;
+      }[]
+    | null;
   filterFunction?: (...args: any[]) => boolean;
   rowsPerPage?: number[];
   emptyMessage?: string;


### PR DESCRIPTION
- frontend: Don't allow objects as SimpleTable data (should be arrays)
- Fix critical crash bug due to empty object in simple table
