### PR TITLE
Render logs using xterm

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -103,6 +103,7 @@
         "http-proxy-middleware": "^2.0.1",
         "husky": "^4.3.8",
         "i18next-parser": "^4.7.0",
+        "jest-canvas-mock": "^2.4.0",
         "lint-staged": "^10.5.4",
         "msw": "^0.47.4",
         "msw-storybook-addon": "^1.6.3",
@@ -3327,6 +3328,27 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
     },
     "node_modules/@material-ui/core": {
       "version": "4.12.4",
@@ -14480,6 +14502,13 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -14804,13 +14833,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -16421,6 +16450,22 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.2.tgz",
+      "integrity": "sha512-FSmlsip0nZ0U4Zcfht0qBJqDhlfGuevTZKE8h+dBOYrJjGvY3iqMGSzzbvkaFhvMXiVxfcMaPHS/kge++T5SKg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -16588,7 +16633,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       }
@@ -17092,7 +17137,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -17269,7 +17314,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -18090,6 +18135,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "node_modules/cssnano": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.9.tgz",
@@ -18411,6 +18462,19 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -18570,7 +18634,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -18622,6 +18686,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -21189,7 +21263,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -21391,7 +21465,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -21929,7 +22003,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -24016,6 +24090,16 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
+      "dev": true,
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
       }
     },
     "node_modules/jest-changed-files": {
@@ -27113,6 +27197,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -27209,7 +27306,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
       "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -27257,7 +27354,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -27396,6 +27493,15 @@
       "peerDependencies": {
         "monaco-editor": "0.25.x || 0.26.x || 0.27.x || 0.28.x",
         "webpack": "^4.5.0 || 5.x"
+      }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4"
       }
     },
     "node_modules/move-concurrently": {
@@ -27606,10 +27712,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-      "dev": true,
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "optional": true
     },
     "node_modules/nanoid": {
@@ -27860,6 +27965,22 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -27979,7 +28100,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -34085,7 +34206,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/set-cookie-parser": {
       "version": "2.5.1",
@@ -34243,6 +34364,39 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -35498,7 +35652,7 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -35515,7 +35669,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -38026,7 +38180,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -40746,6 +40900,24 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      }
     },
     "@material-ui/core": {
       "version": "4.12.4",
@@ -49333,6 +49505,13 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true,
+      "peer": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -49566,13 +49745,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
+      "devOptional": true
     },
     "are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -50820,6 +50999,18 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
       "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA=="
     },
+    "canvas": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.2.tgz",
+      "integrity": "sha512-FSmlsip0nZ0U4Zcfht0qBJqDhlfGuevTZKE8h+dBOYrJjGvY3iqMGSzzbvkaFhvMXiVxfcMaPHS/kge++T5SKg==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      }
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -50936,7 +51127,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
+      "devOptional": true
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -51334,7 +51525,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
+      "devOptional": true
     },
     "colord": {
       "version": "2.9.2",
@@ -51482,7 +51673,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "devOptional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -52109,6 +52300,12 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "cssnano": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.9.tgz",
@@ -52355,6 +52552,16 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -52475,7 +52682,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "devOptional": true
     },
     "depd": {
       "version": "2.0.0",
@@ -52514,6 +52721,13 @@
       "requires": {
         "repeat-string": "^1.5.4"
       }
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "optional": true,
+      "peer": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -54548,7 +54762,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -54726,7 +54940,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -55144,7 +55358,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "devOptional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -56669,6 +56883,16 @@
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
         "jest-cli": "^27.5.1"
+      }
+    },
+    "jest-canvas-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
       }
     },
     "jest-changed-files": {
@@ -58969,6 +59193,13 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "optional": true,
+      "peer": true
+    },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -59040,7 +59271,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
       "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -59076,7 +59307,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -59195,6 +59426,15 @@
       "integrity": "sha512-/P3sFiEgBl+Y50he4mbknMhbLJVop5gBUZiPS86SuHUDOOnQiQ5rL1jU5lwt1XKAwMEkhwZbUwqaHxTPkb1Utw==",
       "requires": {
         "loader-utils": "^2.0.0"
+      }
+    },
+    "moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
       }
     },
     "move-concurrently": {
@@ -59354,10 +59594,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-      "dev": true,
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "optional": true
     },
     "nanoid": {
@@ -59581,6 +59820,16 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -59668,7 +59917,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -64101,7 +64350,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "devOptional": true
     },
     "set-cookie-parser": {
       "version": "2.5.1",
@@ -64231,6 +64480,25 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "optional": true,
+      "peer": true
+    },
+    "simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -65239,7 +65507,7 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -65253,7 +65521,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -67234,7 +67502,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,6 @@
         "@types/webpack-env": "^1.16.2",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
-        "ansi-to-react": "^6.1.6",
         "buffer": "^6.0.3",
         "console-browserify": "^1.2.0",
         "cronstrue": "^1.123.0",
@@ -14672,11 +14671,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/anser": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
-      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -14774,19 +14768,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/ansi-to-react": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.1.6.tgz",
-      "integrity": "sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==",
-      "dependencies": {
-        "anser": "^1.4.1",
-        "escape-carriage": "^1.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.3.2 || ^17.0.0",
-        "react-dom": "^16.3.2 || ^17.0.0"
       }
     },
     "node_modules/anymatch": {
@@ -19330,11 +19311,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-carriage": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.0.tgz",
-      "integrity": "sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ=="
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
@@ -49498,11 +49474,6 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
-    "anser": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
-      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="
-    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -49565,15 +49536,6 @@
           "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
           "dev": true
         }
-      }
-    },
-    "ansi-to-react": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.1.6.tgz",
-      "integrity": "sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==",
-      "requires": {
-        "anser": "^1.4.1",
-        "escape-carriage": "^1.3.0"
       }
     },
     "anymatch": {
@@ -53126,11 +53088,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
-    },
-    "escape-carriage": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.0.tgz",
-      "integrity": "sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,8 +86,9 @@
         "util": "^0.12.4",
         "vfile": "^5.3.0",
         "webpack": "^5.66.0",
-        "xterm": "^4.14.1",
-        "xterm-addon-fit": "^0.5.0"
+        "xterm": "^4.19.0",
+        "xterm-addon-fit": "^0.5.0",
+        "xterm-addon-search": "^0.9.0"
       },
       "devDependencies": {
         "@axe-core/react": "^4.3.2",
@@ -38550,14 +38551,22 @@
       }
     },
     "node_modules/xterm": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.18.0.tgz",
-      "integrity": "sha512-JQoc1S0dti6SQfI0bK1AZvGnAxH4MVw45ZPFSO6FHTInAiau3Ix77fSxNx3mX4eh9OL4AYa8+4C8f5UvnSfppQ=="
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
+      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
       "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
+      "peerDependencies": {
+        "xterm": "^4.0.0"
+      }
+    },
+    "node_modules/xterm-addon-search": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-search/-/xterm-addon-search-0.9.0.tgz",
+      "integrity": "sha512-aoolI8YuHvdGw+Qjg8g2M4kst0v86GtB7WeBm4F0jNXA005/6QbWWy9eCsvnIDLJOFI5JSSrZnD6CaOkvBQYPA==",
       "peerDependencies": {
         "xterm": "^4.0.0"
       }
@@ -67832,14 +67841,20 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "xterm": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.18.0.tgz",
-      "integrity": "sha512-JQoc1S0dti6SQfI0bK1AZvGnAxH4MVw45ZPFSO6FHTInAiau3Ix77fSxNx3mX4eh9OL4AYa8+4C8f5UvnSfppQ=="
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
+      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
     },
     "xterm-addon-fit": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
       "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
+      "requires": {}
+    },
+    "xterm-addon-search": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-search/-/xterm-addon-search-0.9.0.tgz",
+      "integrity": "sha512-aoolI8YuHvdGw+Qjg8g2M4kst0v86GtB7WeBm4F0jNXA005/6QbWWy9eCsvnIDLJOFI5JSSrZnD6CaOkvBQYPA==",
       "requires": {}
     },
     "y18n": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,8 +81,9 @@
     "util": "^0.12.4",
     "vfile": "^5.3.0",
     "webpack": "^5.66.0",
-    "xterm": "^4.14.1",
-    "xterm-addon-fit": "^0.5.0"
+    "xterm": "^4.19.0",
+    "xterm-addon-fit": "^0.5.0",
+    "xterm-addon-search": "^0.9.0"
   },
   "scripts": {
     "prestart": "npm run make-version",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,6 @@
     "@types/webpack-env": "^1.16.2",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
-    "ansi-to-react": "^6.1.6",
     "buffer": "^6.0.3",
     "console-browserify": "^1.2.0",
     "cronstrue": "^1.123.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -172,7 +172,8 @@
     ],
     "transformIgnorePatterns": [
       "/node_modules/(?!d3|internmap|react-markdown|xterm|github-markdown-css|vfile|unist-.+|unified|bail|is-plain-obj|trough|remark-.+|mdast-util-.+|micromark|parse-entities|character-entities|property-information|comma-separated-tokens|hast-util-whitespace|remark-.+|space-separated-tokens|decode-named-character-reference)"
-    ]
+    ],
+    "resetMocks": false
   },
   "prettier": "@kinvolk/eslint-config/prettier-config",
   "devDependencies": {
@@ -189,6 +190,7 @@
     "http-proxy-middleware": "^2.0.1",
     "husky": "^4.3.8",
     "i18next-parser": "^4.7.0",
+    "jest-canvas-mock": "^2.4.0",
     "lint-staged": "^10.5.4",
     "msw": "^0.47.4",
     "msw-storybook-addon": "^1.6.3",

--- a/frontend/src/components/common/ActionButton/ActionButton.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.tsx
@@ -1,9 +1,9 @@
 import { Icon, IconifyIcon } from '@iconify/react';
-import IconButton from '@material-ui/core/IconButton';
+import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import React from 'react';
 
-export interface ActionButtonProps {
+export interface ActionButtonProps extends Omit<IconButtonProps, 'children' | 'color'> {
   /** A short description of the action. */
   description: string;
   /** Either a string icon, or imported icon. */
@@ -29,18 +29,11 @@ export interface ActionButtonProps {
  *
  * So we implement them consistently and encapsulate the implementation.
  */
-export default function ActionButton({
-  description,
-  longDescription,
-  icon,
-  onClick,
-  color,
-  width,
-  edge,
-}: ActionButtonProps) {
+export default function ActionButton(props: ActionButtonProps) {
+  const { description, longDescription, icon, onClick, color, width, edge, ...otherProps } = props;
   return (
     <Tooltip title={longDescription || description}>
-      <IconButton aria-label={description} onClick={onClick} edge={edge}>
+      <IconButton aria-label={description} onClick={onClick} edge={edge} {...otherProps}>
         <Icon icon={icon} color={color} width={width} />
       </IconButton>
     </Tooltip>

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -64,10 +64,19 @@ export interface LogViewerProps extends DialogProps {
   onClose: () => void;
   topActions?: JSX.Element[];
   open: boolean;
+  xtermRef?: React.MutableRefObject<XTerminal | null>;
 }
 
 export function LogViewer(props: LogViewerProps) {
-  const { logs, title = '', downloadName = 'log', onClose, topActions = [], ...other } = props;
+  const {
+    logs,
+    title = '',
+    downloadName = 'log',
+    xtermRef: outXtermRef,
+    onClose,
+    topActions = [],
+    ...other
+  } = props;
   const [isFullScreen, setIsFullScreen] = React.useState(false);
   const classes = useStyle({ isFullScreen });
   const { t } = useTranslation('frequent');
@@ -103,6 +112,11 @@ export function LogViewer(props: LogViewerProps) {
     searchAddonRef.current = new SearchAddon();
 
     xtermRef.current = new XTerminal(XterminalReadonlyConfig);
+
+    if (!!outXtermRef) {
+      outXtermRef.current = xtermRef.current;
+    }
+
     xtermRef.current.loadAddon(fitAddonRef.current);
     xtermRef.current.loadAddon(searchAddonRef.current);
     enableCopyPasteInXterm(xtermRef.current);
@@ -132,6 +146,12 @@ export function LogViewer(props: LogViewerProps) {
       return;
     }
 
+    // We're delegating to external xterm ref.
+    if (!!outXtermRef) {
+      return;
+    }
+
+    xtermRef.current?.clear();
     xtermRef.current?.write(getJointLogs());
 
     return function cleanup() {};

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -1,6 +1,7 @@
 import { Box, DialogContent, Grid, InputBase, makeStyles, Paper } from '@material-ui/core';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 import { ITerminalOptions, Terminal as XTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -85,6 +86,10 @@ export function LogViewer(props: LogViewerProps) {
   const searchAddonRef = React.useRef<any>(null);
   const [terminalContainerRef, setTerminalContainerRef] = React.useState<HTMLElement | null>(null);
   const [showSearch, setShowSearch] = React.useState(false);
+
+  useHotkeys('ctrl+shift+f', () => {
+    setShowSearch(true);
+  });
 
   const XterminalReadonlyConfig: ITerminalOptions = {
     cursorStyle: 'bar',

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -105,6 +105,7 @@ export function LogViewer(props: LogViewerProps) {
     xtermRef.current = new XTerminal(XterminalReadonlyConfig);
     xtermRef.current.loadAddon(fitAddonRef.current);
     xtermRef.current.loadAddon(searchAddonRef.current);
+    enableCopyPasteInXterm(xtermRef.current);
 
     xtermRef.current.open(terminalContainerRef!);
 
@@ -187,6 +188,21 @@ export function LogViewer(props: LogViewerProps) {
       </DialogContent>
     </Dialog>
   );
+}
+
+function enableCopyPasteInXterm(xterm: XTerminal) {
+  xterm.attachCustomKeyEventHandler(arg => {
+    if (arg.ctrlKey && arg.code === 'KeyC' && arg.type === 'keydown') {
+      const selection = xterm.getSelection();
+      if (selection) {
+        return false;
+      }
+    }
+    if (arg.ctrlKey && arg.code === 'KeyV' && arg.type === 'keydown') {
+      return false;
+    }
+    return true;
+  });
 }
 
 const useSearchBoxStyle = makeStyles(theme => {

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -45,6 +45,7 @@ function PodLogViewer(props: PodLogViewerProps) {
   const [container, setContainer] = React.useState(getDefaultContainer());
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
   const [showTimestamps, setShowTimestamps] = React.useState<boolean>(true);
+  const [follow, setFollow] = React.useState<boolean>(true);
   const [lines, setLines] = React.useState<number>(100);
   const [logs, setLogs] = React.useState<string[]>([]);
   const { t } = useTranslation('frequent');
@@ -69,6 +70,7 @@ function PodLogViewer(props: PodLogViewerProps) {
           tailLines: lines,
           showPrevious,
           showTimestamps,
+          follow,
         });
       }
 
@@ -79,7 +81,7 @@ function PodLogViewer(props: PodLogViewerProps) {
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [container, lines, open, showPrevious, showTimestamps]
+    [container, lines, open, showPrevious, showTimestamps, follow]
   );
 
   function handleContainerChange(event: any) {
@@ -107,6 +109,10 @@ function PodLogViewer(props: PodLogViewerProps) {
 
   function handleTimestampsChange() {
     setShowTimestamps(timestamps => !timestamps);
+  }
+
+  function handleFollowChange() {
+    setFollow(follow => !follow);
   }
 
   return (
@@ -182,6 +188,19 @@ function PodLogViewer(props: PodLogViewerProps) {
               checked={showTimestamps}
               onChange={handleTimestampsChange}
               name="checkTimestamps"
+              color="primary"
+              size="small"
+            />
+          }
+        />,
+        <FormControlLabel
+          className={classes.switchControl}
+          label={t('logs|Follow')}
+          control={
+            <Switch
+              checked={follow}
+              onChange={handleFollowChange}
+              name="follow"
               color="primary"
               size="small"
             />

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -25,9 +25,13 @@ const useStyle = makeStyles(theme => ({
   containerFormControl: {
     minWidth: '11rem',
   },
+  linesFormControl: {
+    minWidth: '6rem',
+  },
   switchControl: {
-    minWidth: '11rem',
-    paddingTop: theme.spacing(1),
+    margin: 0,
+    paddingTop: theme.spacing(2),
+    paddingRight: theme.spacing(2),
   },
 }));
 
@@ -131,7 +135,7 @@ function PodLogViewer(props: PodLogViewerProps) {
               ))}
           </Select>
         </FormControl>,
-        <FormControl className={classes.containerFormControl}>
+        <FormControl className={classes.linesFormControl}>
           <InputLabel shrink id="container-lines-chooser-label">
             {t('frequent|Lines')}
           </InputLabel>
@@ -165,19 +169,21 @@ function PodLogViewer(props: PodLogViewerProps) {
                 onChange={handlePreviousChange}
                 name="checkPrevious"
                 color="primary"
+                size="small"
               />
             }
           />
         </LightTooltip>,
         <FormControlLabel
           className={classes.switchControl}
-          label={t('logs|Show Timestamps')}
+          label={t('logs|Timestamps')}
           control={
             <Switch
               checked={showTimestamps}
               onChange={handleTimestampsChange}
               name="checkTimestamps"
               color="primary"
+              size="small"
             />
           }
         />,

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -79,6 +79,16 @@ function PodLogViewer(props: PodLogViewerProps) {
         lastLineShown: logLines.length - 1,
       };
     });
+    // If we stopped following the logs and we have logs already,
+    // then we don't need to fetch them again.
+    if (!follow && logs.logs.length > 0) {
+      xtermRef.current?.write(
+        '\n\n' +
+          t('logs|Logs are paused. Click the follow button to resume following them.') +
+          '\r\n'
+      );
+      return;
+    }
   }
   const debouncedSetState = _.debounce(setLogsDebounced, 500, options);
 

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -216,9 +216,14 @@ export function VolumeDetails(props: VolumeDetailsProps) {
   );
 }
 
-export default function PodDetails() {
+export interface PodDetailsProps {
+  showLogsDefault?: boolean;
+}
+
+export default function PodDetails(props: PodDetailsProps) {
+  const { showLogsDefault } = props;
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
-  const [showLogs, setShowLogs] = React.useState(false);
+  const [showLogs, setShowLogs] = React.useState(!!showLogsDefault);
   const [showTerminal, setShowTerminal] = React.useState(false);
   const { t } = useTranslation('glossary');
 

--- a/frontend/src/components/pod/PodLogs.stories.tsx
+++ b/frontend/src/components/pod/PodLogs.stories.tsx
@@ -1,0 +1,96 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { StreamResultsCb } from '../../lib/k8s/apiProxy';
+import { KubeObjectClass } from '../../lib/k8s/cluster';
+import Pod, { KubePod, LogOptions } from '../../lib/k8s/pod';
+import { TestContext } from '../../test';
+import PodDetails, { PodDetailsProps } from './Details';
+import { podList } from './storyHelper';
+
+const usePhonyGet: KubeObjectClass['useGet'] = (name, namespace) => {
+  return [
+    new Pod(
+      podList.find(
+        pod => pod.metadata.name === name && pod.metadata.namespace === namespace
+      ) as KubePod
+    ),
+    null,
+    () => {},
+    () => {},
+  ] as any;
+};
+
+export default {
+  title: 'Pod/PodLogs',
+  component: PodDetails,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return <Story />;
+    },
+  ],
+} as Meta;
+
+interface MockerStory {
+  podName: string;
+  detailsProps: PodDetailsProps;
+  [key: string]: Pod[keyof typeof Pod | keyof typeof Pod.prototype];
+}
+
+const Template: Story<MockerStory> = args => {
+  const { podName, detailsProps, ...podProps } = args;
+
+  for (const key in podProps) {
+    const [prefix, method] = key.split('.');
+    if (prefix === 'prototype') {
+      Pod.prototype[method as keyof typeof Pod.prototype] = podProps[key];
+      continue;
+    }
+
+    Pod[key as keyof typeof Pod] = podProps[key];
+  }
+
+  return (
+    <TestContext routerMap={{ namespace: 'default', name: podName }}>
+      <PodDetails {...detailsProps} />;
+    </TestContext>
+  );
+};
+
+function getLogs(container: string, onLogs: StreamResultsCb, logsOptions: LogOptions) {
+  const { tailLines, showTimestamps } = logsOptions;
+
+  function generateLogs() {
+    const linesToShow = tailLines || 100;
+    const logs: string[] = [];
+
+    for (let i = 0; i < linesToShow; i++) {
+      logs.push(
+        `${
+          showTimestamps ? `2020-01-01 16:00:00.${i % 1000}` + ' ' : ''
+        }(log #${i}): from container ${container} log line log line log line log line log line log line log line log line log line\n`
+      );
+    }
+
+    return logs;
+  }
+
+  // Simulate a stream by continuously generating new logs.
+  // It's purposedly triggering at a fast pace so we see if the UI can handle it.
+  const logsHandle = setInterval(() => {
+    onLogs(generateLogs());
+  }, 100); // ms
+
+  return () => {
+    clearInterval(logsHandle);
+  };
+}
+
+export const Logs = Template.bind({});
+Logs.args = {
+  useGet: usePhonyGet,
+  'prototype.getLogs': getLogs,
+  podName: 'running',
+  detailsProps: {
+    showLogsDefault: true,
+  },
+};

--- a/frontend/src/components/pod/PodLogs.stories.tsx
+++ b/frontend/src/components/pod/PodLogs.stories.tsx
@@ -66,7 +66,7 @@ function getLogs(container: string, onLogs: StreamResultsCb, logsOptions: LogOpt
     for (let i = 0; i < linesToShow; i++) {
       logs.push(
         `${
-          showTimestamps ? `2020-01-01 16:00:00.${i % 1000}` + ' ' : ''
+          showTimestamps ? new Date().toISOString() + ' ' : ''
         }(log #${i}): from container ${container} log line log line log line log line log line log line log line log line log line\n`
       );
     }
@@ -74,14 +74,14 @@ function getLogs(container: string, onLogs: StreamResultsCb, logsOptions: LogOpt
     return logs;
   }
 
-  // Simulate a stream by continuously generating new logs.
+  // Simulate a stream by continuously generating new logs (only if not under unattended testing).
   // It's purposedly triggering at a fast pace so we see if the UI can handle it.
   const logsHandle = setInterval(() => {
     onLogs(generateLogs());
   }, 100); // ms
 
   return () => {
-    clearInterval(logsHandle);
+    clearInterval(logsHandle as NodeJS.Timeout);
   };
 }
 

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -43,6 +43,8 @@ export interface LogOptions {
   showPrevious?: boolean;
   /** Whether to show the timestamps in the logs */
   showTimestamps?: boolean;
+  /** Whether to follow the log stream */
+  follow?: boolean;
 }
 
 /**@deprecated
@@ -99,9 +101,14 @@ class Pod extends makeKubeObject<KubePod>('Pod') {
     }
 
     const [container, onLogs, logsOptions] = args as Parameters<newGetLogs>;
-    const { tailLines = 100, showPrevious = false, showTimestamps = false } = logsOptions;
+    const {
+      tailLines = 100,
+      showPrevious = false,
+      showTimestamps = false,
+      follow = true,
+    } = logsOptions;
     let logs: string[] = [];
-    const url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/log?container=${container}&previous=${showPrevious}&tailLines=${tailLines}&timestamps=${showTimestamps}&follow=true`;
+    const url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/log?container=${container}&previous=${showPrevious}&tailLines=${tailLines}&timestamps=${showTimestamps}&follow=${follow}`;
 
     function onResults(item: string) {
       if (!item) {
@@ -117,6 +124,7 @@ class Pod extends makeKubeObject<KubePod>('Pod') {
       connectCb: () => {
         logs = [];
       },
+      reconnectOnFailure: follow,
     });
 
     return cancel;

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -36,7 +36,7 @@ export interface ExecOptions extends StreamArgs {
   command?: string[];
 }
 
-interface LogOptions {
+export interface LogOptions {
   /** The number of lines to display from the end side of the log */
   tailLines?: number;
   /** Whether to show the logs from previous runs of the container (only for restarted containers) */

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -3,6 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import 'jest-canvas-mock';
 
 if (typeof TextDecoder === 'undefined' && typeof require !== 'undefined') {
   (global as any).TextDecoder = require('util').TextDecoder;
@@ -13,3 +14,17 @@ if (typeof TextEncoder === 'undefined' && typeof require !== 'undefined') {
 if (typeof ResizeObserver === 'undefined' && typeof require !== 'undefined') {
   (global as any).ResizeObserver = require('resize-observer-polyfill');
 }
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
This PR changes how the logs are rendered, it namely:
* Allows selected text to remain selected even if new logs arrive
* Allows copying logs
* Improves the performance by only rendering the logs that have not yet been shown
* Adds search to logs
* Allows to stop following logs (pauses the stream)

fixes https://github.com/kinvolk/headlamp/issues/785

Testing:
* There's a new story for checking logs in the Storybook
* Go to a pod that has logs or create a [pod that logs constantly](https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/debug/counter-pod.yaml) and click the logs button