### PR TITLE
Update Node 18LTS, Ubuntu 22LTS, Alpine 3.17 stable

### DIFF
--- a/.github/workflows/app-artifacts-linux.yml
+++ b/.github/workflows/app-artifacts-linux.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 18.x
     - uses: actions/setup-go@v2
       with:
         go-version: 1.19

--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 18.x
     - uses: actions/setup-go@v2
       with:
         go-version: 1.19

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 18.x
     - uses: actions/setup-go@v2
       with:
         go-version: 1.19

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -20,10 +20,10 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18.x
     - name: Start cluster
       uses: medyagh/setup-minikube@master
       # now you can run kubectl to see the pods in the cluster

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,11 +21,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v2.3.3

--- a/.github/workflows/helm-chart-lint-test.yml
+++ b/.github/workflows/helm-chart-lint-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_BASE=alpine:3.15.6
+ARG IMAGE_BASE=alpine:3.17.0
 FROM $IMAGE_BASE as base-build
 
 RUN apk update && \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_REPO ?= ghcr.io/kinvolk
 DOCKER_EXT_REPO ?= docker.io/kinvolk
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)
-DOCKER_IMAGE_BASE ?= alpine:3.15.4
+DOCKER_IMAGE_BASE ?= alpine:3.17.0
 
 ifeq ($(OS), Windows_NT)
 	SERVER_EXE_EXT = .exe


### PR DESCRIPTION
Update Node 18LTS, Ubuntu 22LTS, Alpine 3.17 stable

- https://www.releases.ubuntu.com/22.04/
- https://nodejs.org/en/blog/announcements/v18-release-announce/
- https://www.alpinelinux.org/posts/Alpine-3.17.0-released.html

This means, we should use Node 18 and the corresponding new npm (8.19) locally for front end package updates.
Note, we already moved to go 1.19 in the images, but the new alpine also includes go 1.19 by default.


## How to use

It should work as before, just with newer dependencies.

## Testing done

- [x] CI passes
- [x] local smoke test