### PR TITLE
frontend SimpleTable: Make nowrap only on sort having header cells

### DIFF
--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
           scope="col"
         >
           Name
@@ -33,7 +33,7 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
           </button>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
           scope="col"
         >
           Namespace
@@ -54,7 +54,7 @@ exports[`Storyshots ResourceTable Name Search 1`] = `
           </button>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
           scope="col"
           style="text-align: right;"
         >
@@ -128,7 +128,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
           scope="col"
         >
           Name
@@ -149,7 +149,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
           </button>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
           scope="col"
         >
           Namespace
@@ -170,7 +170,7 @@ exports[`Storyshots ResourceTable No Filter 1`] = `
           </button>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
           scope="col"
           style="text-align: right;"
         >

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -8,6 +8,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
+import clsx from 'clsx';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import helpers from '../../helpers';
@@ -20,6 +21,9 @@ const useTableStyle = makeStyles(theme => ({
   headerCell: {
     fontWeight: 'bold',
     paddingBottom: theme.spacing(0.5),
+  },
+  sortCell: {
+    whiteSpace: 'nowrap',
   },
   table: {
     [theme.breakpoints.down('sm')]: {
@@ -343,7 +347,7 @@ export default function SimpleTable(props: SimpleTableProps) {
                 return (
                   <TableCell
                     key={`tabletitle_${i}`}
-                    className={classes.headerCell + ' ' + className}
+                    className={clsx(classes.headerCell, className, sort ? classes.sortCell : '')}
                     {...otherProps}
                   >
                     {label}

--- a/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.stories.storyshot
@@ -12,25 +12,25 @@ exports[`Storyshots SimpleTable Datum 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Status
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Age
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Long Field Name
@@ -129,31 +129,31 @@ exports[`Storyshots SimpleTable Getter 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Status
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Age
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Long Field Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Number
@@ -446,25 +446,25 @@ exports[`Storyshots SimpleTable Label Search 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Namespace
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           UID
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Labels
@@ -718,25 +718,25 @@ exports[`Storyshots SimpleTable Name Search 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Namespace
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           UID
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Labels
@@ -966,25 +966,25 @@ exports[`Storyshots SimpleTable Namespace Search 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Namespace
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           UID
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Labels
@@ -1226,25 +1226,25 @@ exports[`Storyshots SimpleTable Namespace Select 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Namespace
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           UID
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Labels
@@ -1496,19 +1496,19 @@ exports[`Storyshots SimpleTable Number Search 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Namespace
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Number
@@ -1571,19 +1571,19 @@ exports[`Storyshots SimpleTable Reflect In URL 1`] = `
           class="MuiTableRow-root MuiTableRow-head"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
             scope="col"
           >
             Name
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
             scope="col"
           >
             Namespace
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
             scope="col"
           >
             Number
@@ -1723,19 +1723,19 @@ exports[`Storyshots SimpleTable Reflect In URL With Prefix 1`] = `
           class="MuiTableRow-root MuiTableRow-head"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
             scope="col"
           >
             Name
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
             scope="col"
           >
             Namespace
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+            class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
             scope="col"
           >
             Number
@@ -2027,25 +2027,25 @@ exports[`Storyshots SimpleTable UID Search 1`] = `
         class="MuiTableRow-root MuiTableRow-head"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Name
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Namespace
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           UID
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
           scope="col"
         >
           Labels

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.stories.storyshot
@@ -202,19 +202,19 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       IP
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Hostname
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Target
@@ -293,7 +293,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                       scope="col"
                     >
                       Name
@@ -314,7 +314,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                       </button>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                       scope="col"
                     >
                       Port
@@ -335,7 +335,7 @@ exports[`Storyshots endpoints/EndpointsDetailsView Default 1`] = `
                       </button>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                       scope="col"
                     >
                       Protocol

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.stories.storyshot
@@ -61,7 +61,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Name
@@ -82,7 +82,7 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Namespace
@@ -103,14 +103,14 @@ exports[`Storyshots endpoints/EndpointsListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
                 style="width: 40%; max-width: 40%;"
               >
                 Addresses
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
                 style="text-align: right;"
               >

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.stories.storyshot
@@ -240,13 +240,13 @@ exports[`Storyshots hpa/HpaDetailsView Default 1`] = `
                             class="MuiTableRow-root MuiTableRow-head"
                           >
                             <th
-                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                               scope="col"
                             >
                               Name
                             </th>
                             <th
-                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                               scope="col"
                             >
                               (Current/Target)

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.stories.storyshot
@@ -61,7 +61,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Name
@@ -82,7 +82,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Namespace
@@ -103,19 +103,19 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Reference
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Targets
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 MinReplicas
@@ -136,7 +136,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 MaxReplicas
@@ -157,7 +157,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Replicas
@@ -178,7 +178,7 @@ exports[`Storyshots hpa/HpaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
                 style="text-align: right;"
               >

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -338,31 +338,31 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason
@@ -1083,31 +1083,31 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason
@@ -1826,31 +1826,31 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason
@@ -2669,31 +2669,31 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason
@@ -3388,31 +3388,31 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason
@@ -4144,31 +4144,31 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason

--- a/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.stories.storyshot
@@ -61,7 +61,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Name
@@ -82,7 +82,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Namespace
@@ -103,7 +103,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Restarts
@@ -124,13 +124,13 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Ready
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Status
@@ -151,7 +151,7 @@ exports[`Storyshots Pod/PodListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
                 style="text-align: right;"
               >

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -333,31 +333,31 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Condition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Status
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Transition
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Last Update
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                      class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                       scope="col"
                     >
                       Reason

--- a/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/Volumedetails.stories.storyshot
@@ -34,13 +34,13 @@ exports[`Storyshots pods/VolumeDetails Volume Details 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Name
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Type

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.stories.storyshot
@@ -61,7 +61,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Name
@@ -82,7 +82,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Namespace
@@ -103,7 +103,7 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Min Available
@@ -124,19 +124,19 @@ exports[`Storyshots PDB/PDBListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Max Unavailable
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Allowed Disruptions
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
                 style="text-align: right;"
               >

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.stories.storyshot
@@ -61,7 +61,7 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Name
@@ -82,19 +82,19 @@ exports[`Storyshots PriorityClasses/PriorityClassesListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Value
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Global Default
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
                 style="text-align: right;"
               >

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.stories.storyshot
@@ -217,19 +217,19 @@ exports[`Storyshots ResourceQuota/ResourceQuotaDetailsView Default 1`] = `
                             class="MuiTableRow-root MuiTableRow-head"
                           >
                             <th
-                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                               scope="col"
                             >
                               Resource
                             </th>
                             <th
-                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                               scope="col"
                             >
                               Used
                             </th>
                             <th
-                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                               scope="col"
                             >
                               Hard

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.stories.storyshot
@@ -61,7 +61,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
               class="MuiTableRow-root MuiTableRow-head"
             >
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Name
@@ -82,7 +82,7 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
               >
                 Namespace
@@ -103,19 +103,19 @@ exports[`Storyshots ResourceQuota/ResourceQuotaListView Items 1`] = `
                 </button>
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Request
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell"
                 scope="col"
               >
                 Limit
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell "
+                class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell makeStyles-sortCell"
                 scope="col"
                 style="text-align: right;"
               >


### PR DESCRIPTION
So that other header cells still have the opportunity to wrap if they want to. Meaning there's less chance of a problem with header cells that used to fit with wrapping.

**Important:** The PR #835 was closed by mistake after I pushed what I believed was just the PR rebased on main. This PR has the changes @illume had made to it + rebased on main, so it should be fine.