### PR TITLE
frontend: Ensure cluster actions are only processed when they change

### DIFF
--- a/frontend/src/components/common/ActionsNotifier.tsx
+++ b/frontend/src/components/common/ActionsNotifier.tsx
@@ -77,7 +77,7 @@ export { PureActionsNotifier };
 
 export default function ActionsNotifier() {
   const dispatch = useDispatch();
-  const clusterActions = useTypedSelector(state => state.clusterAction);
+  const clusterActions = useTypedSelector(state => state.clusterAction, _.isEqual);
 
   return <PureActionsNotifier dispatch={dispatch} clusterActions={clusterActions} />;
 }


### PR DESCRIPTION
Due to how the useSelector from redux works, we were triggering
changes to the ActionsNotifier whenever anything in the redux state
was changing, so this resulted in continuously processing the cluster
actions even when those didn't change. This had side-effects like
always moving moving back to the "startUrl" when changing routes
while deleting a resource.

This patch adds the evaluation function to the mentioned selector, so
it will only trigger when actually the actions change.

We should still move the URL processing of the actions to somewhere
where it can be better controlled, or to remove it completely and
allow actions to define callbacks for each action state instead
(cancelled/errored), meaning they'd call the route changes themselves
when desired.

fixes #715 

How to test:
1. Go to a pod and delete it;
2. During the cancellation grace period, move to a different view (say ReplicaSets): verify that the view doesn't jump back to pods