### PR TITLE
Limit notifications

### DIFF
--- a/frontend/src/components/App/Notifications/index.tsx
+++ b/frontend/src/components/App/Notifications/index.tsx
@@ -266,6 +266,7 @@ export default function Notifications() {
   const areAllNotificationsInDeleteState =
     notifications.filter(notification => !notification.deleted).length === 0;
   const notificationMenuId = 'notification-menu';
+  const maxNotificationsInPopup = 50;
 
   return (
     <>
@@ -332,7 +333,9 @@ export default function Notifications() {
           </Grid>
         </Box>
         <NotificationsList
-          notifications={areAllNotificationsInDeleteState ? [] : notifications}
+          notifications={
+            areAllNotificationsInDeleteState ? [] : notifications.slice(0, maxNotificationsInPopup)
+          }
           clickEventHandler={menuItemClickHandler}
         />
       </Popover>

--- a/frontend/src/components/App/Notifications/index.tsx
+++ b/frontend/src/components/App/Notifications/index.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
+import helpers from '../../../helpers';
 import Event, { KubeEvent } from '../../../lib/k8s/event';
 import { Notification } from '../../../lib/notification';
 import { createRouteURL } from '../../../lib/router';
@@ -181,7 +182,7 @@ export default function Notifications() {
     let changed = false;
 
     if (currentNotifications.length === 0) {
-      currentNotifications = JSON.parse(localStorage.getItem('notifications') || '[]');
+      currentNotifications = helpers.loadNotifications();
       changed = currentNotifications.length > 0;
     }
 

--- a/frontend/src/helpers/helpers.test.ts
+++ b/frontend/src/helpers/helpers.test.ts
@@ -91,6 +91,15 @@ describe('notifications', () => {
     }));
   });
 
+  test('messageLimits', () => {
+    // Verify that the message limits are set correctly.
+    const notification = new Notification({
+      message: 'm'.repeat(251),
+    });
+
+    expect(notification.message.length).toBe(250);
+  });
+
   test('store', () => {
     const notifications: Notification[] = [];
 

--- a/frontend/src/helpers/helpers.test.ts
+++ b/frontend/src/helpers/helpers.test.ts
@@ -1,3 +1,4 @@
+import { Notification } from '../lib/notification';
 import helpers from './index';
 
 describe('getAppUrl', () => {
@@ -67,5 +68,44 @@ describe('getAppUrl', () => {
       },
     }));
     expect(helpers.getAppUrl()).toBe('http://example.com:4466/');
+  });
+});
+
+describe('notifications', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const windowSpy = jest.spyOn(window, 'window', 'get') as jest.MockInstance<any, any>;
+
+  beforeEach(() => {
+    jest.spyOn(helpers, 'isDevMode').mockImplementation(() => true);
+    jest.spyOn(helpers, 'isElectron').mockImplementation(() => false);
+
+    windowSpy.mockImplementation(() => ({
+      headlampBaseUrl: '.',
+      location: {
+        pathname: '/path',
+        origin: 'http://example.com:4466',
+      },
+    }));
+  });
+
+  test('store', () => {
+    const notifications: Notification[] = [];
+
+    // Create more than the max notifications we allow to store
+    for (let i = 0; i < helpers.defaultMaxNotificationsStored + 1; i++) {
+      notifications.push(
+        new Notification({
+          message: 'm'.repeat(250),
+        })
+      );
+    }
+
+    helpers.storeNotifications(notifications);
+
+    const notificationsFromStorage = JSON.parse(localStorage.getItem('notifications') || '[]');
+    expect(notificationsFromStorage.length).toBe(helpers.defaultMaxNotificationsStored);
   });
 });

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -1,4 +1,5 @@
 import { Cluster } from '../lib/k8s/cluster';
+import { Notification } from '../lib/notification';
 
 /**
  * Determines whether app is running in electron environment.
@@ -178,6 +179,19 @@ function getProductName() {
   return process.env.REACT_APP_HEADLAMP_PRODUCT_NAME;
 }
 
+const defaultMaxNotificationsStored = 200;
+type NotificationStoreOptions = {
+  max?: number;
+};
+function storeNotifications(notifications: Notification[], options: NotificationStoreOptions = {}) {
+  const { max = defaultMaxNotificationsStored } = options;
+  localStorage.setItem('notifications', JSON.stringify(notifications.slice(0, max)));
+}
+
+function loadNotifications(): Notification[] {
+  return JSON.parse(localStorage.getItem('notifications') || '[]');
+}
+
 const exportFunctions = {
   getBaseUrl,
   isDevMode,
@@ -191,6 +205,9 @@ const exportFunctions = {
   setTablesRowsPerPage,
   getVersion,
   getProductName,
+  storeNotifications,
+  loadNotifications,
+  defaultMaxNotificationsStored,
 };
 
 export default exportFunctions;

--- a/frontend/src/lib/notification.tsx
+++ b/frontend/src/lib/notification.tsx
@@ -14,7 +14,7 @@ type NotificationMessageString = string;
 type OldNotificationDateArg = number | string;
 
 export class Notification {
-  message: string = '';
+  private _message: string = '';
   id: string;
   seen: boolean = false;
   url?: string;
@@ -54,6 +54,18 @@ export class Notification {
     }
     // generate the id based on the message and the date attached to a notification
     this.id = btoa(unescape(encodeURIComponent(`${this.date},${this.message},${this.cluster}`)));
+  }
+
+  set message(message: string) {
+    this._message = message;
+    if (this._message.length > 250) {
+      // I am not sure if this applies well to all languages, but it should be good enough for now.
+      this._message = this._message.slice(0, 249) + '…';
+    }
+  }
+
+  get message() {
+    return this._message;
   }
 }
 

--- a/frontend/src/redux/reducers/ui.tsx
+++ b/frontend/src/redux/reducers/ui.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { SidebarEntryProps } from '../../components/Sidebar';
+import helpers from '../../helpers';
 import { Notification } from '../../lib/notification';
 import { Route } from '../../lib/router';
 import themesConf, { setTheme } from '../../lib/themes';
@@ -229,7 +230,7 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       //if it's an empty array that means this is a request to clear notifications
       if (notifications.length === 0) {
         newFilters.notifications = [];
-        localStorage.setItem('notifications', JSON.stringify(newFilters.notifications));
+        helpers.storeNotifications(newFilters.notifications);
         break;
       }
       if (Array.isArray(notifications)) {
@@ -255,7 +256,7 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
       newFilters.notifications.sort((n1: Notification, n2: Notification) => {
         return new Date(n2.date).getTime() - new Date(n1.date).getTime();
       });
-      localStorage.setItem('notifications', JSON.stringify(newFilters.notifications));
+      helpers.storeNotifications(newFilters.notifications);
       break;
     }
     case UI_UPDATE_NOTIFICATION: {
@@ -278,7 +279,7 @@ function reducer(state = _.cloneDeep(INITIAL_STATE), action: Action) {
           return notification;
         });
       }
-      localStorage.setItem('notifications', JSON.stringify(newFilters.notifications));
+      helpers.storeNotifications(newFilters.notifications);
       break;
     }
     case UI_SET_CLUSTER_CHOOSER_BUTTON: {


### PR DESCRIPTION
This PR limits the message field of the notifications to 250 chars, and the number of notifications stored to 200 (by default).

Maybe we should limit more fields in the notification class, but this was an obvious one that we should control.

**How to test:**
- [ ] First check if there are more than 200 notifications in your current headlamp session (Local storage of the Application tab in Edge dev tools)
- [ ] Run this branch and wait for a notifiation to be received; check the stored notifications again: they should be now 200 (at most)
- Frontend tests are also added
fixes #815 