### PR TITLE
plugins: Fix README to mention missing examples

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,12 +6,15 @@ or in this repo at
 [../docs/development/plugins/](../docs/development/plugins/).
 
 
-Folder                                               | Description
-------                                               | -----------
-[examples/](examples)                                | Examples folder.
-[examples/pod-counter](examples/pod-counter)         | Display number of Pods in title bar.
-[examples/change-logo](examples/change-logo)         | Change the logo.
-[examples/sidebar](examples/sidebar)                 | Change the side bar menu.
-[examples/cluster-chooser](examples/cluster-chooser) | Override the default chooser button.
-headlamp-plugin                                      | headlamp-plugin script which plugins use.
-headlamp-plugin/template                             | Template for new Headlamp plugins.
+Folder                                         | Description
+------                                         | -----------
+[examples/](examples)                          | Examples folder.
+[examples/app-menus](examples/app-menus)       | Add app window menus.
+[examples/change-logo](examples/change-logo)   | Change the logo.
+[examples/cluster-chooser](examples/cluster-chooser)   | Override default chooser button.
+[examples/details-view](examples/details-view)         | Custom sections and actions for detail views.
+[examples/dynamic-clusters](examples/dynamic-clusters) | Update cluster configuration dynamically.
+[examples/pod-counter](examples/pod-counter)   | Display number of Pods in title bar.
+[examples/sidebar](examples/sidebar)           | Change the side bar menu.
+headlamp-plugin               | headlamp-plugin script which plugins use.
+headlamp-plugin/template      | Template for new Headlamp plugins.


### PR DESCRIPTION
A couple were missing in the README.