### PR TITLE
ci: Fix homebrew gh action auth issue

### DIFF
--- a/.github/workflows/pr-to-update-homebrew.yml
+++ b/.github/workflows/pr-to-update-homebrew.yml
@@ -37,13 +37,13 @@ jobs:
         run: |
           gh repo sync kinvolk/homebrew-cask
         env:
-          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}
       - name: Check out homebrew-cask repo 
         uses: actions/checkout@v2 
         with: 
           repository: kinvolk/homebrew-cask
           path: homebrew-cask
-          token: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+          token: ${{ secrets.KINVOLK_REPOS_TOKEN }}
           fetch-depth: 0
       - name: Update headlamp version in homebrew-cask
         run: |
@@ -92,4 +92,4 @@ jobs:
             cc: @$user" \
         env:
           LATEST_HEADLAMP_TAG: ${{ env.LATEST_HEADLAMP_TAG }}
-          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}


### PR DESCRIPTION
This patch fixes the auth issue that occurred in gh action, there was an extra space which is removed now.

