### PR TITLE
Simplify testing

### DIFF
--- a/frontend/src/test/index.tsx
+++ b/frontend/src/test/index.tsx
@@ -1,0 +1,30 @@
+import { PropsWithChildren } from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { createStore } from 'redux';
+import defaultStore from '../redux/stores/store';
+
+export type TestContextProps = PropsWithChildren<{
+  store?: ReturnType<typeof createStore>;
+  routerMap?: Record<string, string>;
+}>;
+
+export function TestContext(props: TestContextProps) {
+  const { store, routerMap, children } = props;
+  let url = '';
+  let routePath = '';
+
+  for (const [key, value] of Object.entries(routerMap || {})) {
+    // Add the prefix : to the key to make it a param if needed.
+    routePath += '/' + (key.startsWith(':') ? key : ':' + key);
+    url += '/' + value;
+  }
+
+  return (
+    <Provider store={store || defaultStore}>
+      <MemoryRouter initialEntries={url ? [url] : undefined}>
+        {routePath ? <Route path={routePath}>{children}</Route> : children}
+      </MemoryRouter>
+    </Provider>
+  );
+}

--- a/frontend/src/test/mocker.ts
+++ b/frontend/src/test/mocker.ts
@@ -1,0 +1,48 @@
+import _ from 'lodash';
+import { KubeObjectIface, KubeObjectInterface } from '../lib/k8s/cluster';
+
+interface K8sResourceListGeneratorOptions<T extends KubeObjectInterface> {
+  numResults?: number;
+  instantiateAs?: KubeObjectIface<T>;
+}
+
+export function generateK8sResourceList<T extends KubeObjectInterface = KubeObjectInterface>(
+  baseJson: Omit<T, 'metadata'>,
+  options: K8sResourceListGeneratorOptions<T> = {}
+) {
+  const { numResults = 5, instantiateAs } = options;
+  const list = [];
+  for (let i = 0; i < numResults; i++) {
+    const json = {
+      metadata: {
+        name: '',
+      },
+      ..._.cloneDeep(baseJson),
+    } as T;
+
+    json.metadata.creationTimestamp = new Date('2020-01-01').toISOString();
+
+    if (json.metadata.name) {
+      json.metadata.name = json.metadata.name.replace('{{i}}', i.toString());
+    }
+
+    if (!json.metadata.name) {
+      json.metadata.name = json.kind.toLowerCase() + `-${i}`;
+    }
+
+    if (json.metadata.namespace !== undefined) {
+      json.metadata.namespace.replace('{{i}}', i.toString());
+      if (!json.metadata.namespace) {
+        json.metadata.namespace = 'my-namespace';
+      }
+    }
+
+    json.metadata.resourceVersion = i.toString();
+    json.metadata.selfLink = `/${json.kind.toLowerCase()}/${json.metadata.name}`;
+    json.metadata.uid = 'abcde-' + i;
+
+    list.push(!!instantiateAs ? new instantiateAs(json as T) : json);
+  }
+
+  return list;
+}


### PR DESCRIPTION
These changes allow to deeply simplify the stories we have and to create them also for views which use the list/get API with data coming from the URL (namespace, name).

see an example at #744 