### PR TITLE
frontend: The Plugin.initialize return value isn't used, remove

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -88,7 +88,6 @@ export async function initializePlugins() {
       const plugin = window.plugins[pluginName];
       try {
         // @todo: what should happen if this fails?
-        // @todo: The return code is not checked? What is it for?
         plugin.initialize(new Registry());
       } catch (e) {
         console.error(`Plugin initialize() error in ${pluginName}:`, e);

--- a/frontend/src/plugin/lib.ts
+++ b/frontend/src/plugin/lib.ts
@@ -42,9 +42,11 @@ export abstract class Plugin {
   /**
    * initialize is called for each plugin with a Registry which gives the plugin methods for doing things.
    *
+   * @returns The return code is not used, but used to be required.
+   *
    * @see Registry
    */
-  abstract initialize(register: Registry): boolean;
+  abstract initialize(register: Registry): boolean | void;
 }
 
 declare global {

--- a/plugins/examples/app-menus/src/index.tsx
+++ b/plugins/examples/app-menus/src/index.tsx
@@ -36,8 +36,6 @@ class AppMenuDemo extends Plugin {
       }
       return menus;
     });
-
-    return true;
   }
 }
 


### PR DESCRIPTION
The return code for `Plugin.initialize()`:
- was never used by anything. Don't require a return value
- is now `void | boolean` not `void` for backwards compatibility

## How to use

Just a code cleanup.

## Testing done

- [x] CI tests pass (including plugin tests).