### PR TITLE
choco headlamp 0.14.0

### DIFF
--- a/app/windows/chocolatey/choco-bump.sh
+++ b/app/windows/chocolatey/choco-bump.sh
@@ -63,20 +63,20 @@ while true; do
   esac
 done
 
-if (( $# != 2 )) && [ -z ${FILE_NAME} ]; then
+if (( $# != 2 )) && [ -z "${FILE_NAME}" ]; then
     echo "Error: Please provide a VERSION and CHECKSUM, or a file"
     echo ""
     usage
     exit 1
 fi
 
-if [ -z ${FILE_NAME} ]; then
+if [ -z "${FILE_NAME}" ]; then
     VERSION=$1
     CHECKSUM=$2
 else
-    basename=$(basename ${FILE_NAME})
+    basename=$(basename "${FILE_NAME}")
     VERSION=$(echo ${basename} | sed -n 's/^.*Headlamp-\(.*\)-win.*\.exe/\1/p')
-    CHECKSUM=$(sha256sum ${FILE_NAME} | awk '{print $1}')
+    CHECKSUM=$(sha256sum "${FILE_NAME}" | awk '{print $1}')
 fi
 
 if [ -z "$VERSION" ]; then

--- a/app/windows/chocolatey/headlamp.nuspec
+++ b/app/windows/chocolatey/headlamp.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>headlamp</id>
-    <version>0.13.0</version>
+    <version>0.14.0</version>
     <packageSourceUrl>https://github.com/kinvolk/headlamp/tree/main/app/windows/chocolatey</packageSourceUrl>
     <title>Headlamp</title>
     <authors>Kinvolk</authors>

--- a/app/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/app/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$headlampVersion = '0.13.0'
+$headlampVersion = '0.14.0'
 $url = "https://github.com/kinvolk/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
-$checksum = 'd49a9eb58a5350338d8c3b8911d2414551ff4cd8fa56f927ac6a14c1a983f416'
+$checksum = 'bcc0c30e7111c417d1460d9c5ceb70ee1a45d67c8a0c8c5b639caf9247057311'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
- app: Fix choco-bump.sh's processing of paths with spaces
- app: Bump chocolatey version to Headlamp 0.14.0
