### PR TITLE
Reflect table pages in the URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ backend/tools
 app/electron/src/*
 docs/development/storybook/
 .plugins
+node_modules

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -51,6 +51,15 @@ From within the [Headlamp](https://github.com/kinvolk/headlamp/) repo run:
 make storybook
 ```
 
+If you are adding new stories, please wrap your story components with the `TestContext` helper
+component as it sets up the store, memory router, and other utilities that may be needed for
+current or future stories:
+
+```jsx
+<TestContext>
+  <YourComponentTheStoryIsAbout />
+</TestContext>
+```
 
 ## Accessibility (a11y)
 

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -105,6 +105,7 @@ function Table(props: ResourceTableProps) {
       rowsPerPage={[15, 25, 50]}
       defaultSortingColumn={sortingColumn}
       filterFunction={useFilterFunc()}
+      reflectInURL
       {...otherProps}
     />
   );

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -82,6 +82,10 @@ export interface SimpleTableProps {
    * If true or '', it'll reflect the parameters without a prefix.
    * By default, no parameters are reflected in the URL. */
   reflectInURL?: string | boolean;
+  /** The page number to show by default (by default it's the first page). */
+  page?: number;
+  /** Whether to show the pagination component */
+  showPagination?: boolean;
 }
 
 interface ColumnSortButtonProps {
@@ -145,6 +149,8 @@ export default function SimpleTable(props: SimpleTableProps) {
     data,
     filterFunction = null,
     emptyMessage = null,
+    page: initialPage = 0,
+    showPagination = true,
     errorMessage = null,
     defaultSortingColumn,
     noTableHeader = false,
@@ -152,7 +158,7 @@ export default function SimpleTable(props: SimpleTableProps) {
   } = props;
   const shouldReflectInURL = reflectInURL !== undefined && reflectInURL !== false;
   const prefix = reflectInURL === true ? '' : reflectInURL || '';
-  const [page, setPage] = usePageURLState(shouldReflectInURL ? 'p' : '', prefix, 0);
+  const [page, setPage] = usePageURLState(shouldReflectInURL ? 'p' : '', prefix, initialPage);
   const [currentData, setCurrentData] = React.useState(data);
   const [displayData, setDisplayData] = React.useState(data);
   const rowsPerPageOptions = props.rowsPerPage || [15, 25, 50];
@@ -385,7 +391,7 @@ export default function SimpleTable(props: SimpleTableProps) {
           )}
         </TableBody>
       </Table>
-      {filteredData.length > rowsPerPageOptions[0] && (
+      {filteredData.length > rowsPerPageOptions[0] && showPagination && (
         <TablePagination
           rowsPerPageOptions={rowsPerPageOptions}
           component="div"

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -120,7 +120,7 @@ function usePageURLState(
   initialPage: number
 ): ReturnType<typeof useURLState> {
   const [page, setPage] = useURLState(key, { defaultValue: initialPage + 1, prefix });
-  const [zeroIndexPage, setZeroIndexPage] = React.useState(initialPage);
+  const [zeroIndexPage, setZeroIndexPage] = React.useState(page - 1);
 
   React.useEffect(() => {
     setZeroIndexPage((zeroIndexPage: number) => {

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -1542,6 +1542,300 @@ exports[`Storyshots SimpleTable Number Search 1`] = `
 </div>
 `;
 
+exports[`Storyshots SimpleTable Reflect In URL 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Test changing the page and rows per page.
+    </p>
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      <b>
+        Current URL search:
+      </b>
+       
+      ?p=2
+    </p>
+    <table
+      class="MuiTable-root makeStyles-table"
+    >
+      <thead
+        class="MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            scope="col"
+          >
+            Name
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            scope="col"
+          >
+            Namespace
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            scope="col"
+          >
+            Number
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 5
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 5
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            5
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 6
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 6
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            6
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 7
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 7
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            7
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 8
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 8
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            8
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 9
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 9
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            9
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Storyshots SimpleTable Reflect In URL With Prefix 1`] = `
+<div>
+  <div
+    class="MuiBox-root MuiBox-root"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Test changing the page and rows per page.
+    </p>
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      <b>
+        Current URL search:
+      </b>
+       
+      ?p=2
+    </p>
+    <table
+      class="MuiTable-root makeStyles-table"
+    >
+      <thead
+        class="MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            scope="col"
+          >
+            Name
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            scope="col"
+          >
+            Namespace
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            scope="col"
+          >
+            Number
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 0
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 0
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 1
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 1
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 2
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 2
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 3
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 3
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Name 4
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            Namespace 4
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`Storyshots SimpleTable UID Search 1`] = `
 <div>
   <div

--- a/frontend/src/components/crd/Details.tsx
+++ b/frontend/src/components/crd/Details.tsx
@@ -138,6 +138,7 @@ export default function CustomResourceDefinitionDetails() {
               datum: 'listKind',
             },
           ]}
+          reflectInURL="acceptedNames"
         />
       </SectionBox>
       <SectionBox title={t('frequent|Versions')}>
@@ -157,6 +158,7 @@ export default function CustomResourceDefinitionDetails() {
               getter: version => version.storage.toString(),
             },
           ]}
+          reflectInURL="versions"
         />
       </SectionBox>
       <SectionBox title={t('Conditions')}>
@@ -177,6 +179,7 @@ export default function CustomResourceDefinitionDetails() {
             },
             'age',
           ]}
+          reflectInURL="objects"
         />
       </SectionBox>
       <DetailsViewSection resource={item} />

--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -60,6 +60,7 @@ function TolerationsSection(props: TolerationsSection) {
             sort: true,
           },
         ]}
+        reflectInURL="tolerations"
       />
     </SectionBox>
   );

--- a/frontend/src/components/endpoints/Details.tsx
+++ b/frontend/src/components/endpoints/Details.tsx
@@ -70,6 +70,7 @@ export default function EndpointDetails() {
                           },
                         },
                       ]}
+                      reflectInURL="addresses"
                     />
                     <SectionHeader noPadding title={t('Ports')} headerStyle="label" />
                     <SimpleTable
@@ -92,6 +93,7 @@ export default function EndpointDetails() {
                         },
                       ]}
                       defaultSortingColumn={1}
+                      reflectInURL="ports"
                     />
                   </SectionBox>
                 ))

--- a/frontend/src/components/endpoints/EndpointDetails.stories.tsx
+++ b/frontend/src/components/endpoints/EndpointDetails.stories.tsx
@@ -89,7 +89,11 @@ const Template: Story = (args: MockerStory) => {
     Endpoints.useList = args.useList;
   }
 
-  return <EndpointDetails />;
+  return (
+    <TestContext>
+      <EndpointDetails />
+    </TestContext>
+  );
 };
 
 export const Default = Template.bind({});

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -111,33 +111,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                     </th>
                     <td
                       class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-                    >
-                      <span
-                        class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
-                      >
-                        my-endpoint
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    class="MuiTableRow-root"
-                  >
-                    <th
-                      class="MuiTableCell-root MuiTableCell-body makeStyles-metadataNameCell"
-                      role="cell"
-                      scope="row"
-                    >
-                      Namespace
-                    </th>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body makeStyles-metadataCell"
-                    >
-                      <span
-                        class="MuiTypography-root makeStyles-valueLabel MuiTypography-body1"
-                      >
-                        my-namespace
-                      </span>
-                    </td>
+                    />
                   </tr>
                   <tr
                     class="MuiTableRow-root"

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -57,6 +57,7 @@ export default function IngressDetails() {
               },
             ]}
             data={getHostsData(item)}
+            reflectInURL="rules"
           />
         </SectionBox>
       )}

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -271,6 +271,7 @@ export function VolumeDetails(props: VolumeDetailsProps) {
           },
         ]}
         data={volumes}
+        reflectInURL="volumes"
       />
     </SectionBox>
   );

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ApiError } from '../../lib/k8s/apiProxy';
 import Pod from '../../lib/k8s/pod';
 import { timeAgo } from '../../lib/util';
-import { LightTooltip, SectionFilterHeader } from '../common';
+import { LightTooltip, SectionFilterHeader, SimpleTableProps } from '../common';
 import { StatusLabel, StatusLabelProps } from '../common/Label';
 import ResourceTable, { ResourceTableProps } from '../common/Resource/ResourceTable';
 import { SectionBox } from '../common/SectionBox';
@@ -52,10 +52,11 @@ export interface PodListProps {
   pods: Pod[] | null;
   error: ApiError | null;
   hideColumns?: ('namespace' | 'restarts')[];
+  reflectTableInURL?: SimpleTableProps['reflectInURL'];
 }
 
 export function PodListRenderer(props: PodListProps) {
-  const { pods, error, hideColumns = [] } = props;
+  const { pods, error, hideColumns = [], reflectTableInURL = 'pods' } = props;
   const { t } = useTranslation('glossary');
 
   function getDataCols() {
@@ -110,6 +111,7 @@ export function PodListRenderer(props: PodListProps) {
         errorMessage={Pod.getErrorMessage(error)}
         columns={getDataCols()}
         data={pods}
+        reflectInURL={reflectTableInURL}
       />
     </SectionBox>
   );
@@ -118,5 +120,5 @@ export function PodListRenderer(props: PodListProps) {
 export default function PodList() {
   const [pods, error] = Pod.useList();
 
-  return <PodListRenderer pods={pods} error={error} />;
+  return <PodListRenderer pods={pods} error={error} reflectTableInURL />;
 }

--- a/frontend/src/components/role/BindingDetails.tsx
+++ b/frontend/src/components/role/BindingDetails.tsx
@@ -67,6 +67,7 @@ export default function RoleBindingDetails() {
                   getter: item => item.namespace,
                 },
               ]}
+              reflectInURL="bindingInfo"
             />
           </SectionBox>
         )

--- a/frontend/src/components/role/Details.tsx
+++ b/frontend/src/components/role/Details.tsx
@@ -42,6 +42,7 @@ export default function RoleDetails() {
                 },
               ]}
               data={item.rules}
+              reflectInURL="rules"
             />
           </SectionBox>
         )

--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -74,6 +74,7 @@ export default function ServiceDetails() {
                     ),
                   },
                 ]}
+                reflectInURL="ports"
               />
             </SectionBox>
             <SectionBox title={t('Endpoints')}>
@@ -93,6 +94,7 @@ export default function ServiceDetails() {
                       cellProps: { style: { width: '40%', maxWidth: '40%' } },
                     },
                   ]}
+                  reflectInURL="endpoints"
                 />
               )}
             </SectionBox>

--- a/frontend/src/test/index.tsx
+++ b/frontend/src/test/index.tsx
@@ -7,10 +7,13 @@ import defaultStore from '../redux/stores/store';
 export type TestContextProps = PropsWithChildren<{
   store?: ReturnType<typeof createStore>;
   routerMap?: Record<string, string>;
+  urlSearchParams?: {
+    [key: string]: string;
+  };
 }>;
 
 export function TestContext(props: TestContextProps) {
-  const { store, routerMap, children } = props;
+  const { store, routerMap, urlSearchParams, children } = props;
   let url = '';
   let routePath = '';
 
@@ -18,6 +21,10 @@ export function TestContext(props: TestContextProps) {
     // Add the prefix : to the key to make it a param if needed.
     routePath += '/' + (key.startsWith(':') ? key : ':' + key);
     url += '/' + value;
+  }
+
+  if (!!urlSearchParams) {
+    url += '?' + new URLSearchParams(urlSearchParams).toString();
   }
 
   return (


### PR DESCRIPTION
These changes introduce a new useURLState which is the same as React.useState but reflects that state as a URL search parameter. For flexibility it can also be used as a plain useState, if the key passed to it is false.

It also makes sure that all tables in Headlamp are reflected in the URL.

The default values of the page and rowsPerPage are not shown in the URL (maybe for the latter it'd be a good idea since users may have a different default number for it but I haven't changed it).

BTW, I can also add the reflectURL logic as a new TableWithPropsInURL rather than having a `reflectInURL` prop (but it's been a while since the `SimpleTable` is simple, we might as well just call it table 😛 ).

**Tests:**

Go to a view that has a table; change the page and rows per page -> you should see those properties reflected in the URL.
Arrive at a list view with the p=2 (and enough data for those pages) -> you should be at page 2
Go to a URL with p=200000 -> it should show the last page
Go to a URL with p=-1 or perPage=-1 it should show the minimal value possible in each case
Try also the storybook with the new stories under SimpleTable.


fixes https://github.com/kinvolk/headlamp/issues/21

Needed for https://github.com/kinvolk/headlamp/issues/781