### PR TITLE
frontend i18n: Set the html lang when page loads too

### DIFF
--- a/frontend/src/i18n/ThemeProviderNexti18n.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.tsx
@@ -39,6 +39,10 @@ const ThemeProviderNexti18n: React.FunctionComponent<{ theme: Theme }> = props =
 
   useEffect(() => {
     i18n.on('languageChanged', changeLang);
+    if (i18n.language) {
+      // Set the lang when the page loads too.
+      changeLang(i18n.language);
+    }
     return () => {
       i18n.off('languageChanged', changeLang);
     };


### PR DESCRIPTION
# frontend i18n: Set the html lang when page loads too

Before it wasn't setting it on page load. So, if you were already in a non-english language then the attribute would not be set.

This causes the browser confusion about the language being used.

## How to use

- Set Headlamp to non-en language. 
- Reload the page. 
- It should have set the html lang attribute correctly. eg. `<html lang="uk">`

## Testing done

see how to use ^