### PR TITLE
Allow terminal to reconnect after failure

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -172,8 +172,11 @@ export default function Terminal(props: TerminalProps) {
       (async function () {
         send(4, `{"Width":${xterm.cols},"Height":${xterm.rows}}`);
       })();
-      xtermc.connected = true;
-      console.debug('Terminal is now connected');
+      // On server error, don't set it as connected
+      if (channel !== 3) {
+        xtermc.connected = true;
+        console.debug('Terminal is now connected');
+      }
     }
 
     if (isSuccessfulExitError(channel, text)) {

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -58,6 +58,7 @@ interface TerminalProps extends DialogProps {
 interface XTerminalConnected {
   xterm: XTerminal;
   connected: boolean;
+  reconnectOnEnter: boolean;
 }
 
 type execReturn = ReturnType<Pod['exec']>;
@@ -109,6 +110,18 @@ export default function Terminal(props: TerminalProps) {
           return false;
         }
       }
+
+      if (arg.type === 'keydown' && arg.code === 'Enter') {
+        if (xtermRef.current?.reconnectOnEnter) {
+          setShells(shells => ({
+            ...shells,
+            currentIdx: 0,
+          }));
+          xtermRef.current!.reconnectOnEnter = false;
+          return false;
+        }
+      }
+
       return true;
     });
 
@@ -210,6 +223,11 @@ export default function Terminal(props: TerminalProps) {
       } else {
         xterm.write(t('Failed to connect…') + '\r\n');
       }
+
+      xterm.write('\r\n' + t('Press the enter key to reconnect.') + '\r\n');
+      if (xtermRef.current) {
+        xtermRef.current.reconnectOnEnter = true;
+      }
     } else {
       xterm.write(t('Failed to run "{{ command }}"', { command }) + '\r\n');
       tryNextShell();
@@ -249,6 +267,7 @@ export default function Terminal(props: TerminalProps) {
           windowsMode: isWindows,
         }),
         connected: false,
+        reconnectOnEnter: false,
       };
 
       fitAddonRef.current = new FitAddon();

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -221,7 +221,7 @@ export default function Terminal(props: TerminalProps) {
     const command = getCurrentShellCommand();
     if (isLastShell()) {
       if (xtermc.connected) {
-        xterm.write(t('Failed to run command "{{command}}"…', { command }) + '\r\n');
+        xterm.write(t('Failed to run "{{command}}"…', { command }) + '\r\n');
       } else {
         xterm.clear();
         xterm.write(t('Failed to connect…') + '\r\n');

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -220,10 +220,10 @@ export default function Terminal(props: TerminalProps) {
     const xterm = xtermc.xterm;
     const command = getCurrentShellCommand();
     if (isLastShell()) {
-      xterm.clear();
       if (xtermc.connected) {
         xterm.write(t('Failed to run command "{{command}}"…', { command }) + '\r\n');
       } else {
+        xterm.clear();
         xterm.write(t('Failed to connect…') + '\r\n');
       }
 

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -333,7 +333,7 @@ export default function Terminal(props: TerminalProps) {
     } else if (os === 'windows') {
       return ['powershell.exe', 'cmd.exe'];
     }
-    return ['bash', 'sh', 'powershell.exe', 'cmd.exe'];
+    return ['bash', '/bin/bash', 'sh', '/bin/sh', 'powershell.exe', 'cmd.exe'];
   }
 
   function handleContainerChange(event: any) {


### PR DESCRIPTION
When connecting or connected to a container (via exec), if it fails and Headlamp runs through the list of available shells, then there's no way to retry them (except for refreshing the page).

See #866 for a report where this happens. Even though this patch doesn't try to fix the cause for which the connection is lost after a couple of minutes (not even sure if we can avoid it), it does allow the user to recover because after it runs through the list of terminals it will display a message "Press enter to reconnect" and retry all shells again once the user presses enter.

In the future we shall add UI to select/enter a shell command and to directly refresh it, but for now this is a very non-intrusive solution.

fixes #866 

**How to test:**
- [ ] Connect to a container, then shut the network off and let the terminal get aware of that which should make it run through the list of terminals till the end. Turn the connection on and press Enter to reconnect as the instructions in the terminal say.
- [ ] Connect to a container that doesn't have a known shell and let all shells fail: see how the instructions are shown for the user to reconnect and press Enter to see it attempt it again.