### PR TITLE
frontend: Fix failed assumption of JSON code

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -133,10 +133,9 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function looksLikeJson(code: string) {
-    const trimmedCode = code.trimRight();
-    const lastChar = !!trimmedCode ? trimmedCode[trimmedCode.length - 1] : '';
+    const trimmedCode = code.trimLeft();
     const firstChar = !!trimmedCode ? trimmedCode[0] : '';
-    if (['{', '['].includes(firstChar) || ['}', ']'].includes(lastChar)) {
+    if (['{', '['].includes(firstChar)) {
       return true;
     }
     return false;


### PR DESCRIPTION
We were assuming that if the code is JSON, it should have either a
starting { or [, or an ending ] or }. However, the code can very well
be YAML and end in ]. So this patch makes Headlamp only consider the
starting character of the mentioned logic.

For example, this YAML was being interpreted as JSON and thus not let the user apply it from the UI:
```YAML
kind: Pod
apiVersion: v1
metadata:
       name: test
spec:
       containers:
            - name: cont-1
               image: ubuntu
               command: ["/bin/bash", "-c", 
               "while true; do echo Hello-Coder; sleep 5 ; done"]
```

**How to test:**
- [ ] Try to apply the code above: the editor shouldn't complain that the code is a failed JSON