### PR TITLE
frontend: Force 12 hour clock when under tests

### DIFF
--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -74,6 +74,7 @@ export function localeDate(date: DateParam) {
 
   if (process.env.UNDER_TEST === 'true') {
     options.timeZone = 'UTC';
+    options.hour12 = true;
   } else {
     options.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   }


### PR DESCRIPTION
So this is not changed according to the developer's locale when
creating new snapshots.
