### PR TITLE
frontend: List pods in OwnedPodsSection with query parameters

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -681,7 +681,7 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
 }
 
 // Label selector examples: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
-// deployment selector example: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
+// deployment selector example: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
 // Possible operators: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/selection/operator.go#L24
 // Format rule for expressions: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/labels/selector.go#L305
 function getLabelSelector(item: KubeObjectInterface): string | undefined {

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -729,7 +729,7 @@ function getLabelSelector(item: KubeObjectInterface): string | undefined {
     }
 
     let sorted = [...(expr.values ?? [])].sort().join(',');
-    if (expr.operator == 'In' || expr.operator == 'NotIn') {
+    if (expr.operator === 'In' || expr.operator === 'NotIn') {
       sorted = '(' + sorted + ')';
     }
     segment += sorted;

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -728,19 +728,11 @@ function getLabelSelector(item: KubeObjectInterface): string | undefined {
         continue;
     }
 
-    switch (expr.operator) {
-      case 'In':
-      case 'NotIn':
-        segment += '(';
+    let sorted = [...(expr.values ?? [])].sort().join(',');
+    if (expr.operator == 'In' || expr.operator == 'NotIn') {
+      sorted = '(' + sorted + ')';
     }
-    const sorted = [...(expr.values ?? [])].sort();
-    segment += sorted.join(',');
-    switch (expr.operator) {
-      case 'In':
-      case 'NotIn':
-        segment += ')';
-    }
-
+    segment += sorted;
     segments.push(segment);
   }
 

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -669,32 +669,86 @@ export interface OwnedPodsSectionProps {
 export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   const { resource, hideColumns } = props;
 
-  const [pods, error] = Pod.useList();
+  const queryData = {
+    namespace: resource.kind === 'Namespace' ? resource.metadata.name : undefined,
+    labelSelector: getLabelSelector(resource),
+    fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
+  };
 
-  function getOwnedPods() {
-    if (!pods) {
-      return null;
-    }
+  const [pods, error] = Pod.useList(queryData);
 
-    if (resource.kind === 'Node') {
-      return pods.filter(item => item.spec.nodeName === resource.metadata.name);
-    }
+  return <PodListRenderer hideColumns={hideColumns} pods={pods} error={error} />;
+}
 
-    if (resource.kind === 'Namespace') {
-      return pods.filter(item => item.metadata.namespace === resource.metadata.name);
-    }
+// Label selector examples: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
+// deployment selector example: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
+// Possible operators: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/selection/operator.go#L24
+// Format rule for expressions: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/labels/selector.go#L305
+function getLabelSelector(item: KubeObjectInterface): string | undefined {
+  const segments: string[] = [];
 
-    const resourceTemplateLabel = Object.values(resource?.spec?.template?.metadata?.labels || []);
-    if (!resourceTemplateLabel) {
-      return [];
-    }
-    return pods.filter(item =>
-      resourceTemplateLabel.every(elem => Object.values(item.metadata.labels || {}).includes(elem))
-    );
+  const matchLabels = item?.spec?.selector?.matchLabels ?? {};
+  for (const k in matchLabels) {
+    segments.push(`${k}=${matchLabels[k]}`);
   }
 
-  const filteredPods = getOwnedPods();
-  return <PodListRenderer hideColumns={hideColumns} pods={filteredPods} error={error} />;
+  const matchExpressions = item?.spec?.selector?.matchExpressions ?? [];
+  for (const expr of matchExpressions) {
+    let segment = '';
+    if (expr.operator === 'DoesNotExist') {
+      segment += '!';
+    }
+
+    segment += expr.key;
+    switch (expr.operator) {
+      case 'Equals':
+        segment += '=';
+        break;
+      case 'DoubleEquals':
+        segment += '==';
+        break;
+      case 'NotEquals':
+        segment += '!=';
+        break;
+      case 'In':
+        segment += ' in ';
+        break;
+      case 'NotIn':
+        segment += ' notin ';
+        break;
+      case 'GreaterThan':
+        segment += '>';
+        break;
+      case 'LessThan':
+        segment += '<';
+        break;
+      case 'Exists':
+      case 'DoesNotExist':
+        segments.push(segment);
+        continue;
+    }
+
+    switch (expr.operator) {
+      case 'In':
+      case 'NotIn':
+        segment += '(';
+    }
+    const sorted = [...(expr.values ?? [])].sort();
+    segment += sorted.join(',');
+    switch (expr.operator) {
+      case 'In':
+      case 'NotIn':
+        segment += ')';
+    }
+
+    segments.push(segment);
+  }
+
+  if (segments.length === 0) {
+    return undefined;
+  }
+
+  return segments.join(',');
 }
 
 export function ContainersSection(props: { resource: KubeObjectInterface | null }) {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -43,6 +43,12 @@ export interface ClusterRequest {
   certificateAuthorityData?: string;
 }
 
+export interface QueryParameters {
+  labelSelector?: string;
+  fieldSelector?: string;
+  [prop: string]: any;
+}
+
 //refreshToken checks if the token is about to expire and refreshes it if so.
 async function refreshToken(token: string | null) {
   if (!token || isTokenRefreshInProgress) {
@@ -311,13 +317,18 @@ function singleApiFactory(group: string, version: string, resource: string) {
   const apiRoot = getApiRoot(group, version);
   const url = `${apiRoot}/${resource}`;
   return {
-    list: (cb: StreamResultsCb, errCb: StreamErrCb) => streamResults(url, cb, errCb),
-    get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResult(url, name, cb, errCb),
-    post: (body: KubeObjectInterface) => post(url, body),
-    put: (body: KubeObjectInterface) => put(`${url}/${body.metadata.name}`, body),
-    patch: (body: OpPatch[], name: string) => patch(`${url}/${name}?pretty=true`, body),
-    delete: (name: string) => remove(`${url}/${name}`),
+    list: (cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: QueryParameters) =>
+      streamResults(url, queryParams, cb, errCb),
+    get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: QueryParameters) =>
+      streamResult(url, name, queryParams, cb, errCb),
+    post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      post(url + asQuery(queryParams), body),
+    put: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      put(`${url}/${body.metadata.name}` + asQuery(queryParams), body),
+    patch: (body: OpPatch[], name: string, queryParams?: QueryParameters) =>
+      patch(url + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
+    delete: (name: string, queryParams?: QueryParameters) =>
+      remove(`${url}/${name}` + asQuery(queryParams)),
     isNamespaced: false,
   };
 }
@@ -369,16 +380,30 @@ function simpleApiFactoryWithNamespace(
     scale?: ReturnType<typeof apiScaleFactory>;
     [other: string]: any;
   } = {
-    list: (namespace: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResults(url(namespace), cb, errCb),
-    get: (namespace: string, name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResult(url(namespace), name, cb, errCb),
-    post: (body: KubeObjectInterface) => post(url(body.metadata.namespace as string), body),
-    patch: (body: OpPatch[], namespace: string, name: string) =>
-      patch(`${url(namespace)}/${name}?pretty=true`, body),
-    put: (body: KubeObjectInterface) =>
-      put(`${url(body.metadata.namespace as string)}/${body.metadata.name}`, body),
-    delete: (namespace: string, name: string) => remove(`${url(namespace)}/${name}`),
+    list: (
+      namespace: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: QueryParameters
+    ) => streamResults(url(namespace), queryParams, cb, errCb),
+    get: (
+      namespace: string,
+      name: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: QueryParameters
+    ) => streamResult(url(namespace), name, queryParams, cb, errCb),
+    post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      post(url(body.metadata.namespace as string) + asQuery(queryParams), body),
+    patch: (body: OpPatch[], namespace: string, name: string, queryParams?: QueryParameters) =>
+      patch(`${url(namespace)}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
+    put: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      put(
+        `${url(body.metadata.namespace as string)}/${body.metadata.name}` + asQuery(queryParams),
+        body
+      ),
+    delete: (namespace: string, name: string, queryParams?: QueryParameters) =>
+      remove(`${url(namespace)}/${name}` + asQuery(queryParams)),
     isNamespaced: true,
   };
 
@@ -391,6 +416,10 @@ function simpleApiFactoryWithNamespace(
   function url(namespace: string) {
     return namespace ? `${apiRoot}/namespaces/${namespace}/${resource}` : `${apiRoot}/${resource}`;
   }
+}
+
+function asQuery(queryParams?: QueryParameters): string {
+  return '?' + new URLSearchParams(queryParams).toString();
 }
 
 function resourceDefToApiFactory(resourceDef: KubeObjectInterface): ApiFactoryReturn {
@@ -486,6 +515,7 @@ export function remove(url: string, requestOptions = {}) {
 export async function streamResult(
   url: string,
   name: string,
+  queryParams: QueryParameters | undefined,
   cb: StreamResultsCb,
   errCb: StreamErrCb
 ) {
@@ -497,13 +527,14 @@ export async function streamResult(
 
   async function run() {
     try {
-      const item = await request(`${url}/${name}`);
+      const item = await request(`${url}/${name}` + asQuery(queryParams));
 
       if (isCancelled) return;
       cb(item);
 
-      const fieldSelector = encodeURIComponent(`metadata.name=${name}`);
-      const watchUrl = `${url}?watch=1&fieldSelector=${fieldSelector}`;
+      const watchUrl =
+        url +
+        asQuery({ ...queryParams, ...{ watch: '1', fieldSelector: `metadata.name=${name}` } });
 
       socket = stream(watchUrl, x => cb(x.object), { isJson: true });
     } catch (err) {
@@ -520,7 +551,12 @@ export async function streamResult(
   }
 }
 
-export async function streamResults(url: string, cb: StreamResultsCb, errCb: StreamErrCb) {
+export async function streamResults(
+  url: string,
+  queryParams: QueryParameters | undefined,
+  cb: StreamResultsCb,
+  errCb: StreamErrCb
+) {
   const results: {
     [uid: string]: KubeObjectInterface;
   } = {};
@@ -532,13 +568,15 @@ export async function streamResults(url: string, cb: StreamResultsCb, errCb: Str
 
   async function run() {
     try {
-      const { kind, items, metadata } = await request(url);
+      const { kind, items, metadata } = await request(url + asQuery(queryParams));
 
       if (isCancelled) return;
 
       add(items, kind);
 
-      const watchUrl = `${url}?watch=1&resourceVersion=${metadata.resourceVersion}`;
+      const watchUrl =
+        url +
+        asQuery({ ...queryParams, ...{ watch: '1', resourceVersion: metadata.resourceVersion } });
       socket = stream(watchUrl, update, { isJson: true });
     } catch (err) {
       console.error('Error in api request', { err, url });

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -318,9 +318,9 @@ function singleApiFactory(group: string, version: string, resource: string) {
   const url = `${apiRoot}/${resource}`;
   return {
     list: (cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: QueryParameters) =>
-      streamResults(url, queryParams, cb, errCb),
+      streamResults(url, cb, errCb, queryParams),
     get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: QueryParameters) =>
-      streamResult(url, name, queryParams, cb, errCb),
+      streamResult(url, name, cb, errCb, queryParams),
     post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
       post(url + asQuery(queryParams), body),
     put: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
@@ -385,14 +385,14 @@ function simpleApiFactoryWithNamespace(
       cb: StreamResultsCb,
       errCb: StreamErrCb,
       queryParams?: QueryParameters
-    ) => streamResults(url(namespace), queryParams, cb, errCb),
+    ) => streamResults(url(namespace), cb, errCb, queryParams),
     get: (
       namespace: string,
       name: string,
       cb: StreamResultsCb,
       errCb: StreamErrCb,
       queryParams?: QueryParameters
-    ) => streamResult(url(namespace), name, queryParams, cb, errCb),
+    ) => streamResult(url(namespace), name, cb, errCb, queryParams),
     post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
       post(url(body.metadata.namespace as string) + asQuery(queryParams), body),
     patch: (body: OpPatch[], namespace: string, name: string, queryParams?: QueryParameters) =>
@@ -419,7 +419,9 @@ function simpleApiFactoryWithNamespace(
 }
 
 function asQuery(queryParams?: QueryParameters): string {
-  return '?' + new URLSearchParams(queryParams).toString();
+  return !!queryParams && !!Object.keys(queryParams).length
+    ? '?' + new URLSearchParams(queryParams).toString()
+    : '';
 }
 
 function resourceDefToApiFactory(resourceDef: KubeObjectInterface): ApiFactoryReturn {
@@ -515,9 +517,9 @@ export function remove(url: string, requestOptions = {}) {
 export async function streamResult(
   url: string,
   name: string,
-  queryParams: QueryParameters | undefined,
   cb: StreamResultsCb,
-  errCb: StreamErrCb
+  errCb: StreamErrCb,
+  queryParams?: QueryParameters
 ) {
   let isCancelled = false;
   let socket: ReturnType<typeof stream>;
@@ -553,9 +555,9 @@ export async function streamResult(
 
 export async function streamResults(
   url: string,
-  queryParams: QueryParameters | undefined,
   cb: StreamResultsCb,
-  errCb: StreamErrCb
+  errCb: StreamErrCb,
+  queryParams: QueryParameters | undefined
 ) {
   const results: {
     [uid: string]: KubeObjectInterface;

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -165,7 +165,10 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
     static apiList<U extends KubeObject>(
       onList: (arg: U[]) => void,
       onError?: (err: ApiError) => void,
-      opts?: ApiListOptions
+      opts?: {
+        namespace?: string;
+        queryParams?: QueryParameters;
+      }
     ) {
       const createInstance = (item: T) => this.create(item) as U;
 
@@ -180,11 +183,11 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       }
 
       const queryParams: QueryParameters = {};
-      if (opts?.labelSelector) {
-        queryParams['labelSelector'] = opts.labelSelector;
+      if (opts?.queryParams?.labelSelector) {
+        queryParams['labelSelector'] = opts.queryParams.labelSelector;
       }
-      if (opts?.fieldSelector) {
-        queryParams['fieldSelector'] = opts.fieldSelector;
+      if (opts?.queryParams?.fieldSelector) {
+        queryParams['fieldSelector'] = opts.queryParams.fieldSelector;
       }
       args.push(queryParams);
 
@@ -234,14 +237,14 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
           listCalls.push(
             this.apiList(objList => onObjs(namespace, objList as U[]), onError, {
               namespace,
-              ...queryParams,
+              queryParams,
             })
           );
         }
       } else {
         // If we don't have a namespace set, then we only have one API call
         // response to set and we return it right away.
-        listCalls.push(this.apiList(listCallback, onError, { ...queryParams }));
+        listCalls.push(this.apiList(listCallback, onError, { queryParams }));
       }
 
       useConnectApi(...listCalls);


### PR DESCRIPTION
# frontend: List pod in OwnedPodsSection with query parameters

In Resource.ts, list pod in OwnedPodsSection with query parameters. If users only have namespace access, list all pods isn't available.

## How to use

Instead of filtering pods list, OwnedPodsSection query pods with label selectors and field selectors.

## Testing done

Test list pods in deployment with query parameters. 
