### PR TITLE
Add easier auth buttons + make logs/exec dependent on permissions

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { KubeObject } from '../../../lib/k8s/cluster';
+
+export interface AuthVisibleProps extends React.PropsWithChildren<{}> {
+  /** The item for which auth will be checked. */
+  item: KubeObject;
+  /** The verb associated with the permissions being verifying. See https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb . */
+  authVerb: string;
+  /** The subresource for which the permissions are being verifyied (e.g. "log" when checking for a pod's log). */
+  subresource?: string;
+  /** Callback for when an error occurs.
+   * @param err The error that occurred.
+   */
+  onError?: (err: Error) => void;
+  /** Callback for when the user is not authorized to perform the action. */
+  onUnauthorized?: () => void;
+}
+
+/** A component that will only render its children if the user is authorized to perform the specified action on the given resource.
+ * @param props The props for the component.
+ */
+export default function AuthVisible(props: AuthVisibleProps) {
+  const { item, authVerb, subresource, onError, onUnauthorized, children } = props;
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    let isMounted = true;
+    if (!!item) {
+      item
+        .getAuthorization(authVerb, { subresource })
+        .then((result: any) => {
+          if (isMounted) {
+            if (result.status?.allowed !== visible) {
+              setVisible(!!result.status?.allowed);
+            }
+            if (!!onUnauthorized) {
+              onUnauthorized();
+            }
+          }
+        })
+        .catch((err: Error) => {
+          if (isMounted) {
+            if (!!onError) {
+              onError(err);
+            }
+            setVisible(false);
+          }
+        });
+    }
+
+    return function cleanup() {
+      isMounted = false;
+    };
+  }, [item]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/common/Resource/DeleteButton.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.tsx
@@ -6,6 +6,7 @@ import { KubeObject } from '../../../lib/k8s/cluster';
 import { CallbackActionOptions, clusterAction } from '../../../redux/actions/actions';
 import ActionButton from '../ActionButton';
 import { ConfirmDialog } from '../Dialog';
+import AuthVisible from './AuthVisible';
 
 interface DeleteButtonProps {
   item?: KubeObject;
@@ -16,7 +17,6 @@ export default function DeleteButton(props: DeleteButtonProps) {
   const dispatch = useDispatch();
   const { item, options } = props;
   const [openAlert, setOpenAlert] = React.useState(false);
-  const [visible, setVisible] = React.useState(false);
   const location = useLocation();
   const { t } = useTranslation(['frequent', 'resource']);
 
@@ -48,28 +48,14 @@ export default function DeleteButton(props: DeleteButtonProps) {
     [item]
   );
 
-  React.useEffect(() => {
-    if (item) {
-      item
-        .getAuthorization('delete')
-        .then((result: any) => {
-          if (result.status.allowed) {
-            setVisible(true);
-          }
-        })
-        .catch((err: Error) => {
-          console.error(`Error while getting authorization for delete button in ${item}:`, err);
-          setVisible(false);
-        });
-    }
-  }, [item]);
-
-  if (!visible) {
-    return null;
-  }
-
   return (
-    <React.Fragment>
+    <AuthVisible
+      item={item}
+      authVerb="delete"
+      onError={(err: Error) => {
+        console.error(`Error while getting authorization for delete button in ${item}:`, err);
+      }}
+    >
       <ActionButton
         description={t('frequent|Delete')}
         onClick={() => setOpenAlert(true)}
@@ -82,6 +68,6 @@ export default function DeleteButton(props: DeleteButtonProps) {
         handleClose={() => setOpenAlert(false)}
         onConfirm={() => deleteFunc()}
       />
-    </React.Fragment>
+    </AuthVisible>
   );
 }

--- a/frontend/src/components/common/Resource/ScaleButton.tsx
+++ b/frontend/src/components/common/Resource/ScaleButton.tsx
@@ -18,6 +18,7 @@ import { useLocation } from 'react-router-dom';
 import { KubeObject } from '../../../lib/k8s/cluster';
 import { CallbackActionOptions, clusterAction } from '../../../redux/actions/actions';
 import { LightTooltip } from '../Tooltip';
+import AuthVisible from './AuthVisible';
 
 interface ScaleButtonProps {
   item: KubeObject;
@@ -28,7 +29,6 @@ export default function ScaleButton(props: ScaleButtonProps) {
   const dispatch = useDispatch();
   const { item, options = {} } = props;
   const [openDialog, setOpenDialog] = React.useState(false);
-  const [visible, setVisible] = React.useState(false);
   const location = useLocation();
   const { t } = useTranslation('resource');
 
@@ -66,35 +66,25 @@ export default function ScaleButton(props: ScaleButtonProps) {
     setOpenDialog(false);
   }
 
-  React.useEffect(() => {
-    if (item) {
-      item
-        .getAuthorization('update')
-        .then((result: any) => {
-          if (result.status.allowed) {
-            setVisible(true);
-          }
-        })
-        .catch((err: Error) => {
-          console.error(`Error while getting authorization for edit button in ${item}:`, err);
-          setVisible(false);
-        });
-    }
-  }, [item]);
-
-  if (!visible || !['Deployment', 'StatefulSet', 'ReplicaSet'].includes(item.kind)) {
+  if (!['Deployment', 'StatefulSet', 'ReplicaSet'].includes(item.kind)) {
     return null;
   }
 
   return (
-    <>
+    <AuthVisible
+      item={item}
+      authVerb="update"
+      onError={(err: Error) => {
+        console.error(`Error while getting authorization for scaling button in ${item}:`, err);
+      }}
+    >
       <Tooltip title={t('frequent|Scale') as string}>
         <IconButton aria-label={t('frequent|scale')} onClick={() => setOpenDialog(true)}>
           <Icon icon="mdi:content-copy" />
         </IconButton>
       </Tooltip>
       <ScaleDialog resource={item} open={openDialog} onClose={handleClose} onSave={handleSave} />
-    </>
+    </AuthVisible>
   );
 }
 

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.stories.storyshot
@@ -120,10 +120,10 @@ exports[`Storyshots crd/CustomResourceDetails No Error 1`] = `
                   class="MuiGrid-root MuiGrid-item"
                 >
                   <button
-                    aria-label="Edit"
-                    class="MuiButtonBase-root MuiIconButton-root"
+                    aria-label="View YAML"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd"
                     tabindex="0"
-                    title="Edit"
+                    title="View YAML"
                     type="button"
                   >
                     <span

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -19,6 +19,7 @@ import { LightTooltip, SectionBox, SimpleTable } from '../common';
 import Link from '../common/Link';
 import { LogViewer, LogViewerProps } from '../common/LogViewer';
 import { ConditionsSection, ContainersSection, DetailsGrid } from '../common/Resource';
+import AuthVisible from '../common/Resource/AuthVisible';
 import Terminal from '../common/Terminal';
 import { makePodStatusLabel } from './List';
 
@@ -295,16 +296,23 @@ export default function PodDetails(props: PodDetailsProps) {
       namespace={namespace}
       actions={item =>
         item && [
-          <Tooltip title={t('Show Logs') as string}>
-            <IconButton aria-label={t('logs')} onClick={() => setShowLogs(true)}>
-              <Icon icon="mdi:file-document-box-outline" />
-            </IconButton>
-          </Tooltip>,
-          <Tooltip title={t('Terminal / Exec') as string}>
-            <IconButton aria-label={t('terminal') as string} onClick={() => setShowTerminal(true)}>
-              <Icon icon="mdi:console" />
-            </IconButton>
-          </Tooltip>,
+          <AuthVisible item={item} authVerb="get" subresource="log">
+            <Tooltip title={t('Show Logs') as string}>
+              <IconButton aria-label={t('logs')} onClick={() => setShowLogs(true)}>
+                <Icon icon="mdi:file-document-box-outline" />
+              </IconButton>
+            </Tooltip>
+          </AuthVisible>,
+          <AuthVisible item={item} authVerb="get" subresource="exec">
+            <Tooltip title={t('Terminal / Exec') as string}>
+              <IconButton
+                aria-label={t('terminal') as string}
+                onClick={() => setShowTerminal(true)}
+              >
+                <Icon icon="mdi:console" />
+              </IconButton>
+            </Tooltip>
+          </AuthVisible>,
         ]
       }
       extraInfo={item =>

--- a/frontend/src/components/pod/PodLogs.stories.tsx
+++ b/frontend/src/components/pod/PodLogs.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { StreamResultsCb } from '../../lib/k8s/apiProxy';
-import { KubeObjectClass } from '../../lib/k8s/cluster';
+import { AuthRequestResourceAttrs, KubeObjectClass } from '../../lib/k8s/cluster';
 import Pod, { KubePod, LogOptions } from '../../lib/k8s/pod';
 import { TestContext } from '../../test';
 import PodDetails, { PodDetailsProps } from './Details';
@@ -17,6 +17,19 @@ const usePhonyGet: KubeObjectClass['useGet'] = (name, namespace) => {
     () => {},
     () => {},
   ] as any;
+};
+
+const phonyGetAuthorization: KubeObjectClass['getAuthorization'] = async (
+  verb: string,
+  resourceAttrs?: AuthRequestResourceAttrs
+) => {
+  return new Promise(exec => {
+    exec({
+      status: {
+        allowed: resourceAttrs?.subresource === 'log',
+      },
+    });
+  });
 };
 
 export default {
@@ -88,6 +101,7 @@ function getLogs(container: string, onLogs: StreamResultsCb, logsOptions: LogOpt
 export const Logs = Template.bind({});
 Logs.args = {
   useGet: usePhonyGet,
+  'prototype.getAuthorization': phonyGetAuthorization,
   'prototype.getLogs': getLogs,
   podName: 'running',
   detailsProps: {

--- a/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.stories.storyshot
@@ -58,44 +58,10 @@ exports[`Storyshots Pod/PodDetailsView Error 1`] = `
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="logs"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Show Logs"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -810,44 +776,10 @@ exports[`Storyshots Pod/PodDetailsView Initializing 1`] = `
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="logs"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Show Logs"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -1546,44 +1478,10 @@ exports[`Storyshots Pod/PodDetailsView Liveness Failed 1`] = `
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="logs"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Show Logs"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -2396,44 +2294,10 @@ exports[`Storyshots Pod/PodDetailsView Pull Back Off 1`] = `
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="logs"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Show Logs"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -3115,44 +2979,10 @@ exports[`Storyshots Pod/PodDetailsView Running 1`] = `
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="logs"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Show Logs"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />
@@ -3871,44 +3701,10 @@ exports[`Storyshots Pod/PodDetailsView Successful 1`] = `
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="logs"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Show Logs"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />

--- a/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.stories.storyshot
@@ -80,24 +80,7 @@ exports[`Storyshots Pod/PodLogs Logs 1`] = `
                 </div>
                 <div
                   class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    aria-label="terminal"
-                    class="MuiButtonBase-root MuiIconButton-root"
-                    tabindex="0"
-                    title="Terminal / Exec"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <span />
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                />
                 <div
                   class="MuiGrid-root MuiGrid-item"
                 />


### PR DESCRIPTION
This PR adds a component that verifies the permissions for some action and only renders its children if those are valid.
It replaces the repeated logic for checking for permissions for actions such as edit/delete/etc.

This PR also makes the logs and exec actions based on permissions.

fixes #767 

**How to test:**
- [ ] Set up a token for a service account whose Role (create a new one based on the default _view_ one) is _view_ only; verify that in the role, there's no "pods/log" nor "pods/exec" in the list of the resources: go to a pod and verify that the logs and exec buttons are not visible (only the view button is visible)
- [ ] Edit the role and add `pods/log` and `pods/exec` to the a rule that has at least the `get` verb: verify that the buttons for a pod are visible upon refresh