### PR TITLE
frontend: Print pod status following kubectl

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -127,7 +127,7 @@ interface PodTableRow {
   lastRestartDate: Date;
 }
 
-// Source Code: https://github.com/kubernetes/kubernetes/blob/33bf8a8ebd33eae0d45c18feb1c05baa6a055cde/pkg/printers/internalversion/printers.go#L558
+// Source Code: https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/internalversion/printers.go#L759
 function getPodTableInfo(pod: KubePod): PodTableRow {
   let restarts = 0;
   const totalContainers = (pod.spec.containers ?? []).length;

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -1,9 +1,9 @@
 import { Icon } from '@iconify/react';
 import { Box } from '@material-ui/core';
-import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ApiError } from '../../lib/k8s/apiProxy';
-import Pod from '../../lib/k8s/pod';
+import Pod, { KubePod } from '../../lib/k8s/pod';
+import { timeAgoByDate } from '../../lib/util';
 import { LightTooltip, SectionFilterHeader } from '../common';
 import { StatusLabel, StatusLabelProps } from '../common/Label';
 import ResourceTable, { ResourceTableProps } from '../common/Resource/ResourceTable';
@@ -14,6 +14,7 @@ export function makePodStatusLabel(pod: Pod) {
   let status: StatusLabelProps['status'] = '';
   let tooltip = '';
 
+  const podRow = getPodTableInfo(pod.jsonData);
   if (phase === 'Failed') {
     status = 'error';
   } else if (phase === 'Succeeded' || phase === 'Running') {
@@ -32,7 +33,7 @@ export function makePodStatusLabel(pod: Pod) {
     <LightTooltip title={tooltip} interactive>
       <Box display="inline">
         <StatusLabel status={status}>
-          {phase}
+          {podRow.reason}
           {(status === 'warning' || status === 'error') && (
             <Box
               aria-label="hidden"
@@ -60,20 +61,23 @@ export function PodListRenderer(props: PodListProps) {
   const { pods, error, hideColumns = [] } = props;
   const { t } = useTranslation('glossary');
 
-  function getRestartCount(pod: Pod) {
-    if (!pod) {
-      return 0;
-    }
-    return _.sumBy(pod.status.containerStatuses, container => container.restartCount);
-  }
-
   function getDataCols() {
     const dataCols: ResourceTableProps['columns'] = [
       'name',
       {
+        label: t('frequent|Ready'),
+        getter: (pod: Pod) => {
+          const podRow = getPodTableInfo(pod.jsonData);
+          return `${podRow.readyContainers}/${podRow.totalContainers}`;
+        },
+      },
+      {
         label: t('Status'),
         getter: makePodStatusLabel,
-        sort: (pod: Pod) => pod?.status.phase,
+        sort: (pod: Pod) => {
+          const podRow = getPodTableInfo(pod.jsonData);
+          return podRow.reason;
+        },
       },
       'age',
     ];
@@ -87,7 +91,10 @@ export function PodListRenderer(props: PodListProps) {
     if (!hideColumns.includes('restarts')) {
       dataCols.splice(insertIndex++, 0, {
         label: t('Restarts'),
-        getter: (pod: Pod) => getRestartCount(pod),
+        getter: (pod: Pod) => {
+          const podRow = getPodTableInfo(pod.jsonData);
+          return podRow.restartsStr;
+        },
         sort: true,
       });
     }
@@ -110,4 +117,136 @@ export default function PodList() {
   const [pods, error] = Pod.useList();
 
   return <PodListRenderer pods={pods} error={error} />;
+}
+
+interface PodTableRow {
+  restartsStr: string;
+  reason: string;
+  totalContainers: number;
+  readyContainers: number;
+  lastRestartDate: Date;
+}
+
+// Source Code: https://github.com/kubernetes/kubernetes/blob/33bf8a8ebd33eae0d45c18feb1c05baa6a055cde/pkg/printers/internalversion/printers.go#L558
+function getPodTableInfo(pod: KubePod): PodTableRow {
+  let restarts = 0;
+  const totalContainers = (pod.spec.containers ?? []).length;
+  let readyContainers = 0;
+  let lastRestartDate = new Date(0);
+
+  let reason = pod.status.phase;
+  if (!!pod.status.reason) {
+    reason = pod.status.reason;
+  }
+
+  let initializing = false;
+  for (const i in pod.status.initContainerStatuses) {
+    const container = pod.status.initContainerStatuses[i];
+    restarts += container.restartCount;
+    if (!!container.lastState.terminated) {
+      const terminatedDate = new Date(container.lastState.terminated.finishedAt);
+      if (lastRestartDate.getTime() < terminatedDate.getTime()) {
+        lastRestartDate = terminatedDate;
+      }
+    }
+
+    switch (true) {
+      case !!container.state.terminated && container.state.terminated.exitCode === 0:
+        continue;
+      case !!container.state.terminated:
+        if (!container.state.terminated.reason) {
+          if (container.state.terminated.signal !== 0) {
+            reason = `Init:Signal:${container.state.terminated.signal}`;
+          } else {
+            reason = `Init:ExitCode:${container.state.terminated.exitCode}`;
+          }
+        } else {
+          reason = 'Init:' + container.state.terminated.reason;
+        }
+        initializing = true;
+        break;
+      case !!container.state.waiting &&
+        !!container.state.waiting.reason &&
+        container.state.waiting.reason !== 'PodInitializing':
+        reason = 'Init:' + container.state.waiting.reason;
+        initializing = true;
+        break;
+      default:
+        reason = `Init:${i}/${(pod.spec.initContainers || []).length}`;
+        initializing = true;
+    }
+    break;
+  }
+
+  if (!initializing) {
+    restarts = 0;
+    let hasRunning = false;
+    for (let i = pod.status.containerStatuses.length - 1; i >= 0; i--) {
+      const container = pod.status.containerStatuses[i];
+
+      restarts += container.restartCount;
+      if (!!container.lastState?.terminated) {
+        const terminatedDate = new Date(container.lastState.terminated.finishedAt);
+        if (lastRestartDate.getTime() < terminatedDate.getTime()) {
+          lastRestartDate = terminatedDate;
+        }
+      }
+
+      if (!!container.state.waiting && !!container.state.waiting.reason) {
+        reason = container.state.waiting.reason;
+      } else if (!!container.state.terminated && !!container.state.terminated.reason) {
+        reason = container.state.terminated.reason;
+      } else if (!!container.state.terminated && !container.state.terminated.reason) {
+        if (container.state.terminated.signal !== 0) {
+          reason = `Signal:${container.state.terminated.signal}`;
+        } else {
+          reason = `ExitCode:${container.state.terminated.exitCode}`;
+        }
+      } else if (container.ready && !!container.state.running) {
+        hasRunning = true;
+        readyContainers++;
+      }
+    }
+
+    // change pod status back to "Running" if there is at least one container still reporting as "Running" status
+    if (reason === 'Completed' && hasRunning) {
+      if (hasPodReadyCondition(pod.status.conditions)) {
+        alert('Running');
+        reason = 'Running';
+      } else {
+        reason = 'NotReady';
+      }
+    }
+  }
+
+  // Instead of `pod.deletionTimestamp`. Important!
+  const deletionTimestamp = pod.metadata.deletionTimestamp;
+
+  if (!!deletionTimestamp && pod.status.reason === 'NodeLost') {
+    reason = 'Unknown';
+  } else if (!!deletionTimestamp) {
+    reason = 'Terminating';
+  }
+
+  let restartsStr = `${restarts}`;
+  if (lastRestartDate.getTime() !== 0) {
+    restartsStr = `${restarts} (${timeAgoByDate(lastRestartDate)} ago)`;
+  }
+
+  return {
+    restartsStr: restartsStr,
+    totalContainers: totalContainers,
+    readyContainers: readyContainers,
+    reason: reason,
+    lastRestartDate: lastRestartDate,
+  };
+}
+
+function hasPodReadyCondition(conditions: any): boolean {
+  for (const condition of conditions) {
+    if (condition.type === 'Ready' && condition.Status === 'True') {
+      return true;
+    }
+  }
+  return false;
 }

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -34,6 +34,7 @@ export interface KubeMetadata {
   name: string;
   namespace?: string;
   creationTimestamp: string;
+  deletionTimestamp?: string;
   resourceVersion: string;
   selfLink: string;
   labels?: StringDict;
@@ -516,32 +517,34 @@ export interface KubeMetrics {
   };
 }
 
+export interface ContainerStateApplyConfiguration {
+  running: {
+    startedAt: number;
+  };
+  terminated: {
+    containerID: string;
+    exitCode: number;
+    finishedAt: number;
+    message: string;
+    reason: string;
+    signal: number;
+    startedAt: number;
+  };
+  waiting: {
+    message: string;
+    reason: string;
+  };
+}
+
 export interface KubeContainerStatus {
   containerID: string;
   image: string;
   imageID: string;
-  lastState: string;
   name: string;
   ready: boolean;
   restartCount: number;
-  state: {
-    running: {
-      startedAt: number;
-    };
-    terminated: {
-      containerID: string;
-      exitCode: number;
-      finishedAt: number;
-      message: string;
-      reason: string;
-      signal: number;
-      startedAt: number;
-    };
-    waiting: {
-      message: string;
-      reason: string;
-    };
-  };
+  lastState: ContainerStateApplyConfiguration; // aka: lastTerminationState
+  state: ContainerStateApplyConfiguration;
 }
 
 export type Workload = DaemonSet | ReplicaSet | StatefulSet | Job | CronJob | Deployment;

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -15,6 +15,7 @@ export interface KubePod extends KubeObjectInterface {
     nodeSelector?: {
       [key: string]: string;
     };
+    initContainers?: any[];
   };
   status: {
     conditions: KubeCondition[];

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -69,6 +69,11 @@ export function timeAgo(date: DateParam, options: TimeAgoOptions = {}) {
   });
 }
 
+export function timeAgoByDate(date: Date) {
+  const milliseconds = new Date().getTime() - date.getTime();
+  return humanDuration(milliseconds);
+}
+
 export function localeDate(date: DateParam) {
   const options: Intl.DateTimeFormatOptions = { timeZoneName: 'short' };
 
@@ -228,6 +233,59 @@ export function useErrorState(dependentSetter?: (...args: any) => void) {
 
   // Adding "as any" here because it was getting difficult to validate the setter type.
   return [error, setError as any];
+}
+
+// Source Code: https://github.com/kubernetes/kubernetes/blob/2f275b72b2248bb7c522327115acb17223b8387b/staging/src/k8s.io/apimachinery/pkg/util/duration/duration.go#L48
+export function humanDuration(milliseconds: number): string {
+  const seconds = int(milliseconds / 1000);
+  if (seconds < -1) {
+    return '<invalid>';
+  } else if (seconds < 0) {
+    return '0s';
+  } else if (seconds < 60 * 2) {
+    return `${seconds}s`;
+  }
+
+  const minutes = int(seconds / 60);
+  if (minutes < 10) {
+    const s = seconds % 60;
+    if (s === 0) {
+      return `${minutes}m`;
+    }
+    return `${minutes}m${s}s`;
+  } else if (minutes < 60 * 3) {
+    return `${minutes}m`;
+  }
+
+  const hours = int(minutes / 60);
+  if (hours < 8) {
+    const m = minutes % 60;
+    if (m === 0) {
+      return `${hours}h`;
+    }
+    return `${hours}h${m}m`;
+  } else if (hours < 48) {
+    return `${hours}h`;
+  } else if (hours < 24 * 8) {
+    const h = hours % 24;
+    if (h === 0) {
+      return `${int(hours / 24)}d`;
+    }
+    return `${int(hours / 24)}d${h}h`;
+  } else if (hours < 24 * 365 * 2) {
+    return `${int(hours / 24)}d`;
+  } else if (hours < 24 * 365 * 8) {
+    const dy = int(hours / 24) % 365;
+    if (dy === 0) {
+      return `${int(hours / 24 / 365)}y`;
+    }
+    return `${int(hours / 24 / 365)}y${dy}d`;
+  }
+  return `${int(hours / 24 / 365)}y`;
+}
+
+function int(num: number): number {
+  return Math.floor(num);
 }
 
 // Make units available from here


### PR DESCRIPTION
# Print pod status following kubectl

Print pod status following kubectl convention. https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/internalversion/printers.go#L759

## How to use
The pod status in Headlamp cannot describe the full picture of the container status. It is confusing when user see running pod status marked with yellow. So, I change status and restarts by following the link I provide above. 

In this PR.
![image](https://user-images.githubusercontent.com/13809749/197151358-4f19543a-be15-4f6f-99d8-f5d0683f4c97.png)

Current situation.
![image](https://user-images.githubusercontent.com/13809749/197151551-f886d0b6-93db-4c61-93ab-5082e09946d2.png)

This is pretty wired 
## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
