### PR TITLE
Add notification and cluster-chooser page

### DIFF
--- a/frontend/src/components/App/Notifications/List.tsx
+++ b/frontend/src/components/App/Notifications/List.tsx
@@ -1,0 +1,174 @@
+import { Icon } from '@iconify/react';
+import { Box, IconButton, Menu, MenuItem, Tooltip, Typography, useTheme } from '@material-ui/core';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { Notification } from '../../../lib/notification';
+import { setUINotifications, updateUINotification } from '../../../redux/actions/actions';
+import { useTypedSelector } from '../../../redux/reducers/reducers';
+import { DateLabel, SectionBox, SectionFilterHeader, SimpleTable } from '../../common';
+import Empty from '../../common/EmptyContent';
+
+export default function NotificationList() {
+  const notifications = useTypedSelector(state => state.ui.notifications);
+  const config = useTypedSelector(state => state.config);
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const theme = useTheme();
+  const search = useTypedSelector(state => state.filter.search);
+  const history = useHistory();
+
+  function checkIfAllNotificationsDeleted() {
+    return notifications.filter(notification => notification.deleted === false).length === 0;
+  }
+
+  function notificationSeenUnseenHandler(event: any, notification?: Notification) {
+    if (!notification) {
+      return;
+    }
+    notification.seen = !notification.seen;
+    dispatch(updateUINotification(notification));
+  }
+
+  function clearAllNotifications() {
+    const currentSetOfNotifications = notifications;
+    const massagedNotifications = currentSetOfNotifications.map(notification => {
+      notification.deleted = true;
+      return notification;
+    });
+    dispatch(setUINotifications(massagedNotifications));
+  }
+
+  function markAllAsRead() {
+    const massagedNotifications = notifications.map(notification => {
+      notification.seen = true;
+      return notification;
+    });
+    dispatch(setUINotifications(massagedNotifications));
+  }
+
+  function notificationItemClickHandler(notification: Notification) {
+    notification.url && history.push(notification.url);
+    notification.seen = true;
+    dispatch(updateUINotification(notification));
+  }
+
+  function NotificationActionMenu() {
+    const [anchorEl, setAnchorEl] = useState(null);
+
+    function handleClick(event: any) {
+      setAnchorEl(event.currentTarget);
+    }
+
+    function handleClose() {
+      setAnchorEl(null);
+    }
+
+    return (
+      <>
+        <IconButton>
+          <Icon icon="mdi:dots-vertical" onClick={handleClick} />
+        </IconButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={markAllAsRead}>
+            <Typography color={'primary'}>{t('Mark all as read')}</Typography>
+          </MenuItem>
+          <MenuItem onClick={clearAllNotifications}>
+            <Typography color="primary">{t('Clear all')}</Typography>
+          </MenuItem>
+        </Menu>
+      </>
+    );
+  }
+
+  return (
+    <SectionBox
+      title={
+        <SectionFilterHeader
+          title={t('Notifications')}
+          noNamespaceFilter
+          actions={[<NotificationActionMenu />]}
+        />
+      }
+    >
+      {checkIfAllNotificationsDeleted() ? (
+        <Empty>{t(`notifications|You don't have any notifications right now`)}</Empty>
+      ) : (
+        <SimpleTable
+          filterFunction={(notification: Notification) =>
+            (notification?.message || '').includes(search)
+          }
+          columns={[
+            {
+              label: t('Message'),
+              getter: (notification: Notification) => (
+                <Box width={'30vw'}>
+                  <Tooltip
+                    title={`${t(`notifications|${notification.message}`)}`}
+                    disableHoverListener={!notification.message}
+                  >
+                    <Typography
+                      style={{
+                        fontWeight: notification.seen ? 'normal' : 'bold',
+                        cursor: 'pointer',
+                      }}
+                      noWrap
+                      onClick={() => notificationItemClickHandler(notification)}
+                    >
+                      {`${notification.message || t(`notifications|No message`)}`}
+                    </Typography>
+                  </Tooltip>
+                </Box>
+              ),
+            },
+            {
+              label: t('Cluster'),
+              getter: (notification: Notification) => (
+                <Box display={'flex'} alignItems="center">
+                  {Object.entries(config?.clusters || {}).length > 1 && notification.cluster && (
+                    <Box
+                      border={1}
+                      p={0.5}
+                      mr={1}
+                      textOverflow="ellipsis"
+                      overflow={'hidden'}
+                      whiteSpace="nowrap"
+                    >
+                      {notification.cluster}
+                    </Box>
+                  )}{' '}
+                </Box>
+              ),
+            },
+            {
+              label: t('Date'),
+              getter: (notification: Notification) => <DateLabel date={notification.date} />,
+            },
+            {
+              label: t('Visible'),
+              getter: (notification: Notification) =>
+                !notification.seen && (
+                  <Tooltip title={t(`notifications|Mark as read`)}>
+                    <IconButton
+                      onClick={e => notificationSeenUnseenHandler(e, notification)}
+                      aria-label={t(`notifications|Mark as read`)}
+                    >
+                      <Icon
+                        icon="mdi:circle"
+                        color={theme.palette.error.main}
+                        height={12}
+                        width={12}
+                      />
+                    </IconButton>
+                  </Tooltip>
+                ),
+            },
+          ]}
+          data={notifications}
+          noTableHeader
+        />
+      )}
+    </SectionBox>
+  );
+}

--- a/frontend/src/components/App/Notifications/index.tsx
+++ b/frontend/src/components/App/Notifications/index.tsx
@@ -175,6 +175,7 @@ export default function Notifications() {
   const dispatch = useDispatch();
   const [events] = Event.useList();
   const { t } = useTranslation();
+  const history = useHistory();
 
   useEffect(() => {
     let notificationsToShow: Notification[] = [];
@@ -338,6 +339,17 @@ export default function Notifications() {
           }
           clickEventHandler={menuItemClickHandler}
         />
+        <Button
+          fullWidth
+          color="primary"
+          onClick={() => {
+            history.push('/notifications');
+            setAnchorEl(null);
+          }}
+          style={{ textTransform: 'none' }}
+        >
+          {t('View all Notifications')}
+        </Button>
       </Popover>
     </>
   );

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -15,7 +15,7 @@ import CreateButton from '../common/Resource/CreateButton';
 import HeadlampButton from './HeadlampButton';
 import NavigationTabs from './NavigationTabs';
 import prepareRoutes from './prepareRoutes';
-import SidebarItem, { SidebarEntryProps } from './SidebarItem';
+import SidebarItem, { SidebarEntryProps, SidebarItemProps } from './SidebarItem';
 import VersionButton from './VersionButton';
 
 export const drawerWidth = 330;
@@ -65,6 +65,14 @@ const useStyle = makeStyles(theme => ({
   },
 }));
 
+const specialSidebarOptions: SidebarItemProps[] = [
+  {
+    name: 'notifications',
+    icon: 'mdi:bell',
+    label: 'Notifications',
+    url: '/notifications',
+  },
+];
 export default function Sidebar() {
   const sidebar = useTypedSelector(state => state.ui.sidebar);
   const isSidebarOpen = useTypedSelector(state => state.ui.sidebar.isSidebarOpen);
@@ -72,16 +80,24 @@ export default function Sidebar() {
     state => state.ui.sidebar.isSidebarOpenUserSelected
   );
   const arePluginsLoaded = useTypedSelector(state => state.ui.pluginsLoaded);
-
   const namespaces = useTypedSelector(state => state.filter.namespaces);
+  const [isSpecialSidebarOpen, setSpecialSidebarOpen] = React.useState(false);
   const dispatch = useDispatch();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const { t, i18n } = useTranslation(['glossary', 'frequent']);
   const items = React.useMemo(
-    () => prepareRoutes(t),
-    [sidebar.entries, i18n.language, arePluginsLoaded]
+    () => (isSpecialSidebarOpen ? specialSidebarOptions : prepareRoutes(t)),
+    [sidebar.entries, i18n.language, arePluginsLoaded, isSpecialSidebarOpen]
   );
   const search = namespaces.size !== 0 ? `?namespace=${[...namespaces].join('+')}` : '';
+
+  React.useEffect(() => {
+    if (specialSidebarOptions.map(item => item.name).includes(location.pathname.split('/')[1])) {
+      setSpecialSidebarOpen(true);
+    } else {
+      setSpecialSidebarOpen(false);
+    }
+  }, [location]);
 
   // Use the location to make sure the sidebar is changed, as it depends on the cluster
   // (defined in the URL ATM).

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -65,26 +65,33 @@ const useStyle = makeStyles(theme => ({
   },
 }));
 
-const specialSidebarOptions: SidebarItemProps[] = [
-  {
-    name: 'notifications',
-    icon: 'mdi:bell',
-    label: 'Notifications',
-    url: '/notifications',
-  },
-];
 export default function Sidebar() {
+  const { t, i18n } = useTranslation(['glossary', 'frequent']);
+  const specialSidebarOptions: SidebarItemProps[] = [
+    {
+      name: t('frequent|back'),
+      icon: 'mdi:arrow-left',
+      label: t('frequent|Back'),
+    },
+    {
+      name: t('frequent|notifications'),
+      icon: 'mdi:bell',
+      label: t('frequent|Notifications'),
+      url: '/notifications',
+    },
+  ];
+
   const sidebar = useTypedSelector(state => state.ui.sidebar);
   const isSidebarOpen = useTypedSelector(state => state.ui.sidebar.isSidebarOpen);
   const isSidebarOpenUserSelected = useTypedSelector(
     state => state.ui.sidebar.isSidebarOpenUserSelected
   );
+  const location = useLocation();
   const arePluginsLoaded = useTypedSelector(state => state.ui.pluginsLoaded);
   const namespaces = useTypedSelector(state => state.filter.namespaces);
   const [isSpecialSidebarOpen, setSpecialSidebarOpen] = React.useState(false);
   const dispatch = useDispatch();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const { t, i18n } = useTranslation(['glossary', 'frequent']);
   const items = React.useMemo(
     () => (isSpecialSidebarOpen ? specialSidebarOptions : prepareRoutes(t)),
     [sidebar.entries, i18n.language, arePluginsLoaded, isSpecialSidebarOpen]

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -168,6 +168,12 @@ export default function SidebarItem(props: SidebarItemProps) {
     linkClass += ' ' + classes.linkSmallWidth;
   }
 
+  function handleSpecificClickForBackSidebarOption() {
+    if (name === 'back') {
+      // todo: Handle the case when there is no history present
+      window.history.back();
+    }
+  }
   return (
     <React.Fragment>
       <ListItemLink
@@ -181,6 +187,7 @@ export default function SidebarItem(props: SidebarItemProps) {
         icon={icon}
         name={label}
         search={search}
+        onClick={handleSpecificClickForBackSidebarOption}
         {...other}
       />
       {subList.length > 0 && (

--- a/frontend/src/components/Sidebar/Sidebaritem.stories.tsx
+++ b/frontend/src/components/Sidebar/Sidebaritem.stories.tsx
@@ -2,7 +2,9 @@ import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
+import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import store from '../../redux/stores/store';
 import SidebarItem, { SidebarItemProps } from './SidebarItem';
 
 export default {
@@ -20,11 +22,13 @@ export default {
 
 const Template: Story<SidebarItemProps> = args => {
   return (
-    <Grid item style={{ backgroundColor: 'rgba(0, 0, 0, 0.87)' }}>
-      <List>
-        <SidebarItem {...args} />
-      </List>
-    </Grid>
+    <Provider store={store}>
+      <Grid item style={{ backgroundColor: 'rgba(0, 0, 0, 0.87)' }}>
+        <List>
+          <SidebarItem {...args} />
+        </List>
+      </Grid>
+    </Provider>
   );
 };
 

--- a/frontend/src/components/common/SectionFilterHeader.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.tsx
@@ -21,7 +21,12 @@ interface SectionFilterHeaderProps extends SectionHeaderProps {
 }
 
 export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
-  const { noNamespaceFilter = false, noSearch = false, ...headerProps } = props;
+  const {
+    noNamespaceFilter = false,
+    noSearch = false,
+    actions: propsActions = [],
+    ...headerProps
+  } = props;
   const filter = useTypedSelector(state => state.filter);
   const dispatch = useDispatch();
   const location = useLocation();
@@ -77,7 +82,7 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
     []
   );
 
-  const actions = [];
+  let actions: React.ReactNode[] = [];
 
   if (!showFilters) {
     actions.push(
@@ -118,6 +123,10 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
         </Grid>
       </Grid>
     );
+  }
+
+  if (!!propsActions) {
+    actions = actions.concat(propsActions);
   }
 
   return (

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -75,6 +75,7 @@ export interface SimpleTableProps {
   emptyMessage?: string;
   errorMessage?: string | null;
   defaultSortingColumn?: number;
+  noTableHeader?: boolean;
 }
 
 interface ColumnSortButtonProps {
@@ -113,6 +114,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     emptyMessage = null,
     errorMessage = null,
     defaultSortingColumn,
+    noTableHeader = false,
   } = props;
   const [page, setPage] = React.useState(0);
   const [currentData, setCurrentData] = React.useState(data);
@@ -276,31 +278,33 @@ export default function SimpleTable(props: SimpleTableProps) {
         )
       }
       <Table className={classes.table}>
-        <TableHead>
-          <TableRow>
-            {columns.map(({ label, cellProps = {}, sort }, i) => {
-              const { className = '', ...otherProps } = cellProps;
-              return (
-                <TableCell
-                  key={`tabletitle_${i}`}
-                  className={classes.headerCell + ' ' + className}
-                  {...otherProps}
-                >
-                  {label}
-                  {sort && (
-                    <ColumnSortButtons
-                      isIncreasingOrder={Boolean(isIncreasingOrder)}
-                      isDefaultSorted={sortColIndex === i}
-                      clickHandler={(isIncreasingOrder: boolean) =>
-                        sortClickHandler(isIncreasingOrder, i)
-                      }
-                    />
-                  )}
-                </TableCell>
-              );
-            })}
-          </TableRow>
-        </TableHead>
+        {!noTableHeader && (
+          <TableHead>
+            <TableRow>
+              {columns.map(({ label, cellProps = {}, sort }, i) => {
+                const { className = '', ...otherProps } = cellProps;
+                return (
+                  <TableCell
+                    key={`tabletitle_${i}`}
+                    className={classes.headerCell + ' ' + className}
+                    {...otherProps}
+                  >
+                    {label}
+                    {sort && (
+                      <ColumnSortButtons
+                        isIncreasingOrder={Boolean(isIncreasingOrder)}
+                        isDefaultSorted={sortColIndex === i}
+                        clickHandler={(isIncreasingOrder: boolean) =>
+                          sortClickHandler(isIncreasingOrder, i)
+                        }
+                      />
+                    )}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          </TableHead>
+        )}
         <TableBody>
           {filteredData.length > 0 ? (
             getPagedRows().map((row: any, i: number) => (

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { generatePath } from 'react-router';
 import NotFoundComponent from '../components/404';
 import AuthToken from '../components/account/Auth';
+import NotificationList from '../components/App/Notifications/List';
 import AuthChooser from '../components/authchooser';
 import Chooser from '../components/cluster/Chooser';
 import Overview from '../components/cluster/Overview';
@@ -508,6 +509,15 @@ const defaultRoutes: {
     name: 'Custom Resource',
     sidebar: 'crds',
     component: () => <CustomResourceDetails />,
+  },
+  notifications: {
+    path: '/notifications',
+    exact: true,
+    useClusterURL: false,
+    name: 'Notifications',
+    sidebar: 'notifications',
+    noAuthRequired: true,
+    component: () => <NotificationList />,
   },
 };
 


### PR DESCRIPTION
# [Title: describe the change in one sentence]
This patch adds two route entries /notifications and /cluster-chooser  and also add a "view all notifications" to notification popup.

## How to use
Go to notification popup click on view all notification and you will be taken to notification list view

fixes #644 