### PR TITLE
small storybook fixes for SimpleTable

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -72,6 +72,15 @@ export const parameters = {
       rest.post('http://localhost/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', (_req, res, ctx) => {
         return res(ctx.json({status: 200}));
       }),
+      rest.get('http://localhost:4466/api/v1/namespaces', (_req, res, ctx) => {
+        return res(ctx.json({}));
+      }),
+      rest.get('http://localhost:4466/api/v1/events', (_req, res, ctx) => {
+        return res(ctx.json({}));
+      }),
+      rest.post('http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', (_req, res, ctx) => {
+        return res(ctx.json({status: 200}));
+      }),
     ]
   },
 };

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -540,7 +540,7 @@ export async function streamResult(
       socket = stream(watchUrl, x => cb(x.object), { isJson: true });
     } catch (err) {
       console.error('Error in api request', { err, url });
-      if (errCb) errCb(err as ApiError, cancel);
+      if (errCb && typeof errCb === 'function') errCb(err as ApiError, cancel);
     }
   }
 
@@ -581,7 +581,9 @@ export async function streamResults(
       socket = stream(watchUrl, update, { isJson: true });
     } catch (err) {
       console.error('Error in api request', { err, url });
-      if (errCb) errCb(err as ApiError, cancel);
+      if (errCb && typeof errCb === 'function') {
+        errCb(err as ApiError, cancel);
+      }
     }
   }
 

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -540,6 +540,8 @@ export async function streamResult(
       socket = stream(watchUrl, x => cb(x.object), { isJson: true });
     } catch (err) {
       console.error('Error in api request', { err, url });
+      // @todo: sometimes errCb is {}, the typing for apiProxy needs improving.
+      //        See https://github.com/kinvolk/headlamp/pull/833
       if (errCb && typeof errCb === 'function') errCb(err as ApiError, cancel);
     }
   }


### PR DESCRIPTION
- Fix storybook config to add port to mocked URLs
- Fix errCb guard to see if it's a function

This was the error shown in the console.
```ts
Failed to load resource: net::ERR_CONNECTION_REFUSED
apiProxy.ts:204 
        
       Unable to parse error json at url: http://localhost:4466/api/v1/namespaces Object with request data: Object
request @ apiProxy.ts:204
apiProxy.ts:583 
        
       Error in api request Object
run @ apiProxy.ts:583
apiProxy.ts:584 
        
       Uncaught (in promise) TypeError: errCb is not a function
    at run (apiProxy.ts:584:1)
```

## How to use

- Go to SimpleTable story http://localhost:6006/?path=/story/simpletable--name-search
- See no error (after this PR).

## Testing done

see ^