### PR TITLE
Fetch pods by labels

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -664,32 +664,78 @@ export interface OwnedPodsSectionProps {
 export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   const { resource, hideColumns } = props;
 
-  const [pods, error] = Pod.useList();
+  const queryData = {
+    namespace: resource.kind === 'Namespace' ? resource.metadata.name : undefined,
+    labelSelector: getLabelSelector(resource),
+    fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
+  };
 
-  function getOwnedPods() {
-    if (!pods) {
-      return null;
-    }
+  const [pods, error] = Pod.useList(queryData);
 
-    if (resource.kind === 'Node') {
-      return pods.filter(item => item.spec.nodeName === resource.metadata.name);
-    }
+  return <PodListRenderer hideColumns={hideColumns} pods={pods} error={error} />;
+}
 
-    if (resource.kind === 'Namespace') {
-      return pods.filter(item => item.metadata.namespace === resource.metadata.name);
-    }
+// Label selector examples: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
+// deployment selector example: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
+// Possible operators: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/selection/operator.go#L24
+// Format rule for expressions: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/labels/selector.go#L305
+function getLabelSelector(item: KubeObjectInterface): string | undefined {
+  const segments: string[] = [];
 
-    const resourceTemplateLabel = Object.values(resource?.spec?.template?.metadata?.labels || []);
-    if (!resourceTemplateLabel) {
-      return [];
-    }
-    return pods.filter(item =>
-      resourceTemplateLabel.every(elem => Object.values(item.metadata.labels || {}).includes(elem))
-    );
+  const matchLabels = item?.spec?.selector?.matchLabels ?? {};
+  for (const k in matchLabels) {
+    segments.push(`${k}=${matchLabels[k]}`);
   }
 
-  const filteredPods = getOwnedPods();
-  return <PodListRenderer hideColumns={hideColumns} pods={filteredPods} error={error} />;
+  const matchExpressions = item?.spec?.selector?.matchExpressions ?? [];
+  for (const expr of matchExpressions) {
+    let segment = '';
+    if (expr.operator === 'DoesNotExist') {
+      segment += '!';
+    }
+
+    segment += expr.key;
+    switch (expr.operator) {
+      case 'Equals':
+        segment += '=';
+        break;
+      case 'DoubleEquals':
+        segment += '==';
+        break;
+      case 'NotEquals':
+        segment += '!=';
+        break;
+      case 'In':
+        segment += ' in ';
+        break;
+      case 'NotIn':
+        segment += ' notin ';
+        break;
+      case 'GreaterThan':
+        segment += '>';
+        break;
+      case 'LessThan':
+        segment += '<';
+        break;
+      case 'Exists':
+      case 'DoesNotExist':
+        segments.push(segment);
+        continue;
+    }
+
+    let sorted = [...(expr.values ?? [])].sort().join(',');
+    if (expr.operator === 'In' || expr.operator === 'NotIn') {
+      sorted = '(' + sorted + ')';
+    }
+    segment += sorted;
+    segments.push(segment);
+  }
+
+  if (segments.length === 0) {
+    return undefined;
+  }
+
+  return segments.join(',');
 }
 
 export function ContainersSection(props: { resource: KubeObjectInterface | null }) {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -394,14 +394,11 @@ function simpleApiFactoryWithNamespace(
       queryParams?: QueryParameters
     ) => streamResult(url(namespace), name, cb, errCb, queryParams),
     post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
-      post(url(body.metadata.namespace as string) + asQuery(queryParams), body),
+      post(url(body.metadata.namespace!) + asQuery(queryParams), body),
     patch: (body: OpPatch[], namespace: string, name: string, queryParams?: QueryParameters) =>
       patch(`${url(namespace)}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
     put: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
-      put(
-        `${url(body.metadata.namespace as string)}/${body.metadata.name}` + asQuery(queryParams),
-        body
-      ),
+      put(`${url(body.metadata.namespace!)}/${body.metadata.name}` + asQuery(queryParams), body),
     delete: (namespace: string, name: string, queryParams?: QueryParameters) =>
       remove(`${url(namespace)}/${name}` + asQuery(queryParams)),
     isNamespaced: true,
@@ -468,7 +465,7 @@ function apiScaleFactory(apiRoot: string, resource: string) {
   return {
     get: (namespace: string, name: string) => request(url(namespace, name)),
     put: (body: { metadata: KubeMetadata; spec: { replicas: number } }) =>
-      put(url(body.metadata.namespace as string, body.metadata.name), body),
+      put(url(body.metadata.namespace!, body.metadata.name), body),
   };
 
   function url(namespace: string, name: string) {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -43,6 +43,12 @@ export interface ClusterRequest {
   certificateAuthorityData?: string;
 }
 
+export interface QueryParameters {
+  labelSelector?: string;
+  fieldSelector?: string;
+  [prop: string]: any;
+}
+
 //refreshToken checks if the token is about to expire and refreshes it if so.
 async function refreshToken(token: string | null) {
   if (!token || isTokenRefreshInProgress) {
@@ -311,13 +317,18 @@ function singleApiFactory(group: string, version: string, resource: string) {
   const apiRoot = getApiRoot(group, version);
   const url = `${apiRoot}/${resource}`;
   return {
-    list: (cb: StreamResultsCb, errCb: StreamErrCb) => streamResults(url, cb, errCb),
-    get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResult(url, name, cb, errCb),
-    post: (body: KubeObjectInterface) => post(url, body),
-    put: (body: KubeObjectInterface) => put(`${url}/${body.metadata.name}`, body),
-    patch: (body: OpPatch[], name: string) => patch(`${url}/${name}?pretty=true`, body),
-    delete: (name: string) => remove(`${url}/${name}`),
+    list: (cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: QueryParameters) =>
+      streamResults(url, cb, errCb, queryParams),
+    get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: QueryParameters) =>
+      streamResult(url, name, cb, errCb, queryParams),
+    post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      post(url + asQuery(queryParams), body),
+    put: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      put(`${url}/${body.metadata.name}` + asQuery(queryParams), body),
+    patch: (body: OpPatch[], name: string, queryParams?: QueryParameters) =>
+      patch(url + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
+    delete: (name: string, queryParams?: QueryParameters) =>
+      remove(`${url}/${name}` + asQuery(queryParams)),
     isNamespaced: false,
   };
 }
@@ -369,16 +380,30 @@ function simpleApiFactoryWithNamespace(
     scale?: ReturnType<typeof apiScaleFactory>;
     [other: string]: any;
   } = {
-    list: (namespace: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResults(url(namespace), cb, errCb),
-    get: (namespace: string, name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResult(url(namespace), name, cb, errCb),
-    post: (body: KubeObjectInterface) => post(url(body.metadata.namespace as string), body),
-    patch: (body: OpPatch[], namespace: string, name: string) =>
-      patch(`${url(namespace)}/${name}?pretty=true`, body),
-    put: (body: KubeObjectInterface) =>
-      put(`${url(body.metadata.namespace as string)}/${body.metadata.name}`, body),
-    delete: (namespace: string, name: string) => remove(`${url(namespace)}/${name}`),
+    list: (
+      namespace: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: QueryParameters
+    ) => streamResults(url(namespace), cb, errCb, queryParams),
+    get: (
+      namespace: string,
+      name: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: QueryParameters
+    ) => streamResult(url(namespace), name, cb, errCb, queryParams),
+    post: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      post(url(body.metadata.namespace as string) + asQuery(queryParams), body),
+    patch: (body: OpPatch[], namespace: string, name: string, queryParams?: QueryParameters) =>
+      patch(`${url(namespace)}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
+    put: (body: KubeObjectInterface, queryParams?: QueryParameters) =>
+      put(
+        `${url(body.metadata.namespace as string)}/${body.metadata.name}` + asQuery(queryParams),
+        body
+      ),
+    delete: (namespace: string, name: string, queryParams?: QueryParameters) =>
+      remove(`${url(namespace)}/${name}` + asQuery(queryParams)),
     isNamespaced: true,
   };
 
@@ -391,6 +416,12 @@ function simpleApiFactoryWithNamespace(
   function url(namespace: string) {
     return namespace ? `${apiRoot}/namespaces/${namespace}/${resource}` : `${apiRoot}/${resource}`;
   }
+}
+
+function asQuery(queryParams?: QueryParameters): string {
+  return !!queryParams && !!Object.keys(queryParams).length
+    ? '?' + new URLSearchParams(queryParams).toString()
+    : '';
 }
 
 function resourceDefToApiFactory(resourceDef: KubeObjectInterface): ApiFactoryReturn {
@@ -487,7 +518,8 @@ export async function streamResult(
   url: string,
   name: string,
   cb: StreamResultsCb,
-  errCb: StreamErrCb
+  errCb: StreamErrCb,
+  queryParams?: QueryParameters
 ) {
   let isCancelled = false;
   let socket: ReturnType<typeof stream>;
@@ -497,13 +529,14 @@ export async function streamResult(
 
   async function run() {
     try {
-      const item = await request(`${url}/${name}`);
+      const item = await request(`${url}/${name}` + asQuery(queryParams));
 
       if (isCancelled) return;
       cb(item);
 
-      const fieldSelector = encodeURIComponent(`metadata.name=${name}`);
-      const watchUrl = `${url}?watch=1&fieldSelector=${fieldSelector}`;
+      const watchUrl =
+        url +
+        asQuery({ ...queryParams, ...{ watch: '1', fieldSelector: `metadata.name=${name}` } });
 
       socket = stream(watchUrl, x => cb(x.object), { isJson: true });
     } catch (err) {
@@ -520,7 +553,12 @@ export async function streamResult(
   }
 }
 
-export async function streamResults(url: string, cb: StreamResultsCb, errCb: StreamErrCb) {
+export async function streamResults(
+  url: string,
+  cb: StreamResultsCb,
+  errCb: StreamErrCb,
+  queryParams: QueryParameters | undefined
+) {
   const results: {
     [uid: string]: KubeObjectInterface;
   } = {};
@@ -532,13 +570,15 @@ export async function streamResults(url: string, cb: StreamResultsCb, errCb: Str
 
   async function run() {
     try {
-      const { kind, items, metadata } = await request(url);
+      const { kind, items, metadata } = await request(url + asQuery(queryParams));
 
       if (isCancelled) return;
 
       add(items, kind);
 
-      const watchUrl = `${url}?watch=1&resourceVersion=${metadata.resourceVersion}`;
+      const watchUrl =
+        url +
+        asQuery({ ...queryParams, ...{ watch: '1', resourceVersion: metadata.resourceVersion } });
       socket = stream(watchUrl, update, { isJson: true });
     } catch (err) {
       console.error('Error in api request', { err, url });

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -1,9 +1,10 @@
 import { OpPatch } from 'json-patch';
+import { unset } from 'lodash';
 import React from 'react';
 import { createRouteURL } from '../router';
 import { timeAgo, useErrorState } from '../util';
 import { useConnectApi } from '.';
-import { ApiError, apiFactory, apiFactoryWithNamespace, post } from './apiProxy';
+import { ApiError, apiFactory, apiFactoryWithNamespace, post, QueryParameters } from './apiProxy';
 import CronJob from './cronJob';
 import DaemonSet from './daemonSet';
 import Deployment from './deployment';
@@ -50,7 +51,7 @@ export interface KubeOwnerReference {
   uid: string;
 }
 
-export interface ApiListOptions {
+export interface ApiListOptions extends QueryParameters {
   namespace?: string | string[];
 }
 
@@ -178,6 +179,7 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       onError?: (err: ApiError) => void,
       opts?: {
         namespace?: string;
+        queryParams?: QueryParameters;
       }
     ) {
       const createInstance = (item: T) => this.create(item) as U;
@@ -191,6 +193,15 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       if (onError) {
         args.push(onError);
       }
+
+      const queryParams: QueryParameters = {};
+      if (opts?.queryParams?.labelSelector) {
+        queryParams['labelSelector'] = opts.queryParams.labelSelector;
+      }
+      if (opts?.queryParams?.fieldSelector) {
+        queryParams['fieldSelector'] = opts.queryParams.fieldSelector;
+      }
+      args.push(queryParams);
 
       return this.apiEndpoint.list.bind(null, ...args);
     }
@@ -222,6 +233,8 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
       }
 
       const listCalls = [];
+      const queryParams = opts;
+      unset(queryParams, 'namespace');
       if (!!opts?.namespace) {
         let namespaces: string[] = [];
         if (typeof opts.namespace === 'string') {
@@ -234,13 +247,16 @@ export function makeKubeObject<T extends KubeObjectInterface | KubeEvent>(
 
         for (const namespace of namespaces) {
           listCalls.push(
-            this.apiList(objList => onObjs(namespace, objList as U[]), onError, { namespace })
+            this.apiList(objList => onObjs(namespace, objList as U[]), onError, {
+              namespace,
+              queryParams,
+            })
           );
         }
       } else {
         // If we don't have a namespace set, then we only have one API call
         // response to set and we return it right away.
-        listCalls.push(this.apiList(listCallback, onError));
+        listCalls.push(this.apiList(listCallback, onError, { queryParams }));
       }
 
       useConnectApi(...listCalls);

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -545,7 +545,7 @@ export interface LabelSelector {
     key: string;
     operator: string;
     values: string[];
-  };
+  }[];
   matchLabels?: {
     [key: string]: string;
   };

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -194,45 +194,63 @@ export function labelSelectorToQuery(labelSelector: LabelSelector) {
       segment += '!';
     }
 
+    let needsParensWrap = false;
+    const NoLengthLimits = -1;
+    let expectedValuesLength = NoLengthLimits;
+
     segment += expr.key;
     switch (expr.operator) {
       case 'Equals':
         segment += '=';
+        expectedValuesLength = 1;
         break;
       case 'DoubleEquals':
         segment += '==';
+        expectedValuesLength = 1;
         break;
       case 'NotEquals':
         segment += '!=';
+        expectedValuesLength = 1;
         break;
       case 'In':
         segment += ' in ';
+        needsParensWrap = true;
         break;
       case 'NotIn':
         segment += ' notin ';
+        needsParensWrap = true;
         break;
       case 'GreaterThan':
         segment += '>';
+        expectedValuesLength = 1;
         break;
       case 'LessThan':
         segment += '<';
+        expectedValuesLength = 1;
         break;
       case 'Exists':
       case 'DoesNotExist':
-        segments.push(segment);
-        continue;
+        expectedValuesLength = 0;
+        break;
     }
 
-    let sorted = [...(expr.values ?? [])].sort().join(',');
-    if (expr.operator === 'In' || expr.operator === 'NotIn') {
-      sorted = '(' + sorted + ')';
+    let values = '';
+
+    if (expectedValuesLength === 1) {
+      values = expr.values[0] ?? '';
+    } else if (expectedValuesLength === NoLengthLimits) {
+      values = [...(expr.values ?? [])].sort().join(',');
+      if (needsParensWrap) {
+        values = '(' + values + ')';
+      }
     }
-    segment += sorted;
+
+    segment += values;
     segments.push(segment);
   }
 
   if (segments.length === 0) {
-    return undefined;
+    return '';
   }
 
   return segments.join(',');


### PR DESCRIPTION
# frontend: List pod in OwnedPodsSection with query parameters

In Resource.ts, list pod in OwnedPodsSection with query parameters. If users only have namespace access, list all pods isn't available.

Branch created from #760 so we can rework the PR a bit.
cc/ @lijianzhi01 

## How to use

Instead of filtering pods list, OwnedPodsSection query pods with label selectors and field selectors.

## Testing done

* Test list pods in deployment with query parameters. 
* Run `make frontend-test` to run the unit tests for the query conversion function.