### PR TITLE
frontend: Replace lastTerminationState with lastState

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -516,32 +516,34 @@ export interface KubeMetrics {
   };
 }
 
+export interface ContainerStateApplyConfiguration {
+  running: {
+    startedAt: number;
+  };
+  terminated: {
+    containerID: string;
+    exitCode: number;
+    finishedAt: number;
+    message: string;
+    reason: string;
+    signal: number;
+    startedAt: number;
+  };
+  waiting: {
+    message: string;
+    reason: string;
+  };
+}
+
 export interface KubeContainerStatus {
   containerID: string;
   image: string;
   imageID: string;
-  lastState: string;
   name: string;
   ready: boolean;
   restartCount: number;
-  state: {
-    running: {
-      startedAt: number;
-    };
-    terminated: {
-      containerID: string;
-      exitCode: number;
-      finishedAt: number;
-      message: string;
-      reason: string;
-      signal: number;
-      startedAt: number;
-    };
-    waiting: {
-      message: string;
-      reason: string;
-    };
-  };
+  lastState: ContainerStateApplyConfiguration; // aka: lastTerminationState
+  state: ContainerStateApplyConfiguration;
 }
 
 export type Workload = DaemonSet | ReplicaSet | StatefulSet | Job | CronJob | Deployment;


### PR DESCRIPTION
# Replace lastTerminationState with lastState

The lastTerminationState of KubeContainerStatus is not existed. I checked the doc here. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/

## How to use

Replace lastTerminationState  to lastState

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
