### PR TITLE
frontend: Show/hide filter depending on the search + who triggered it

### DIFF
--- a/frontend/src/components/App/Notifications/List.tsx
+++ b/frontend/src/components/App/Notifications/List.tsx
@@ -97,7 +97,7 @@ export default function NotificationList() {
       ) : (
         <SimpleTable
           filterFunction={(notification: Notification) =>
-            (notification?.message || '').includes(search)
+            (notification?.message?.toLowerCase() || '').includes(search.toLowerCase())
           }
           columns={[
             {


### PR DESCRIPTION
When the user moves to a different route, the search filter is reset
(to an empty string), but this goes through redux, so when the new
route is rendered, the search filter is still the old one. Eventually,
the redux state will be updated, but at this point we already have the
filter being shown (when it should actually be shown). OTOH, if we
always hide the filter when the search (and namespace) are empty, it
will also hide when the user deletes the whole string, and that's not
desireable (because they may want to keep writing and at that point the
filter has een hidden and input is lost).

To solve this, we keep track of whether the filter has been shown by
the user, in which case we don't hide it even when the search is empty.

fixes #837 

**How to test (filter means filter header)**
- [ ] Go to the notifications page and click on an event: you're taken to the cluster overview and the filter is opened, showing the search string
- [ ] Go to the Workloads view and click the button to open the filter: filter is shown, type on it and verify the search works; then go to the Pods view: verify the filter is hidden.
- [ ] In the pods view, open the filter, keep the search empty and select a namespace, move to the Workloads view and verify that the filter is opened, displaying the namespace you selected
- [ ] Clear the namespace filtering and start typing in the search field of the filter, then backspace until the search string is empty: verify that the filter remains opened