### PR TITLE
frontend: Fix filter/search when items are numbers

### DIFF
--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -200,6 +200,7 @@ const podData = {
         selfLink: '0',
         namespace: 'MyNamespace0',
       },
+      someNumber: 0,
     },
     {
       kind: 'CustomResourceDefinition',
@@ -215,6 +216,7 @@ const podData = {
           mylabel1: 'myvalue1',
         },
       },
+      someNumber: 10,
     },
     {
       kind: 'CustomResourceDefinition',
@@ -230,6 +232,7 @@ const podData = {
           mykey2: 'mylabel',
         },
       },
+      someNumber: 20,
     },
     {
       kind: 'CustomResourceDefinition',
@@ -245,6 +248,7 @@ const podData = {
           mykey3: 'myvalue3',
         },
       },
+      someNumber: 30,
     },
   ],
   defaultSortingColumn: 1,
@@ -278,6 +282,29 @@ export const NamespaceSelect = TemplateWithFilter.bind({});
 NamespaceSelect.args = {
   simpleTableArgs: podData,
   namespaces: ['MyNamespace0', 'MyNamespace1'],
+};
+
+export const NumberSearch = TemplateWithFilter.bind({});
+NumberSearch.args = {
+  simpleTableArgs: {
+    ...podData,
+    matchCriteria: ['.someNumber'],
+    columns: [
+      {
+        label: 'Name',
+        getter: (item: KubeObjectInterface) => item.metadata.name,
+      },
+      {
+        label: 'Namespace',
+        getter: (item: KubeObjectInterface) => item.metadata.namespace,
+      },
+      {
+        label: 'Number',
+        datum: 'someNumber',
+      },
+    ],
+  },
+  search: '30',
 };
 
 // emptyMessage

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -1166,6 +1166,245 @@ exports[`Storyshots SimpleTable Namespace Select 1`] = `
 </div>
 `;
 
+exports[`Storyshots SimpleTable Number Search 1`] = `
+<div
+  id="root"
+>
+  <div
+    class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item"
+    >
+      <h1
+        class="MuiTypography-root makeStyles-sectionTitle makeStyles-sectionTitle MuiTypography-h1 MuiTypography-noWrap"
+      >
+        Test
+      </h1>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-flex-end"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-wrap-xs-nowrap MuiGrid-align-items-xs-flex-end MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                aria-expanded="false"
+                class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                role="combobox"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                    style="margin-top: 0px;"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+                      data-shrink="true"
+                      for="namespaces-filter"
+                      id="namespaces-filter-label"
+                    >
+                      Namespaces
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                    >
+                      <input
+                        aria-autocomplete="both"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                        id="namespaces-filter"
+                        placeholder="Filter"
+                        spellcheck="false"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        class="MuiAutocomplete-endAdornment"
+                      >
+                        <button
+                          aria-label="Clear"
+                          class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                          tabindex="-1"
+                          title="Clear"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                        <button
+                          aria-label="Open"
+                          class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                          tabindex="-1"
+                          title="Open"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M7 10l5 5 5-5z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                class="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled MuiFormLabel-focused MuiInputLabel-focused"
+                  data-shrink="true"
+                  for="standard-search"
+                  id="standard-search-label"
+                >
+                  Search
+                </label>
+                <div
+                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-focused MuiInput-focused MuiInputBase-formControl MuiInput-formControl"
+                  role="search"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputTypeSearch MuiInput-inputTypeSearch"
+                    id="standard-search"
+                    placeholder="Filter"
+                    type="search"
+                    value="30"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                aria-controls="standard-search"
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiButton-label"
+                >
+                  Clear
+                  <span
+                    class="MuiButton-endIcon MuiButton-iconSizeMedium"
+                  >
+                    <span />
+                  </span>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <table
+    class="MuiTable-root makeStyles-table"
+  >
+    <thead
+      class="MuiTableHead-root"
+    >
+      <tr
+        class="MuiTableRow-root MuiTableRow-head"
+      >
+        <th
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          scope="col"
+        >
+          Name
+        </th>
+        <th
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          scope="col"
+        >
+          Namespace
+        </th>
+        <th
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          scope="col"
+        >
+          Number
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="MuiTableBody-root"
+    >
+      <tr
+        class="MuiTableRow-root"
+      >
+        <td
+          class="MuiTableCell-root MuiTableCell-body"
+        >
+          mydefinition.phonyresources3.io
+        </td>
+        <td
+          class="MuiTableCell-root MuiTableCell-body"
+        >
+          MyNamespace3
+        </td>
+        <td
+          class="MuiTableCell-root MuiTableCell-body"
+        >
+          30
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Storyshots SimpleTable UID Search 1`] = `
 <div
   id="root"

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -167,10 +167,10 @@ export function filterResource(
 
       // Include matches values in the criteria
       values.forEach((value: any) => {
-        if (typeof value === 'string') {
+        if (typeof value === 'string' || typeof value === 'number') {
           // Don't use empty string, otherwise it'll match everything
           if (value !== '') {
-            usedMatchCriteria.push(value.toLowerCase());
+            usedMatchCriteria.push(value.toString().toLowerCase());
           }
         } else if (Array.isArray(value)) {
           value.forEach((elem: any) => {


### PR DESCRIPTION
When items to be matched in the filter are numbers, the filter was
not matching them because it first verified whether the matched items
were string.

How to test:
- [ ] Check the new story added for it