### PR TITLE
frontend: fix test warnings so running tests is less chatty

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import themesConf from '../src/lib/themes';
 import { ThemeProvider, StylesProvider } from '@material-ui/core/styles';
+import { initialize, mswDecorator } from 'msw-storybook-addon';
+import { rest } from 'msw'
+
+// https://github.com/mswjs/msw-storybook-addon
+initialize();
 
 const darkTheme = themesConf['dark'];
 const lightTheme = themesConf['light'];
@@ -29,7 +34,7 @@ const withThemeProvider = (Story, context) => {
     )
   }
 };
-export const decorators = [withThemeProvider];
+export const decorators = [withThemeProvider, mswDecorator];
 
 export const globalTypes = {
   theme: {
@@ -51,4 +56,22 @@ export const parameters = {
     ],
   },
   actions: { argTypesRegex: '^on[A-Z].*' },
+
+  // https://github.com/mswjs/msw-storybook-addon#composing-request-handlers
+  msw: {
+    handlers: [
+      rest.get('https://api.iconify.design/mdi.json', (_req, res, ctx) => {
+        return res(ctx.json({}));
+      }),
+      rest.get('http://localhost/api/v1/namespaces', (_req, res, ctx) => {
+        return res(ctx.json({}));
+      }),
+      rest.get('http://localhost/api/v1/events', (_req, res, ctx) => {
+        return res(ctx.json({}));
+      }),
+      rest.post('http://localhost/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', (_req, res, ctx) => {
+        return res(ctx.json({status: 200}));
+      }),
+    ]
+  },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -105,6 +105,8 @@
         "husky": "^4.3.8",
         "i18next-parser": "^4.7.0",
         "lint-staged": "^10.5.4",
+        "msw": "^0.47.4",
+        "msw-storybook-addon": "^1.6.3",
         "prettier": "^2.4.1",
         "resize-observer-polyfill": "^1.5.1",
         "typedoc": "^0.22.10",
@@ -3895,6 +3897,38 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz",
+      "integrity": "sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "^3.1.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4039,6 +4073,12 @@
       "dependencies": {
         "@octokit/openapi-types": "^11.2.0"
       }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -13306,6 +13346,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
@@ -13499,6 +13545,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
@@ -13744,6 +13796,15 @@
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "dependencies": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -14384,6 +14445,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
+      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -14398,6 +14468,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -15671,6 +15748,41 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -16415,6 +16527,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -16683,6 +16801,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
@@ -16712,6 +16842,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cliui": {
@@ -18365,6 +18504,27 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -20188,6 +20348,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -20326,6 +20512,30 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -21543,6 +21753,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gulp-sort": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-sort/-/gulp-sort-2.0.0.tgz",
@@ -22159,6 +22378,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
+      "dev": true
     },
     "node_modules/heimdalljs": {
       "version": "0.2.6",
@@ -22876,6 +23101,48 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "node_modules/inquirer": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -23276,6 +23543,15 @@
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -23309,6 +23585,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -25201,6 +25483,15 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
       "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
@@ -27176,6 +27467,150 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msw": {
+      "version": "0.47.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.4.tgz",
+      "integrity": "sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.0",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.0.1",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.3.0",
+        "path-to-regexp": "^6.2.0",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.2.6",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.2.x <= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.6.3.tgz",
+      "integrity": "sha512-Ps80WdRmXsmenoTwfrgKMNpQD8INUUFyUFyZOecx8QjuqSlL++UYrLaGyACXN2goOn+/VS6rb0ZapbjrasPClg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": ">=0.35.0 <1.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -27187,6 +27622,12 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.16.0",
@@ -27945,6 +28386,45 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/ordered-read-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
@@ -28003,6 +28483,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz",
+      "integrity": "sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==",
+      "dev": true
     },
     "node_modules/overlayscrollbars": {
       "version": "1.13.1",
@@ -32890,6 +33376,15 @@
         "node": "6.* || >= 7.*"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -33614,6 +34109,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
       "dev": true
     },
     "node_modules/set-value": {
@@ -34421,6 +34922,15 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+      "dev": true,
+      "dependencies": {
+        "events": "^3.3.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -37069,6 +37579,27 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
       }
     },
     "node_modules/web-namespaces": {
@@ -40624,6 +41155,32 @@
         }
       }
     },
+    "@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "requires": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "@mswjs/interceptors": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz",
+      "integrity": "sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==",
+      "dev": true,
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "^3.1.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -40752,6 +41309,12 @@
       "requires": {
         "@octokit/openapi-types": "^11.2.0"
       }
+    },
+    "@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -47788,6 +48351,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
     "@types/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
@@ -47981,6 +48550,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
     },
     "@types/js-yaml": {
       "version": "4.0.5",
@@ -48228,6 +48803,15 @@
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "requires": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/set-cookie-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -48740,6 +49324,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
+      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+      "dev": true
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -48754,6 +49344,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "abab": {
       "version": "2.0.6",
@@ -49727,6 +50324,29 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -50294,6 +50914,12 @@
       "resolved": "https://registry.npmjs.org/charcodes/-/charcodes-0.2.0.tgz",
       "integrity": "sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ=="
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -50500,6 +51126,12 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true
+    },
     "cli-table3": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
@@ -50519,6 +51151,12 @@
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
       }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
@@ -51809,6 +52447,23 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
           "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+        }
+      }
+    },
+    "defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+          "dev": true
         }
       }
     },
@@ -53252,6 +53907,28 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -53370,6 +54047,23 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        }
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -54336,6 +55030,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true
+    },
     "gulp-sort": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-sort/-/gulp-sort-2.0.0.tgz",
@@ -54812,6 +55512,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "headers-polyfill": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
+      "dev": true
     },
     "heimdalljs": {
       "version": "0.2.6",
@@ -55366,6 +56072,41 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "inquirer": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -55636,6 +56377,12 @@
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -55657,6 +56404,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
+    },
+    "is-node-process": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -57071,6 +57824,12 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
       "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -58522,6 +59281,106 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msw": {
+      "version": "0.47.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.4.tgz",
+      "integrity": "sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==",
+      "dev": true,
+      "requires": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.0",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.0.1",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.3.0",
+        "path-to-regexp": "^6.2.0",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.2.6",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
+    "msw-storybook-addon": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.6.3.tgz",
+      "integrity": "sha512-Ps80WdRmXsmenoTwfrgKMNpQD8INUUFyUFyZOecx8QjuqSlL++UYrLaGyACXN2goOn+/VS6rb0ZapbjrasPClg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
+      }
+    },
     "multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -58530,6 +59389,12 @@
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       }
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "nan": {
       "version": "2.16.0",
@@ -59135,6 +60000,35 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "ordered-read-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
@@ -59192,6 +60086,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "outvariant": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz",
+      "integrity": "sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==",
+      "dev": true
     },
     "overlayscrollbars": {
       "version": "1.13.1",
@@ -62675,6 +63575,12 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -63238,6 +64144,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
       "dev": true
     },
     "set-value": {
@@ -63909,6 +64821,15 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "strict-event-emitter": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+      "dev": true,
+      "requires": {
+        "events": "^3.3.0"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -66008,6 +66929,25 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "requires": {
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
       }
     },
     "web-namespaces": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
     "start": "react-scripts start",
     "prebuild": "npm run make-version",
     "build": "if-env PUBLIC_URL react-scripts build || cross-env PUBLIC_URL=./ react-scripts build --max_old_space_size=768 && rimraf build/frontend/index.baseUrl.html",
-    "test": "cross-env TEST_TZ=true react-scripts test",
+    "test": "cross-env UNDER_TEST=true react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint -c package.json --ext .js,.ts,.tsx src/ ../app/electron ../plugins/headlamp-plugin --ignore-pattern ../plugins/headlamp-plugin/template",
     "format": "prettier --config package.json --write src ../app/electron ../plugins/headlamp-plugin/bin ../plugins/headlamp-plugin/lib ../plugins/headlamp-plugin/config ../plugins/headlamp-plugin/template ../plugins/headlamp-plugin/test*.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -191,6 +191,8 @@
     "husky": "^4.3.8",
     "i18next-parser": "^4.7.0",
     "lint-staged": "^10.5.4",
+    "msw": "^0.47.4",
+    "msw-storybook-addon": "^1.6.3",
     "prettier": "^2.4.1",
     "resize-observer-polyfill": "^1.5.1",
     "typedoc": "^0.22.10",

--- a/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots TopBar No Token 1`] = `
-<div
-  id="root"
->
+<div>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiAppBar-root MuiAppBar-positionFixed MuiAppBar-colorPrimary makeStyles-appbar makeStyles-appbar mui-fixed MuiPaper-elevation1"
@@ -116,9 +114,7 @@ exports[`Storyshots TopBar No Token 1`] = `
 `;
 
 exports[`Storyshots TopBar One Cluster 1`] = `
-<div
-  id="root"
->
+<div>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiAppBar-root MuiAppBar-positionFixed MuiAppBar-colorPrimary makeStyles-appbar makeStyles-appbar mui-fixed MuiPaper-elevation1"
@@ -231,9 +227,7 @@ exports[`Storyshots TopBar One Cluster 1`] = `
 `;
 
 exports[`Storyshots TopBar Token 1`] = `
-<div
-  id="root"
->
+<div>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiAppBar-root MuiAppBar-positionFixed MuiAppBar-colorPrimary makeStyles-appbar makeStyles-appbar mui-fixed MuiPaper-elevation1"
@@ -346,9 +340,7 @@ exports[`Storyshots TopBar Token 1`] = `
 `;
 
 exports[`Storyshots TopBar Two Cluster 1`] = `
-<div
-  id="root"
->
+<div>
   <nav
     aria-label="Appbar Tools"
     class="MuiPaper-root MuiAppBar-root MuiAppBar-positionFixed MuiAppBar-colorPrimary makeStyles-appbar makeStyles-appbar mui-fixed MuiPaper-elevation1"

--- a/frontend/src/components/App/__snapshots__/VersionDialog.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/VersionDialog.stories.storyshot
@@ -2,6 +2,6 @@
 
 exports[`Storyshots Version Dialog Version Dialog 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;

--- a/frontend/src/components/DetailsViewSection/__snapshots__/DetailsViewSection.stories.storyshot
+++ b/frontend/src/components/DetailsViewSection/__snapshots__/DetailsViewSection.stories.storyshot
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots DetailsViewSection Match Render It 1`] = `
-<div
-  id="root"
-/>
-`;
+exports[`Storyshots DetailsViewSection Match Render It 1`] = `<div />`;
 
-exports[`Storyshots DetailsViewSection No Match No Render 1`] = `
-<div
-  id="root"
-/>
-`;
+exports[`Storyshots DetailsViewSection No Match No Render 1`] = `<div />`;

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Sidebar/Sidebar Closed 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiDrawer-root MuiDrawer-docked makeStyles-drawer makeStyles-drawerClose"
   >
@@ -753,9 +751,7 @@ exports[`Storyshots Sidebar/Sidebar Closed 1`] = `
 `;
 
 exports[`Storyshots Sidebar/Sidebar Open 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiDrawer-root MuiDrawer-docked makeStyles-drawer makeStyles-drawerOpen"
   >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Sidebar/SidebarItem Selected 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-item"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -44,9 +42,7 @@ exports[`Storyshots Sidebar/SidebarItem Selected 1`] = `
 `;
 
 exports[`Storyshots Sidebar/SidebarItem Sublist 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-item"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -130,9 +126,7 @@ exports[`Storyshots Sidebar/SidebarItem Sublist 1`] = `
 `;
 
 exports[`Storyshots Sidebar/SidebarItem Sublist Expanded 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-item"
     style="background-color: rgba(0, 0, 0, 0.87);"
@@ -216,9 +210,7 @@ exports[`Storyshots Sidebar/SidebarItem Sublist Expanded 1`] = `
 `;
 
 exports[`Storyshots Sidebar/SidebarItem Unselected 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-item"
     style="background-color: rgba(0, 0, 0, 0.87);"

--- a/frontend/src/components/account/__snapshots__/AuthToken.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots AuthToken Show Actions 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 >
   <main
     class="MuiBox-root MuiBox-root"
@@ -12,7 +12,7 @@ exports[`Storyshots AuthToken Show Actions 1`] = `
 
 exports[`Storyshots AuthToken Show Error 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 >
   <main
     class="MuiBox-root MuiBox-root"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.stories.storyshot
@@ -2,30 +2,30 @@
 
 exports[`Storyshots AuthChooser An Error 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots AuthChooser Auth Typeoidc 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots AuthChooser Basic Auth Chooser 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots AuthChooser Have Clusters 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots AuthChooser Testing 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;

--- a/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.stories.storyshot
+++ b/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots common/ActionButton Basic 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="Some label"
     class="MuiButtonBase-root MuiIconButton-root"
@@ -24,9 +22,7 @@ exports[`Storyshots common/ActionButton Basic 1`] = `
 `;
 
 exports[`Storyshots common/ActionButton Large And Colorful 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="Some label"
     class="MuiButtonBase-root MuiIconButton-root"
@@ -47,9 +43,7 @@ exports[`Storyshots common/ActionButton Large And Colorful 1`] = `
 `;
 
 exports[`Storyshots common/ActionButton Long Description 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="Some label"
     class="MuiButtonBase-root MuiIconButton-root"

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentBar.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Charts/PercentageBar No Data 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="recharts-responsive-container makeStyles-container"
     style="width: 95%; height: 20px;"
@@ -12,9 +10,7 @@ exports[`Storyshots Charts/PercentageBar No Data 1`] = `
 `;
 
 exports[`Storyshots Charts/PercentageBar Percent 50 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="recharts-responsive-container makeStyles-container"
     style="width: 95%; height: 20px;"
@@ -23,9 +19,7 @@ exports[`Storyshots Charts/PercentageBar Percent 50 1`] = `
 `;
 
 exports[`Storyshots Charts/PercentageBar Percent 100 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="recharts-responsive-container makeStyles-container"
     style="width: 95%; height: 20px;"
@@ -34,9 +28,7 @@ exports[`Storyshots Charts/PercentageBar Percent 100 1`] = `
 `;
 
 exports[`Storyshots Charts/PercentageBar Tooltip 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="recharts-responsive-container makeStyles-container"
     style="width: 95%; height: 20px;"

--- a/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.stories.storyshot
+++ b/frontend/src/components/common/Chart.stories/__snapshots__/PercentageCircle.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Charts/PercentageCircle No Data 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     aria-busy="true"
     aria-live="polite"
@@ -43,9 +41,7 @@ exports[`Storyshots Charts/PercentageCircle No Data 1`] = `
 `;
 
 exports[`Storyshots Charts/PercentageCircle Percent 50 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     aria-busy="false"
     aria-live="polite"
@@ -127,9 +123,7 @@ exports[`Storyshots Charts/PercentageCircle Percent 50 1`] = `
 `;
 
 exports[`Storyshots Charts/PercentageCircle Percent 100 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     aria-busy="false"
     aria-live="polite"

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -60,7 +60,11 @@ export function DialogTitle(props: OurDialogTitleProps) {
         </Grid>
         {buttons && buttons.length > 0 && (
           <Grid item>
-            <Box>{buttons}</Box>
+            <Box>
+              {buttons.map((button, index) => {
+                return <React.Fragment key={index}>{button}</React.Fragment>;
+              })}
+            </Box>
           </Grid>
         )}
       </Grid>

--- a/frontend/src/components/common/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -19,30 +19,42 @@ const Template: Story<ErrorBoundaryProps> = args => (
     <i>This is not failing.</i>
   </ErrorBoundary>
 );
-export const NoProblem = Template.bind({});
+const NoProblem = Template.bind({});
 NoProblem.args = {};
 
-const BrokenTemplate: Story<ErrorBoundaryProps> = args => (
-  <ErrorBoundary {...args}>
-    <BrokenComponent />
-  </ErrorBoundary>
-);
-export const BrokenNoFallback = BrokenTemplate.bind({});
-BrokenNoFallback.args = {};
+// Do not run these under test, because they emit lots of console.error logs.
+// It's still useful to run them in the storybook, to see and test them manually.
+type StoryOrNull = Story<ErrorBoundaryProps> | (() => void);
+let BrokenNoFallback: StoryOrNull = () => 'disabled under test to avoid console spam';
+let BrokenFallback: StoryOrNull = () => 'disabled under test to avoid console spam';
+let BrokenFallbackElement: StoryOrNull = () => 'disabled under test to avoid console spam';
 
-const BrokenFallbackTemplate: Story<ErrorBoundaryProps> = args => (
-  <ErrorBoundary {...args}>
-    <BrokenComponent />
-  </ErrorBoundary>
-);
-export const BrokenFallback = BrokenFallbackTemplate.bind({});
-BrokenFallback.args = {
-  fallback: ({ error }: { error: Error }) => {
-    return <div>This is a fallback. Error msg: "{error}"</div>;
-  },
-};
+if (process.env.UNDER_TEST !== 'true') {
+  // These are only seen in the storybook, not under test.
+  const BrokenTemplate: Story<ErrorBoundaryProps> = args => (
+    <ErrorBoundary {...args}>
+      <BrokenComponent />
+    </ErrorBoundary>
+  );
+  BrokenNoFallback = BrokenTemplate.bind({});
+  BrokenNoFallback.args = {};
 
-export const BrokenFallbackElement = BrokenFallbackTemplate.bind({});
-BrokenFallback.args = {
-  fallback: <p>A simple element</p>,
-};
+  const BrokenFallbackTemplate: Story<ErrorBoundaryProps> = args => (
+    <ErrorBoundary {...args}>
+      <BrokenComponent />
+    </ErrorBoundary>
+  );
+  BrokenFallback = BrokenFallbackTemplate.bind({});
+  BrokenFallback.args = {
+    fallback: ({ error }: { error: Error }) => {
+      return <div>This is a fallback. Error msg: "{error}"</div>;
+    },
+  };
+
+  BrokenFallbackElement = BrokenFallbackTemplate.bind({});
+  BrokenFallback.args = {
+    fallback: <p>A simple element</p>,
+  };
+}
+
+export { NoProblem, BrokenNoFallback, BrokenFallback, BrokenFallbackElement };

--- a/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.stories.storyshot
+++ b/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.stories.storyshot
@@ -1,33 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots common/ErrorBoundary Broken Fallback 1`] = `
-<div
-  id="root"
->
+<div>
   disabled under test to avoid console spam
 </div>
 `;
 
 exports[`Storyshots common/ErrorBoundary Broken Fallback Element 1`] = `
-<div
-  id="root"
->
+<div>
   disabled under test to avoid console spam
 </div>
 `;
 
 exports[`Storyshots common/ErrorBoundary Broken No Fallback 1`] = `
-<div
-  id="root"
->
+<div>
   disabled under test to avoid console spam
 </div>
 `;
 
 exports[`Storyshots common/ErrorBoundary No Problem 1`] = `
-<div
-  id="root"
->
+<div>
   <i>
     This is not failing.
   </i>

--- a/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.stories.storyshot
+++ b/frontend/src/components/common/ErrorBoundary/__snapshots__/ErrorBoundary.stories.storyshot
@@ -4,22 +4,24 @@ exports[`Storyshots common/ErrorBoundary Broken Fallback 1`] = `
 <div
   id="root"
 >
-  <p>
-    A simple element
-  </p>
+  disabled under test to avoid console spam
 </div>
 `;
 
 exports[`Storyshots common/ErrorBoundary Broken Fallback Element 1`] = `
 <div
   id="root"
-/>
+>
+  disabled under test to avoid console spam
+</div>
 `;
 
 exports[`Storyshots common/ErrorBoundary Broken No Fallback 1`] = `
 <div
   id="root"
-/>
+>
+  disabled under test to avoid console spam
+</div>
 `;
 
 exports[`Storyshots common/ErrorBoundary No Problem 1`] = `

--- a/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.stories.storyshot
@@ -47,23 +47,7 @@ exports[`Storyshots Label/HeaderLabel Header Label Tool Tip 1`] = `
       <div
         class="MuiContainer-root makeStyles-container MuiContainer-maxWidthLg"
       >
-        <svg
-          aria-hidden="true"
-          class=" iconify iconify--mdi"
-          height="1em"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          title="tooltip"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <path
-            d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span />
       </div>
     </div>
     <div

--- a/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HeaderLabel.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Label/HeaderLabel Header Label 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center"
   >
@@ -34,9 +32,7 @@ exports[`Storyshots Label/HeaderLabel Header Label 1`] = `
 `;
 
 exports[`Storyshots Label/HeaderLabel Header Label Tool Tip 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center"
   >
@@ -51,7 +47,23 @@ exports[`Storyshots Label/HeaderLabel Header Label Tool Tip 1`] = `
       <div
         class="MuiContainer-root makeStyles-container MuiContainer-maxWidthLg"
       >
-        <span />
+        <svg
+          aria-hidden="true"
+          class=" iconify iconify--mdi"
+          height="1em"
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          title="tooltip"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <path
+            d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
+            fill="currentColor"
+          />
+        </svg>
       </div>
     </div>
     <div

--- a/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.stories.storyshot
@@ -1,28 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Label/HoverInfoLabel Hover Info Label 1`] = `
-<div
-  id="root"
->
+<div>
   <p
     class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
     title="hover info"
   >
     Some label
-    <span />
+    <svg
+      aria-hidden="true"
+      class="makeStyles-icon iconify iconify--mdi"
+      height="1rem"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      viewBox="0 0 24 24"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+    >
+      <path
+        d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
+        fill="currentColor"
+      />
+    </svg>
   </p>
 </div>
 `;
 
 exports[`Storyshots Label/HoverInfoLabel Hover Info Label Info 1`] = `
-<div
-  id="root"
->
+<div>
   <p
     class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
   >
     Some label
-    <span />
+    <svg
+      aria-hidden="true"
+      class="makeStyles-icon iconify iconify--mdi"
+      height="1rem"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      viewBox="0 0 24 24"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+    >
+      <path
+        d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
+        fill="currentColor"
+      />
+    </svg>
   </p>
 </div>
 `;

--- a/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/HoverInfoLabel.stories.storyshot
@@ -7,22 +7,7 @@ exports[`Storyshots Label/HoverInfoLabel Hover Info Label 1`] = `
     title="hover info"
   >
     Some label
-    <svg
-      aria-hidden="true"
-      class="makeStyles-icon iconify iconify--mdi"
-      height="1rem"
-      preserveAspectRatio="xMidYMid meet"
-      role="img"
-      viewBox="0 0 24 24"
-      width="1rem"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    >
-      <path
-        d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span />
   </p>
 </div>
 `;
@@ -33,22 +18,7 @@ exports[`Storyshots Label/HoverInfoLabel Hover Info Label Info 1`] = `
     class="MuiTypography-root makeStyles-noWrap MuiTypography-body1"
   >
     Some label
-    <svg
-      aria-hidden="true"
-      class="makeStyles-icon iconify iconify--mdi"
-      height="1rem"
-      preserveAspectRatio="xMidYMid meet"
-      role="img"
-      viewBox="0 0 24 24"
-      width="1rem"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    >
-      <path
-        d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span />
   </p>
 </div>
 `;

--- a/frontend/src/components/common/Label.stories/__snapshots__/InfoLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/InfoLabel.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Label/InfoLabel Info Label 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-align-items-xs-flex-start"
   >

--- a/frontend/src/components/common/Label.stories/__snapshots__/NameLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/NameLabel.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Label/NameLabel Name Label 1`] = `
-<div
-  id="root"
->
+<div>
   <span
     class="MuiTypography-root makeStyles-nameLabel MuiTypography-body1"
   >

--- a/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Label/StatusLabel Error 1`] = `
-<div
-  id="root"
->
+<div>
   <span
     class="MuiTypography-root makeStyles-statusLabel  MuiTypography-body1"
     style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
@@ -14,9 +12,7 @@ exports[`Storyshots Label/StatusLabel Error 1`] = `
 `;
 
 exports[`Storyshots Label/StatusLabel Success 1`] = `
-<div
-  id="root"
->
+<div>
   <span
     class="MuiTypography-root makeStyles-statusLabel  MuiTypography-body1"
     style="background-color: rgb(232, 245, 233); color: rgb(46, 125, 50);"
@@ -27,9 +23,7 @@ exports[`Storyshots Label/StatusLabel Success 1`] = `
 `;
 
 exports[`Storyshots Label/StatusLabel Warning 1`] = `
-<div
-  id="root"
->
+<div>
   <span
     class="MuiTypography-root makeStyles-statusLabel  MuiTypography-body1"
     style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"

--- a/frontend/src/components/common/Label.stories/__snapshots__/ValueLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/ValueLabel.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Label/ValueLabel Value Label 1`] = `
-<div
-  id="root"
->
+<div>
   <span
     class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
   >

--- a/frontend/src/components/common/Resource/EditorDialog.stories.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.stories.tsx
@@ -26,3 +26,11 @@ const Template: Story<EditorDialogProps> = args => {
 };
 
 export const EditorDialogWithResource = Template.bind({});
+EditorDialogWithResource.args = {
+  open: true,
+};
+
+export const EditorDialogWithResourceClosed = Template.bind({});
+EditorDialogWithResourceClosed.args = {
+  open: false,
+};

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -315,9 +315,6 @@ export default function EditorDialog(props: EditorDialogProps) {
             ) : (
               <Tabs
                 onTabChanged={handleTabChange}
-                tabProps={{
-                  centered: true,
-                }}
                 tabs={[
                   {
                     label: t('frequent|Editor'),

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.stories.storyshot
@@ -2,12 +2,8 @@
 
 exports[`Storyshots Resource/EditorDialog Editor Dialog With Resource 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
-exports[`Storyshots Resource/EditorDialog Editor Dialog With Resource Closed 1`] = `
-<div
-  id="root"
-/>
-`;
+exports[`Storyshots Resource/EditorDialog Editor Dialog With Resource Closed 1`] = `<div />`;

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.stories.storyshot
@@ -5,3 +5,9 @@ exports[`Storyshots Resource/EditorDialog Editor Dialog With Resource 1`] = `
   id="root"
 />
 `;
+
+exports[`Storyshots Resource/EditorDialog Editor Dialog With Resource Closed 1`] = `
+<div
+  id="root"
+/>
+`;

--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >
@@ -127,9 +125,7 @@ exports[`Storyshots Resource/MetadataDisplay Metadata Display 1`] = `
 `;
 
 exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >
@@ -313,9 +309,7 @@ exports[`Storyshots Resource/MetadataDisplay With Extra Rows 1`] = `
 `;
 
 exports[`Storyshots Resource/MetadataDisplay With Owner References 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots ResourceTable Name Search 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >
@@ -119,9 +117,7 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
 `;
 
 exports[`Storyshots ResourceTable No Filter 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >

--- a/frontend/src/components/common/Resource/__snapshots__/SimpleEditor.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/SimpleEditor.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Resource/SimpleEditor Simple 1`] = `
-<div
-  id="root"
->
+<div>
   <textarea
     aria-label="yaml Code"
     class="makeStyles-editor"

--- a/frontend/src/components/common/Resource/__snapshots__/ViewButton.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ViewButton.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Resource/ViewButton View 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="View YAML"
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
@@ -25,7 +23,7 @@ exports[`Storyshots Resource/ViewButton View 1`] = `
 
 exports[`Storyshots Resource/ViewButton View Open 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 >
   <button
     aria-label="View YAML"

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -70,6 +70,7 @@ export default function Tabs(props: TabsProps) {
         textColor="primary"
         aria-label={t('tabs')}
         variant="scrollable"
+        centered={false}
         scrollButtons="auto"
         className={props.className}
         {...tabProps}

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.stories.storyshot
@@ -1,21 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Tooltip/TooltipIcon Just Text 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiContainer-root makeStyles-container MuiContainer-maxWidthLg"
   >
-    <span />
+    <svg
+      aria-hidden="true"
+      class=" iconify iconify--mdi"
+      height="1em"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      title="This is the text"
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+    >
+      <path
+        d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
+        fill="currentColor"
+      />
+    </svg>
   </div>
 </div>
 `;
 
 exports[`Storyshots Tooltip/TooltipIcon With Icon 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiContainer-root makeStyles-container MuiContainer-maxWidthLg"
   >

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipIcon.stories.storyshot
@@ -5,23 +5,7 @@ exports[`Storyshots Tooltip/TooltipIcon Just Text 1`] = `
   <div
     class="MuiContainer-root makeStyles-container MuiContainer-maxWidthLg"
   >
-    <svg
-      aria-hidden="true"
-      class=" iconify iconify--mdi"
-      height="1em"
-      preserveAspectRatio="xMidYMid meet"
-      role="img"
-      title="This is the text"
-      viewBox="0 0 24 24"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    >
-      <path
-        d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
-        fill="currentColor"
-      />
-    </svg>
+    <span />
   </div>
 </div>
 `;

--- a/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.stories.storyshot
+++ b/frontend/src/components/common/Tooltip/__snapshots__/TooltipLight.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Tooltip/TooltipLight Add 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="Add"
     class="MuiButtonBase-root MuiIconButton-root"

--- a/frontend/src/components/common/__snapshots__/ActionsNotifier.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ActionsNotifier.stories.storyshot
@@ -1,15 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots ActionsNotifier None 1`] = `
-<div
-  id="root"
-/>
-`;
+exports[`Storyshots ActionsNotifier None 1`] = `<div />`;
 
 exports[`Storyshots ActionsNotifier Some 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="makeStyles-bottom makeStyles-left makeStyles-root"
   >

--- a/frontend/src/components/common/__snapshots__/AlertNotification.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/AlertNotification.stories.storyshot
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots AlertNotification Error 1`] = `
-<div
-  id="root"
-/>
-`;
+exports[`Storyshots AlertNotification Error 1`] = `<div />`;
 
-exports[`Storyshots AlertNotification No Error 1`] = `
-<div
-  id="root"
-/>
-`;
+exports[`Storyshots AlertNotification No Error 1`] = `<div />`;

--- a/frontend/src/components/common/__snapshots__/ConfirmButton.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmButton.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots ConfirmButton Confirm 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="confirm undo"
     class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -24,9 +22,7 @@ exports[`Storyshots ConfirmButton Confirm 1`] = `
 `;
 
 exports[`Storyshots ConfirmButton Extends Button 1`] = `
-<div
-  id="root"
->
+<div>
   <button
     aria-label="confirm undo"
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary"

--- a/frontend/src/components/common/__snapshots__/ConfirmDialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmDialog.stories.storyshot
@@ -2,16 +2,14 @@
 
 exports[`Storyshots ConfirmDialog Confirm Dialog 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 >
   <div />
 </div>
 `;
 
 exports[`Storyshots ConfirmDialog Confirm Dialog Closed 1`] = `
-<div
-  id="root"
->
+<div>
   <div />
 </div>
 `;

--- a/frontend/src/components/common/__snapshots__/Dialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.stories.storyshot
@@ -2,24 +2,24 @@
 
 exports[`Storyshots Dialog Dialog 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots Dialog Dialog Already In Full Screen 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots Dialog Dialog With Close Button 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;
 
 exports[`Storyshots Dialog Dialog With Full Screen Button 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;

--- a/frontend/src/components/common/__snapshots__/Link.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Link.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Link Basic 1`] = `
-<div
-  id="root"
->
+<div>
   <a
     class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
     href="/"
@@ -14,9 +12,7 @@ exports[`Storyshots Link Basic 1`] = `
 `;
 
 exports[`Storyshots Link Params 1`] = `
-<div
-  id="root"
->
+<div>
   <a
     class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
     href="/"

--- a/frontend/src/components/common/__snapshots__/Loader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Loader.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Loader With Container 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root makeStyles-loaderContainer"
   >
@@ -32,9 +30,7 @@ exports[`Storyshots Loader With Container 1`] = `
 `;
 
 exports[`Storyshots Loader Without Container 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
     role="progressbar"

--- a/frontend/src/components/common/__snapshots__/LogViewer.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/LogViewer.stories.storyshot
@@ -2,6 +2,6 @@
 
 exports[`Storyshots LogViewer Some Logs 1`] = `
 <div
-  id="root"
+  aria-hidden="true"
 />
 `;

--- a/frontend/src/components/common/__snapshots__/NamespacesAutocomplete.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/NamespacesAutocomplete.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots NamespacesAutocomplete Some 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     aria-expanded="false"
     class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"

--- a/frontend/src/components/common/__snapshots__/SectionBox.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionBox.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots SectionBox Custom Title 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -22,9 +20,7 @@ exports[`Storyshots SectionBox Custom Title 1`] = `
 `;
 
 exports[`Storyshots SectionBox Header Props 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -53,9 +49,7 @@ exports[`Storyshots SectionBox Header Props 1`] = `
 `;
 
 exports[`Storyshots SectionBox Titled 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -84,9 +78,7 @@ exports[`Storyshots SectionBox Titled 1`] = `
 `;
 
 exports[`Storyshots SectionBox Titled Children 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -119,9 +111,7 @@ exports[`Storyshots SectionBox Titled Children 1`] = `
 `;
 
 exports[`Storyshots SectionBox With Children 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >

--- a/frontend/src/components/common/__snapshots__/SectionHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SectionHeader.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots SectionHeader Actions 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -43,9 +41,7 @@ exports[`Storyshots SectionHeader Actions 1`] = `
 `;
 
 exports[`Storyshots SectionHeader Main 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -63,9 +59,7 @@ exports[`Storyshots SectionHeader Main 1`] = `
 `;
 
 exports[`Storyshots SectionHeader Normal 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -83,9 +77,7 @@ exports[`Storyshots SectionHeader Normal 1`] = `
 `;
 
 exports[`Storyshots SectionHeader Normal No Padding 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -103,9 +95,7 @@ exports[`Storyshots SectionHeader Normal No Padding 1`] = `
 `;
 
 exports[`Storyshots SectionHeader Subsection 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots SimpleTable Datum 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >
@@ -120,9 +118,7 @@ exports[`Storyshots SimpleTable Datum 1`] = `
 `;
 
 exports[`Storyshots SimpleTable Getter 1`] = `
-<div
-  id="root"
->
+<div>
   <table
     class="MuiTable-root makeStyles-table"
   >
@@ -260,9 +256,7 @@ exports[`Storyshots SimpleTable Getter 1`] = `
 `;
 
 exports[`Storyshots SimpleTable Label Search 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -534,9 +528,7 @@ exports[`Storyshots SimpleTable Label Search 1`] = `
 `;
 
 exports[`Storyshots SimpleTable Name Search 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -784,9 +776,7 @@ exports[`Storyshots SimpleTable Name Search 1`] = `
 `;
 
 exports[`Storyshots SimpleTable Namespace Search 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -1034,9 +1024,7 @@ exports[`Storyshots SimpleTable Namespace Search 1`] = `
 `;
 
 exports[`Storyshots SimpleTable Namespace Select 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -1318,9 +1306,7 @@ exports[`Storyshots SimpleTable Namespace Select 1`] = `
 `;
 
 exports[`Storyshots SimpleTable Number Search 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >
@@ -1557,9 +1543,7 @@ exports[`Storyshots SimpleTable Number Search 1`] = `
 `;
 
 exports[`Storyshots SimpleTable UID Search 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root makeStyles-sectionHeader makeStyles-sectionHeader MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-space-between"
   >

--- a/frontend/src/components/common/__snapshots__/Tabs.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Tabs Basic Tabs 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiTabs-root"
   >
@@ -88,9 +86,7 @@ exports[`Storyshots Tabs Basic Tabs 1`] = `
 `;
 
 exports[`Storyshots Tabs Starting Tab 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiTabs-root"
   >

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -81,22 +81,7 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
             <span
               class="MuiButton-startIcon MuiButton-iconSizeSmall"
             >
-              <svg
-                aria-hidden="true"
-                class="iconify iconify--mdi"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-              >
-                <path
-                  d="M15.41 16.58L10.83 12l4.58-4.59L14 6l-6 6l6 6l1.41-1.42Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span />
             </span>
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -146,22 +131,7 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                     <span
                       class="MuiIconButton-label"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="iconify iconify--mdi"
-                        height="1em"
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <path
-                          d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83l3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
+                      <span />
                     </span>
                     <span
                       class="MuiTouchRipple-root"
@@ -284,22 +254,7 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                         title="My description"
                       >
                         mycustomresource
-                        <svg
-                          aria-hidden="true"
-                          class="makeStyles-icon iconify iconify--mdi"
-                          height="1rem"
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width="1rem"
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                        >
-                          <path
-                            d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
-                            fill="currentColor"
-                          />
-                        </svg>
+                        <span />
                       </p>
                     </td>
                   </tr>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots crd/CustomResourceDetails Error Getting CR 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -17,9 +15,7 @@ exports[`Storyshots crd/CustomResourceDetails Error Getting CR 1`] = `
 `;
 
 exports[`Storyshots crd/CustomResourceDetails Error Getting CRD 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -33,9 +29,7 @@ exports[`Storyshots crd/CustomResourceDetails Error Getting CRD 1`] = `
 `;
 
 exports[`Storyshots crd/CustomResourceDetails Loading CRD 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root makeStyles-loaderContainer"
   >
@@ -64,9 +58,7 @@ exports[`Storyshots crd/CustomResourceDetails Loading CRD 1`] = `
 `;
 
 exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
   >
@@ -89,7 +81,22 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
             <span
               class="MuiButton-startIcon MuiButton-iconSizeSmall"
             >
-              <span />
+              <svg
+                aria-hidden="true"
+                class="iconify iconify--mdi"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+              >
+                <path
+                  d="M15.41 16.58L10.83 12l4.58-4.59L14 6l-6 6l6 6l1.41-1.42Z"
+                  fill="currentColor"
+                />
+              </svg>
             </span>
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -130,10 +137,45 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   class="MuiGrid-root MuiGrid-item"
                 >
                   <button
-                    aria-label="View YAML"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
+                    aria-label="Edit"
+                    class="MuiButtonBase-root MuiIconButton-root"
                     tabindex="0"
-                    title="View YAML"
+                    title="Edit"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="iconify iconify--mdi"
+                        height="1em"
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                      >
+                        <path
+                          d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83l3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                >
+                  <button
+                    aria-label="Delete"
+                    class="MuiButtonBase-root MuiIconButton-root"
+                    tabindex="0"
+                    title="Delete"
                     type="button"
                   >
                     <span
@@ -145,10 +187,8 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                       class="MuiTouchRipple-root"
                     />
                   </button>
+                  <div />
                 </div>
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                />
               </div>
             </div>
           </div>
@@ -244,7 +284,22 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                         title="My description"
                       >
                         mycustomresource
-                        <span />
+                        <svg
+                          aria-hidden="true"
+                          class="makeStyles-icon iconify iconify--mdi"
+                          height="1rem"
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                        >
+                          <path
+                            d="M11 9h2V7h-2m1 13c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m-1 15h2v-6h-2v6Z"
+                            fill="currentColor"
+                          />
+                        </svg>
                       </p>
                     </td>
                   </tr>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
   >
@@ -428,9 +426,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
 `;
 
 exports[`Storyshots endpoints/EndpointsDetailsView Error 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
   >
@@ -523,9 +519,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Error 1`] = `
 `;
 
 exports[`Storyshots endpoints/EndpointsDetailsView No Item Yet 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
   >

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >

--- a/frontend/src/components/pod/__snapshots__/Pod.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/Pod.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots pods/PodListRenderer Pods 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >
@@ -37,7 +35,22 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
               <span
                 class="MuiIconButton-label"
               >
-                <span />
+                <svg
+                  aria-hidden="true"
+                  class="iconify iconify--mdi"
+                  height="1em"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:xlink="http://www.w3.org/1999/xlink"
+                >
+                  <path
+                    d="M6 13h12v-2H6M3 6v2h18V6M10 18h4v-2h-4v2Z"
+                    fill="currentColor"
+                  />
+                </svg>
               </span>
               <span
                 class="MuiTouchRipple-root"
@@ -76,7 +89,22 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <span />
+                    <svg
+                      aria-hidden="true"
+                      class="iconify iconify--mdi"
+                      height="1em"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -97,7 +125,22 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <span />
+                    <svg
+                      aria-hidden="true"
+                      class="iconify iconify--mdi"
+                      height="1em"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -118,7 +161,22 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <span />
+                    <svg
+                      aria-hidden="true"
+                      class="iconify iconify--mdi"
+                      height="1em"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -139,7 +197,22 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <span />
+                    <svg
+                      aria-hidden="true"
+                      class="iconify iconify--mdi"
+                      height="1em"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -161,7 +234,22 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <span />
+                    <svg
+                      aria-hidden="true"
+                      class="iconify iconify--mdi"
+                      height="1em"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="m7 15l5-5l5 5H7Z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -220,7 +308,23 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   title="4/25/2022, 12:00:00 AM UTC"
                 >
                   3mo
-                  <span />
+                  <svg
+                    aria-hidden="true"
+                    class="makeStyles-icon iconify iconify--mdi"
+                    height="1rem"
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style="color: rgb(97, 97, 97);"
+                    viewBox="0 0 24 24"
+                    width="1rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                  >
+                    <path
+                      d="M19 19H5V8h14m-3-7v2H8V1H6v2H5c-1.11 0-2 .89-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-1V1m-1 11h-5v5h5v-5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
                 </p>
               </td>
             </tr>

--- a/frontend/src/components/pod/__snapshots__/Pod.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/Pod.stories.storyshot
@@ -35,22 +35,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
               <span
                 class="MuiIconButton-label"
               >
-                <svg
-                  aria-hidden="true"
-                  class="iconify iconify--mdi"
-                  height="1em"
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlns:xlink="http://www.w3.org/1999/xlink"
-                >
-                  <path
-                    d="M6 13h12v-2H6M3 6v2h18V6M10 18h4v-2h-4v2Z"
-                    fill="currentColor"
-                  />
-                </svg>
+                <span />
               </span>
               <span
                 class="MuiTouchRipple-root"
@@ -89,22 +74,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="iconify iconify--mdi"
-                      height="1em"
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                    >
-                      <path
-                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span />
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -125,22 +95,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="iconify iconify--mdi"
-                      height="1em"
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                    >
-                      <path
-                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span />
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -161,22 +116,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="iconify iconify--mdi"
-                      height="1em"
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                    >
-                      <path
-                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span />
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -197,22 +137,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="iconify iconify--mdi"
-                      height="1em"
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                    >
-                      <path
-                        d="m12 6l-5 5h10l-5-5m-5 7l5 5l5-5H7Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span />
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -234,22 +159,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   <span
                     class="MuiIconButton-label"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="iconify iconify--mdi"
-                      height="1em"
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                    >
-                      <path
-                        d="m7 15l5-5l5 5H7Z"
-                        fill="currentColor"
-                      />
-                    </svg>
+                    <span />
                   </span>
                   <span
                     class="MuiTouchRipple-root"
@@ -308,23 +218,7 @@ exports[`Storyshots pods/PodListRenderer Pods 1`] = `
                   title="4/25/2022, 12:00:00 AM UTC"
                 >
                   3mo
-                  <svg
-                    aria-hidden="true"
-                    class="makeStyles-icon iconify iconify--mdi"
-                    height="1rem"
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    style="color: rgb(97, 97, 97);"
-                    viewBox="0 0 24 24"
-                    width="1rem"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlns:xlink="http://www.w3.org/1999/xlink"
-                  >
-                    <path
-                      d="M19 19H5V8h14m-3-7v2H8V1H6v2H5c-1.11 0-2 .89-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-1V1m-1 11h-5v5h5v-5Z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                  <span />
                 </p>
               </td>
             </tr>

--- a/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots pods/VolumeDetails Volume Details 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiBox-root MuiBox-root"
   >

--- a/frontend/src/i18n/LocaleSelect/__snapshots__/LocaleSelect.stories.storyshot
+++ b/frontend/src/i18n/LocaleSelect/__snapshots__/LocaleSelect.stories.storyshot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots LocaleSelect Initial 1`] = `
-<div
-  id="root"
->
+<div>
   <div
     class="MuiFormControl-root makeStyles-formControl"
   >

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -463,9 +463,9 @@ export function getRoute(routeName: string) {
   let routeKey = routeName;
   for (const key in defaultRoutes) {
     if (key.toLowerCase() === routeName.toLowerCase()) {
-      if (key !== routeName) {
-        console.warn(`Route name ${routeName} and ${key} are not matching`);
-      }
+      // if (key !== routeName) {
+      //   console.warn(`Route name ${routeName} and ${key} are not matching`);
+      // }
       routeKey = key;
       break;
     }

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -46,7 +46,7 @@ export function timeAgo(date: DateParam, options: TimeAgoOptions = {}) {
   const fromDate = new Date(date);
   let now = new Date();
 
-  if (!!process.env.TEST_TZ) {
+  if (process.env.UNDER_TEST === 'true') {
     // For testing, we consider the current moment to be 3 months from the dates we are testing.
     const days = 24 * 3600 * 1000; // in ms
     now = new Date(fromDate.getTime() + 90 * days);
@@ -72,7 +72,7 @@ export function timeAgo(date: DateParam, options: TimeAgoOptions = {}) {
 export function localeDate(date: DateParam) {
   const options: Intl.DateTimeFormatOptions = { timeZoneName: 'short' };
 
-  if (process.env.TEST_TZ) {
+  if (process.env.UNDER_TEST === 'true') {
     options.timeZone = 'UTC';
   } else {
     options.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
- storyshots: Add mocks for rest API calls
- storyshots: Fix test runner so storyshots run within act
- EditorDialog: Add open for story to remove console warning
- EditorDialog: Remove incompatible Tab centered
- ErrorBoundary: Stop console spam under test, rename TEST_TZ
- Dialog: Add keys to buttons to fix warning
- Tabs: Fix depreciation warning with scrollable variant

See https://github.com/mswjs/msw-storybook-addon#readme for mocking network requests.

## How to use

`npm run test` and there should be no warnings

## Testing done

with tests there are no more warnings when running them

