### PR TITLE
frontend: Don't show bottom buttons in special sidebar

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -125,10 +125,12 @@ export default function Sidebar() {
         dispatch(setWhetherSidebarOpen(!sidebar.isSidebarOpen));
       }}
       linkArea={
-        <>
-          <CreateButton />
-          <VersionButton />
-        </>
+        !isSpecialSidebarOpen && (
+          <>
+            <CreateButton />
+            <VersionButton />
+          </>
+        )
       }
     />
   );


### PR DESCRIPTION
The special sidebar should not have the plus nor the version buttons,
since they are tied to the concept of having a current cluster.
