### PR TITLE
frontend: Resize terminal in toggle fullscreen

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -353,6 +353,11 @@ export default function Terminal(props: TerminalProps) {
   return (
     <Dialog
       onClose={onClose}
+      onFullScreenToggled={() => {
+        setTimeout(() => {
+          fitAddonRef.current!.fit();
+        }, 1);
+      }}
       keepMounted
       withFullScreen
       title={t('Terminal: {{ itemName }}', { itemName: item.metadata.name })}


### PR DESCRIPTION
# [Title: describe the change in one sentence]

Toggle full screen without resizing terminal. Text will not auto fit into columns. 

![image](https://user-images.githubusercontent.com/13809749/201698389-cb321b0f-580c-41fe-9a15-3789776af2df.png)


## How to use

Fit after toggle.

## Testing done

![image](https://user-images.githubusercontent.com/13809749/201698706-c3b3cd40-7b50-4e80-8733-8fc438ed5c12.png)
