### PR TITLE
frontend: Add filter by type for events section

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -8,6 +8,7 @@ import { useLocation } from 'react-router';
 import Event from '../../lib/k8s/event';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
+import { useFilterFunc } from '../../lib/util';
 import { setSearchFilter } from '../../redux/actions/actions';
 import { Link, StatusLabel } from '../common';
 import Empty from '../common/EmptyContent';
@@ -70,6 +71,7 @@ function EventsSection() {
   const queryParams = new URLSearchParams(location.search);
   const eventsFilter = queryParams.get('eventsFilter');
   const dispatch = useDispatch();
+  const filterFunc = useFilterFunc(['.jsonData.involvedObject.kind']);
 
   React.useEffect(() => {
     if (!eventsFilter) {
@@ -128,6 +130,7 @@ function EventsSection() {
           },
           'age',
         ]}
+        filterFunction={filterFunc}
       />
     </SectionBox>
   );


### PR DESCRIPTION
# [Title: describe the change in one sentence]

Allow to search by type for events table

## How to use

Go to cluster overview page go to events table search with a resource type and it would filter the table based on resource type

fixes #769 